### PR TITLE
Build packages before starting storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,22 +3,18 @@
   "name": "frontend-packages",
   "description": "NDLA Frontend Packages",
   "scripts": {
-    "lint":
-      "yarn run lint-prettier --silent && eslint --ext .js --ext .jsx ./packages --ignore-path .gitignore",
+    "lint": "yarn run lint-prettier --silent && eslint --ext .js --ext .jsx ./packages --ignore-path .gitignore",
     "lint-prettier": "node scripts/prettier.js lint",
     "test": "cross-env NODE_ENV=unittest jest",
     "deploy-storybook": "storybook-to-ghpages",
     "clean": "lerna clean && lerna run clean",
     "bootstrap": "lerna bootstrap && lerna run prepublish",
     "watch": "node ./scripts/watch.js",
-    "start":
-      "concurrently -r --kill-others \"npm run watch\" \"npm run start-storybook\"",
+    "start": "node ./scripts/build.js packages && concurrently -r --kill-others \"npm run watch\" \"npm run start-storybook\"",
     "start-storybook": "node ./scripts/startStorybook.js",
     "prebuild-storybook": "yarn bootstrap --silent",
-    "build-storybook":
-      "cross-env NODE_ENV=production node ./scripts/buildStorybook.js",
-    "serve-storybook":
-      "cross-env NODE_ENV=production serve ./packages/designmanual/storybook-static",
+    "build-storybook": "cross-env NODE_ENV=production node ./scripts/buildStorybook.js",
+    "serve-storybook": "cross-env NODE_ENV=production serve ./packages/designmanual/storybook-static",
     "prettier": "node ./scripts/prettier.js write"
   },
   "repository": {
@@ -31,7 +27,9 @@
   "homepage": "https://github.com/NDLANO/frontend-packages",
   "author": "ndla@knowit.no",
   "license": "GPL-3.0",
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "devDependencies": {
     "@storybook/storybook-deployer": "^2.0.0",
     "babel-cli": "^6.26.0",
@@ -51,6 +49,7 @@
     "eslint": "^4.8.0",
     "jest": "21.2.1",
     "lerna": "^2.4.0",
+    "mkdirp": "^0.5.1",
     "node-sass": "^4.3.0",
     "prettier": "^1.7.4",
     "prop-types": "15.6.0",
@@ -66,6 +65,7 @@
     "rimraf": "2.6.2",
     "sass-loader": "^6.0.6",
     "serve": "^6.2.0",
+    "string-length": "^2.0.0",
     "style-loader": "^0.19.0",
     "webpack": "^3.6.0"
   }

--- a/scripts/_getPackages.js
+++ b/scripts/_getPackages.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2017-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PACKAGES_DIR = path.resolve(__dirname, '..', './packages');
+
+// Get absolute paths of all directories under packages/*
+function getPackages() {
+  return fs
+    .readdirSync(PACKAGES_DIR)
+    .map(file => path.resolve(PACKAGES_DIR, file))
+    .filter(f => fs.lstatSync(path.resolve(f)).isDirectory())
+    .filter(
+      f =>
+        f.indexOf('designmanual') === -1 &&
+        f.indexOf('ndla-scripts') === -1 &&
+        f.indexOf('ndla-source-map-resolver') === -1 &&
+        f.indexOf('eslint-config-ndla') === -1,
+    ); // skip private, config and script packages
+}
+
+module.exports = getPackages;

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -10,6 +10,10 @@ const chalk = require('chalk');
 const babel = require('babel-core');
 const fs = require('fs');
 const path = require('path');
+const glob = require('glob');
+const mkdirp = require('mkdirp');
+const stringLength = require('string-length');
+const getPackages = require('./_getPackages');
 
 const PACKAGES_DIR = path.resolve(__dirname, '..', './packages');
 
@@ -17,10 +21,28 @@ const babelOptions = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '..', '.babelrc'), 'utf8'),
 );
 babelOptions.babelrc = false;
+const SRC_DIR = 'src';
+const JS_FILES_PATTERN = '**/*.js*';
+const IGNORE_PATTERN = '**/__tests__/**';
+const OK = chalk.reset.inverse.bold.green(' DONE ');
+
+const adjustToTerminalWidth = str => {
+  const columns = process.stdout.columns || 80;
+  const width = columns - stringLength(OK) + 1;
+  const strs = str.match(new RegExp(`(.{1,${width}})`, 'g'));
+  let lastString = strs[strs.length - 1];
+  if (lastString.length < width) {
+    lastString += Array(width - lastString.length).join(chalk.dim('.'));
+  }
+  return strs
+    .slice(0, -1)
+    .concat(lastString)
+    .join('\n');
+};
 
 function resolveDestPath(file) {
   const packageName = path.relative(PACKAGES_DIR, file).split(path.sep)[0];
-  const packageSrcPath = path.resolve(PACKAGES_DIR, packageName, 'src');
+  const packageSrcPath = path.resolve(PACKAGES_DIR, packageName, SRC_DIR);
   const packageBuildPath = path.resolve(PACKAGES_DIR, packageName, 'es');
   const relativeToSrcPath = path.relative(packageSrcPath, file);
   const destPath = path.resolve(packageBuildPath, relativeToSrcPath);
@@ -42,23 +64,52 @@ function removeBuildFile(file) {
   );
 }
 
-function buildFile(file) {
+function buildFile(file, verbose = true) {
   const destPath = resolveDestPath(file);
+  mkdirp.sync(path.dirname(destPath));
   try {
     const transformed = babel.transformFileSync(file, babelOptions).code;
     fs.writeFileSync(destPath, transformed);
-    process.stdout.write(
-      `${chalk.green('\u2022 ') +
-        path.relative(PACKAGES_DIR, file) +
-        chalk.green(' \u21D2  ') +
-        path.relative(PACKAGES_DIR, destPath)}\n`,
-    );
+    if (verbose) {
+      process.stdout.write(
+        `${chalk.green('\u2022 ') +
+          path.relative(PACKAGES_DIR, file) +
+          chalk.green(' \u21D2  ') +
+          path.relative(PACKAGES_DIR, destPath)}\n`,
+      );
+    }
   } catch (e) {
     process.stdout.write(`${chalk.red('\u2022 ') + chalk.red(e)}\n`);
   }
 }
 
+function buildNodePackage(p) {
+  const srcDir = path.resolve(p, SRC_DIR);
+  const pattern = path.resolve(srcDir, JS_FILES_PATTERN);
+  const files = glob.sync(pattern, {
+    nodir: true,
+    ignore: [IGNORE_PATTERN],
+  });
+
+  process.stdout.write(adjustToTerminalWidth(`${path.basename(p)}`));
+
+  files.forEach(file => buildFile(file, false));
+  process.stdout.write(`${OK}\n`);
+}
+
+function buildPackages() {
+  const packages = getPackages();
+  process.stdout.write(chalk.inverse('Building packages \n'));
+  packages.forEach(buildNodePackage);
+  process.stdout.write('\n');
+}
+
+if (process.argv[2] === 'packages') {
+  buildPackages();
+}
+
 module.exports = {
+  buildPackages,
   removeBuildFile,
   buildFile,
 };

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -64,13 +64,13 @@ function removeBuildFile(file) {
   );
 }
 
-function buildFile(file, verbose = true) {
+function buildFile(file, silent) {
   const destPath = resolveDestPath(file);
   mkdirp.sync(path.dirname(destPath));
   try {
     const transformed = babel.transformFileSync(file, babelOptions).code;
     fs.writeFileSync(destPath, transformed);
-    if (verbose) {
+    if (!silent) {
       process.stdout.write(
         `${chalk.green('\u2022 ') +
           path.relative(PACKAGES_DIR, file) +
@@ -93,7 +93,7 @@ function buildNodePackage(p) {
 
   process.stdout.write(adjustToTerminalWidth(`${path.basename(p)}`));
 
-  files.forEach(file => buildFile(file, false));
+  files.forEach(file => buildFile(file, true));
   process.stdout.write(`${OK}\n`);
 }
 

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -8,29 +8,17 @@
 
 const chokidar = require('chokidar');
 const chalk = require('chalk');
-const fs = require('fs');
 const path = require('path');
 const { buildFile, removeBuildFile } = require('./build');
+const getPackages = require('./_getPackages');
 
 const SRC_DIR = 'src';
 const JS_FILES_PATTERN = '**/*.js*';
 const IGNORE_PATTERN = '**/__tests__/**';
-const PACKAGES_DIR = path.resolve(__dirname, '..', './packages');
 
-// Get absolute paths of all directories under packages/*
-function getPackages() {
-  return fs
-    .readdirSync(PACKAGES_DIR)
-    .map(file => path.resolve(PACKAGES_DIR, file))
-    .filter(f => fs.lstatSync(path.resolve(f)).isDirectory());
-}
-
-const packagePatterns = getPackages()
-  .filter(
-    f =>
-      f.indexOf('storybook') === -1 && f.indexOf('eslint-config-ndla') === -1,
-  ) // skip storybook and eslint-config-ndla
-  .map(p => path.resolve(p, SRC_DIR, JS_FILES_PATTERN));
+const packagePatterns = getPackages().map(p =>
+  path.resolve(p, SRC_DIR, JS_FILES_PATTERN),
+);
 
 // Initialize watcher
 const watcher = chokidar.watch(packagePatterns, {
@@ -46,5 +34,5 @@ watcher
   .on('unlink', removeBuildFile);
 
 process.stdout.write(
-  `${chalk.red('-> ') + chalk.cyan('Watching for changes...')}`,
+  `${chalk.red('-> ') + chalk.cyan('Watching for changes...')}\n`,
 );


### PR DESCRIPTION
Fixes so that you don't need to run  `yarn bootstrap` before `yarn start` when you have edited som files in other packages than designmanual.