### PR TITLE
Misc adjustments and fixes

### DIFF
--- a/packages/designmanual/.storybook/preview-head.html
+++ b/packages/designmanual/.storybook/preview-head.html
@@ -22,3 +22,11 @@
     top: 90px;
   }
 </style>
+
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=MML_CHTML"></script>
+
+<script>
+  window.MathJax.Hub.Config({
+    showMathMenu: false,
+  });
+</script>

--- a/packages/designmanual/stories/article/FigureWithLicense.jsx
+++ b/packages/designmanual/stories/article/FigureWithLicense.jsx
@@ -94,4 +94,8 @@ FigureWithLicense.propTypes = {
   typeLabel: PropTypes.string,
 };
 
+FigureWithLicense.defaultProps = {
+  classes: '',
+};
+
 export default FigureWithLicense;

--- a/packages/designmanual/stories/article/LicenseExample.jsx
+++ b/packages/designmanual/stories/article/LicenseExample.jsx
@@ -33,14 +33,13 @@ const VideoContent = () => (
     <MediaList>
       <MediaListItem>
         <MediaListItemImage>
-          <iframe
-            title="Youtube video"
-            width="200"
-            height="113"
-            src="https://www.youtube.com/embed/f9VriNNRn0U?feature=oembed"
-            frameBorder="0"
-            allowFullScreen=""
-          />
+          <a href="">
+            <img
+              src="https://images.unsplash.com/photo-1453733190371-0a9bedd82893?auto=format&fit=crop&w=500&q=60&ixid=dW5zcGxhc2guY29tOzs7Ozs%3D"
+              width="260"
+              alt="alt"
+            />
+          </a>
         </MediaListItemImage>
         <MediaListItemBody
           license="by-nc-nd"

--- a/packages/designmanual/stories/basic-styles.jsx
+++ b/packages/designmanual/stories/basic-styles.jsx
@@ -421,12 +421,12 @@ storiesOf('Grunnstiler', module)
         </h2>
         <p>
           Noen informasjonstyper kan stå for seg selv og være midtstilt.
-          Matematiske formler er ett eksempel på midtstilt tekst (har ikke
-          støtte for å vise mattematiske formler i designmanualen, så derfor er
-          det ingen eksempel).
+          Matematiske formler er ett eksempel på midtstilt tekst.
         </p>
-        <p className="u-text-center">
-          Dette er en midtstilt tekst. Lorum ipsum.
+        <p
+          className="u-text-center"
+        >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"><mn>4</mn><mo>=</mo><mfrac><mrow><mo>-</mo><mn>12</mn></mrow><mrow><mo>-</mo><mn>3</mn></mrow></mfrac></math>
         </p>
       </StoryBody>
     </div>

--- a/packages/designmanual/stories/basic-styles.jsx
+++ b/packages/designmanual/stories/basic-styles.jsx
@@ -423,10 +423,21 @@ storiesOf('Grunnstiler', module)
           Noen informasjonstyper kan stå for seg selv og være midtstilt.
           Matematiske formler er ett eksempel på midtstilt tekst.
         </p>
-        <p
-          className="u-text-center"
-        >
-          <math xmlns="http://www.w3.org/1998/Math/MathML"><mn>4</mn><mo>=</mo><mfrac><mrow><mo>-</mo><mn>12</mn></mrow><mrow><mo>-</mo><mn>3</mn></mrow></mfrac></math>
+        <p className="u-text-center">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <mn>4</mn>
+            <mo>=</mo>
+            <mfrac>
+              <mrow>
+                <mo>-</mo>
+                <mn>12</mn>
+              </mrow>
+              <mrow>
+                <mo>-</mo>
+                <mn>3</mn>
+              </mrow>
+            </mfrac>
+          </math>
         </p>
       </StoryBody>
     </div>

--- a/packages/designmanual/stories/basic-styles.jsx
+++ b/packages/designmanual/stories/basic-styles.jsx
@@ -266,69 +266,74 @@ storiesOf('Grunnstiler', module)
               <th>Størrelse på liten skjerm</th>
             </tr>
           </thead>
-          <tr>
-            <td>Overskrifter</td>
-            <td>
-              38 px{' '}
-              <span style={{ color: 'rgb(144, 144, 144)' }}>(2.1rem)</span>
-            </td>
-            <td>
-              30 px{' '}
-              <span style={{ color: 'rgb(144, 144, 144)' }}>(1.67rem)</span>
-            </td>
-          </tr>
-          <tr>
-            <td>Mellomoverskrifter</td>
-            <td>
-              22 px{' '}
-              <span style={{ color: 'rgb(144, 144, 144)' }}>(1.22rem)</span>
-            </td>
-            <td>
-              22 px{' '}
-              <span style={{ color: 'rgb(144, 144, 144)' }}>(1.22rem)</span>
-            </td>
-          </tr>
-          <tr>
-            <td>Små overskrifter</td>
-            <td>
-              18 px <span style={{ color: 'rgb(144, 144, 144)' }}>(1rem)</span>
-            </td>
-            <td>
-              18 px <span style={{ color: 'rgb(144, 144, 144)' }}>(1rem)</span>
-            </td>
-          </tr>
-          <tr>
-            <td>Ingress</td>
-            <td>
-              26 px{' '}
-              <span style={{ color: 'rgb(144, 144, 144)' }}>(1.44rem)</span>
-            </td>
-            <td>
-              20 px{' '}
-              <span style={{ color: 'rgb(144, 144, 144)' }}>(1.1rem)</span>
-            </td>
-          </tr>
-          <tr>
-            <td>Brødtekst</td>
-            <td>
-              18 px <span style={{ color: 'rgb(144, 144, 144)' }}>(1rem)</span>
-            </td>
-            <td>
-              16 px{' '}
-              <span style={{ color: 'rgb(144, 144, 144)' }}>(0.88rem)</span>
-            </td>
-          </tr>
-          <tr>
-            <td>Metatekst</td>
-            <td>
-              16 px{' '}
-              <span style={{ color: 'rgb(144, 144, 144)' }}>(0.88rem)</span>
-            </td>
-            <td>
-              16 px{' '}
-              <span style={{ color: 'rgb(144, 144, 144)' }}>(0.88rem)</span>
-            </td>
-          </tr>
+          <tbody>
+            <tr>
+              <td>Overskrifter</td>
+              <td>
+                38 px{' '}
+                <span style={{ color: 'rgb(144, 144, 144)' }}>(2.1rem)</span>
+              </td>
+              <td>
+                30 px{' '}
+                <span style={{ color: 'rgb(144, 144, 144)' }}>(1.67rem)</span>
+              </td>
+            </tr>
+            <tr>
+              <td>Mellomoverskrifter</td>
+              <td>
+                22 px{' '}
+                <span style={{ color: 'rgb(144, 144, 144)' }}>(1.22rem)</span>
+              </td>
+              <td>
+                22 px{' '}
+                <span style={{ color: 'rgb(144, 144, 144)' }}>(1.22rem)</span>
+              </td>
+            </tr>
+            <tr>
+              <td>Små overskrifter</td>
+              <td>
+                18 px{' '}
+                <span style={{ color: 'rgb(144, 144, 144)' }}>(1rem)</span>
+              </td>
+              <td>
+                18 px{' '}
+                <span style={{ color: 'rgb(144, 144, 144)' }}>(1rem)</span>
+              </td>
+            </tr>
+            <tr>
+              <td>Ingress</td>
+              <td>
+                26 px{' '}
+                <span style={{ color: 'rgb(144, 144, 144)' }}>(1.44rem)</span>
+              </td>
+              <td>
+                20 px{' '}
+                <span style={{ color: 'rgb(144, 144, 144)' }}>(1.1rem)</span>
+              </td>
+            </tr>
+            <tr>
+              <td>Brødtekst</td>
+              <td>
+                18 px{' '}
+                <span style={{ color: 'rgb(144, 144, 144)' }}>(1rem)</span>
+              </td>
+              <td>
+                16 px{' '}
+                <span style={{ color: 'rgb(144, 144, 144)' }}>(0.88rem)</span>
+              </td>
+            </tr>
+            <tr>
+              <td>Metatekst</td>
+              <td>
+                16 px{' '}
+                <span style={{ color: 'rgb(144, 144, 144)' }}>(0.88rem)</span>
+              </td>
+              <td>
+                16 px{' '}
+                <span style={{ color: 'rgb(144, 144, 144)' }}>(0.88rem)</span>
+              </td>
+            </tr>
+          </tbody>
         </table>
 
         <p>

--- a/packages/designmanual/stories/basic-styles.jsx
+++ b/packages/designmanual/stories/basic-styles.jsx
@@ -189,6 +189,9 @@ storiesOf('Grunnstiler', module)
             <a href="#lenker" target="_self">
               Lenker
             </a>,
+            <a href="#midtstilttekst" target="_self">
+              Midtstilt tekst
+            </a>,
           ]}
         />
       </StoryIntro>
@@ -397,6 +400,12 @@ storiesOf('Grunnstiler', module)
         </div>
 
         <p>Se også «Bruk av lenker» under «Enkle komponenter».</p>
+
+        <h2 id="midtstilttekst" className="u-heading">Midtstilt tekst</h2>
+        <p>Noen informasjonstyper kan stå for seg selv og være midtstilt. Matematiske formler er ett eksempel på midtstilt tekst (har ikke støtte for å vise mattematiske formler i designmanualen, så derfor er det ingen eksempel).</p>
+        <p className="u-text-center">
+          Dette er en midtstilt tekst. Lorum ipsum.
+        </p>
       </StoryBody>
     </div>
   ))

--- a/packages/designmanual/stories/basic-styles.jsx
+++ b/packages/designmanual/stories/basic-styles.jsx
@@ -229,6 +229,11 @@ storiesOf('Grunnstiler', module)
               <td>700</td>
             </tr>
             <tr>
+              <td>Små overskrifter</td>
+              <td>Source Sans Pro</td>
+              <td>700</td>
+            </tr>
+            <tr>
               <td>Ingress</td>
               <td>Source Sans Pro</td>
               <td>300</td>
@@ -284,6 +289,15 @@ storiesOf('Grunnstiler', module)
             </td>
           </tr>
           <tr>
+            <td>Små overskrifter</td>
+            <td>
+              18 px <span style={{ color: 'rgb(144, 144, 144)' }}>(1rem)</span>
+            </td>
+            <td>
+              18 px <span style={{ color: 'rgb(144, 144, 144)' }}>(1rem)</span>
+            </td>
+          </tr>
+          <tr>
             <td>Ingress</td>
             <td>
               26 px{' '}
@@ -331,12 +345,13 @@ storiesOf('Grunnstiler', module)
         <code>{'<h1>Overskrift</h1>'}</code>
 
         <p>
-          Det er to nivåer av overskrifter. Bruker man likevel overskrifts-tag
-          for nivå 3, 4 osv, vil de få samme stil som nivå 2 nedenfor:
+          Det er tre nivåer av overskrifter. Bruker man likevel overskrifts-tag
+          for nivå 4, 5 osv, vil de få samme stil som nivå 3 nedenfor:
         </p>
         <div className="c-bodybox">
           <div dangerouslySetInnerHTML={{ __html: heading('', 1) }} />
           <div dangerouslySetInnerHTML={{ __html: heading('', 2) }} />
+          <div dangerouslySetInnerHTML={{ __html: heading('', 3) }} />
         </div>
         <h2 id="ingress" className="u-heading">
           Ingress
@@ -401,8 +416,15 @@ storiesOf('Grunnstiler', module)
 
         <p>Se også «Bruk av lenker» under «Enkle komponenter».</p>
 
-        <h2 id="midtstilttekst" className="u-heading">Midtstilt tekst</h2>
-        <p>Noen informasjonstyper kan stå for seg selv og være midtstilt. Matematiske formler er ett eksempel på midtstilt tekst (har ikke støtte for å vise mattematiske formler i designmanualen, så derfor er det ingen eksempel).</p>
+        <h2 id="midtstilttekst" className="u-heading">
+          Midtstilt tekst
+        </h2>
+        <p>
+          Noen informasjonstyper kan stå for seg selv og være midtstilt.
+          Matematiske formler er ett eksempel på midtstilt tekst (har ikke
+          støtte for å vise mattematiske formler i designmanualen, så derfor er
+          det ingen eksempel).
+        </p>
         <p className="u-text-center">
           Dette er en midtstilt tekst. Lorum ipsum.
         </p>

--- a/packages/designmanual/stories/helpers.jsx
+++ b/packages/designmanual/stories/helpers.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { uuid } from 'ndla-util';
 
 export const Center = ({ children, style }) => (
   <div
@@ -52,7 +53,7 @@ export const AnchorNavigation = ({ links }) => (
       margin: 0,
       padding: 0,
     }}>
-    {links.map(link => <li>{link}</li>)}
+    {links.map(link => <li key={uuid()}>{link}</li>)}
   </ul>
 );
 

--- a/packages/designmanual/stories/simple-components.jsx
+++ b/packages/designmanual/stories/simple-components.jsx
@@ -35,7 +35,9 @@ storiesOf('Enkle komponenter', module)
           produsere filmen. Derfor er du avhengig av at noen tenner på idéen din
           og bestemmer seg for å bruke ressurser på nettopp dette prosjektet.
         </p>
-        <FigureWithLicense classes="u-float-left">
+        <FigureWithLicense
+          classes="u-float-left"
+          caption="Du har en kjempegod idé til en kortfilm. Men det koster mange penger å produsere filmen.">
           <Image
             alt="Forstørrelsesglass"
             src="https://staging.api.ndla.no/image-api/raw/42-45210905.jpg"
@@ -59,7 +61,7 @@ storiesOf('Enkle komponenter', module)
           tydeligere for både deg selv og dem du eventuelt jobber sammen med i
           klassen.
         </p>
-        <FigureWithLicense>
+        <FigureWithLicense caption="Du har en kjempegod idé til en kortfilm. Men det koster mange penger å produsere filmen.">
           <Image
             alt="Forstørrelsesglass"
             src="https://staging.api.ndla.no/image-api/raw/42-45210905.jpg"
@@ -71,7 +73,9 @@ storiesOf('Enkle komponenter', module)
           tydeligere for både deg selv og dem du eventuelt jobber sammen med i
           klassen.
         </p>
-        <FigureWithLicense classes="u-float-right">
+        <FigureWithLicense
+          classes="u-float-right"
+          caption="Du har en kjempegod idé til en kortfilm. Men det koster mange penger å produsere filmen.">
           <Image
             lazyLoad
             alt="Forstørrelsesglass"
@@ -102,7 +106,7 @@ storiesOf('Enkle komponenter', module)
         </p>
       </StoryIntro>
       <StoryBody>
-        <FigureWithLicense authors="" caption="">
+        <FigureWithLicense caption="Du har en kjempegod idé til en kortfilm. Men det koster mange penger å produsere filmen.">
           <Image
             alt=""
             src="https://staging.api.ndla.no/image-api/raw/42-45210905.jpg"

--- a/packages/designmanual/stories/simple-components.jsx
+++ b/packages/designmanual/stories/simple-components.jsx
@@ -30,6 +30,26 @@ storiesOf('Enkle komponenter', module)
       </StoryIntro>
 
       <StoryBody>
+        <h2>Fullbredde</h2>
+        <p>
+          Pitching er også en god måte å bevisstgjøre seg selv på. Når du
+          pitcher, blir idéen og historien i den filmen du planlegger å lage,
+          tydeligere for både deg selv og dem du eventuelt jobber sammen med i
+          klassen.
+        </p>
+        <FigureWithLicense caption="Du har en kjempegod idé til en kortfilm. Men det koster mange penger å produsere filmen.">
+          <Image
+            alt="Forstørrelsesglass"
+            src="https://staging.api.ndla.no/image-api/raw/42-45210905.jpg"
+          />
+        </FigureWithLicense>
+        <p>
+          Pitching er også en god måte å bevisstgjøre seg selv på. Når du
+          pitcher, blir idéen og historien i den filmen du planlegger å lage,
+          tydeligere for både deg selv og dem du eventuelt jobber sammen med i
+          klassen.
+        </p>
+        <h2>Flyt til venstre</h2>
         <p>
           Du har en kjempegod idé til en kortfilm. Men det koster mange penger å
           produsere filmen. Derfor er du avhengig av at noen tenner på idéen din
@@ -61,8 +81,20 @@ storiesOf('Enkle komponenter', module)
           tydeligere for både deg selv og dem du eventuelt jobber sammen med i
           klassen.
         </p>
-        <FigureWithLicense caption="Du har en kjempegod idé til en kortfilm. Men det koster mange penger å produsere filmen.">
+
+        <h2>Flyt til høyre</h2>
+        <p>
+          Pitching er også en god måte å bevisstgjøre seg selv på. Når du
+          pitcher, blir idéen og historien i den filmen du planlegger å lage,
+          tydeligere for både deg selv og dem du eventuelt jobber sammen med i
+          klassen.
+        </p>
+
+        <FigureWithLicense
+          classes="u-float-right"
+          caption="Du har en kjempegod idé til en kortfilm. Men det koster mange penger å produsere filmen.">
           <Image
+            lazyLoad
             alt="Forstørrelsesglass"
             src="https://staging.api.ndla.no/image-api/raw/42-45210905.jpg"
           />
@@ -73,8 +105,27 @@ storiesOf('Enkle komponenter', module)
           tydeligere for både deg selv og dem du eventuelt jobber sammen med i
           klassen.
         </p>
+        <p>
+          Pitching er også en god måte å bevisstgjøre seg selv på. Når du
+          pitcher, blir idéen og historien i den filmen du planlegger å lage,
+          tydeligere for både deg selv og dem du eventuelt jobber sammen med i
+          klassen.
+        </p>
+        <p>
+          Pitching er også en god måte å bevisstgjøre seg selv på. Når du
+          pitcher, blir idéen og historien i den filmen du planlegger å lage,
+          tydeligere for både deg selv og dem du eventuelt jobber sammen med i
+          klassen.
+        </p>
+        <h2>Flyt til høyre, liten versjon</h2>
+        <p>
+          Pitching er også en god måte å bevisstgjøre seg selv på. Når du
+          pitcher, blir idéen og historien i den filmen du planlegger å lage,
+          tydeligere for både deg selv og dem du eventuelt jobber sammen med i
+          klassen.
+        </p>
         <FigureWithLicense
-          classes="u-float-right"
+          classes="u-float-small-right"
           caption="Du har en kjempegod idé til en kortfilm. Men det koster mange penger å produsere filmen.">
           <Image
             lazyLoad
@@ -82,6 +133,64 @@ storiesOf('Enkle komponenter', module)
             src="https://staging.api.ndla.no/image-api/raw/42-45210905.jpg"
           />
         </FigureWithLicense>
+        <p>
+          Pitching er også en god måte å bevisstgjøre seg selv på. Når du
+          pitcher, blir idéen og historien i den filmen du planlegger å lage,
+          tydeligere for både deg selv og dem du eventuelt jobber sammen med i
+          klassen.
+        </p>
+        <p>
+          Pitching er også en god måte å bevisstgjøre seg selv på. Når du
+          pitcher, blir idéen og historien i den filmen du planlegger å lage,
+          tydeligere for både deg selv og dem du eventuelt jobber sammen med i
+          klassen.
+        </p>
+        <p>
+          Pitching er også en god måte å bevisstgjøre seg selv på. Når du
+          pitcher, blir idéen og historien i den filmen du planlegger å lage,
+          tydeligere for både deg selv og dem du eventuelt jobber sammen med i
+          klassen.
+        </p>
+        <p>
+          Pitching er også en god måte å bevisstgjøre seg selv på. Når du
+          pitcher, blir idéen og historien i den filmen du planlegger å lage,
+          tydeligere for både deg selv og dem du eventuelt jobber sammen med i
+          klassen.
+        </p>
+        <h2>Flyt til venstre, liten versjon</h2>
+        <p>
+          Pitching er også en god måte å bevisstgjøre seg selv på. Når du
+          pitcher, blir idéen og historien i den filmen du planlegger å lage,
+          tydeligere for både deg selv og dem du eventuelt jobber sammen med i
+          klassen.
+        </p>
+        <FigureWithLicense
+          classes="u-float-small-left"
+          caption="Du har en kjempegod idé til en kortfilm. Men det koster mange penger å produsere filmen.">
+          <Image
+            lazyLoad
+            alt="Forstørrelsesglass"
+            src="https://staging.api.ndla.no/image-api/raw/42-45210905.jpg"
+          />
+        </FigureWithLicense>
+        <p>
+          Pitching er også en god måte å bevisstgjøre seg selv på. Når du
+          pitcher, blir idéen og historien i den filmen du planlegger å lage,
+          tydeligere for både deg selv og dem du eventuelt jobber sammen med i
+          klassen.
+        </p>
+        <p>
+          Pitching er også en god måte å bevisstgjøre seg selv på. Når du
+          pitcher, blir idéen og historien i den filmen du planlegger å lage,
+          tydeligere for både deg selv og dem du eventuelt jobber sammen med i
+          klassen.
+        </p>
+        <p>
+          Pitching er også en god måte å bevisstgjøre seg selv på. Når du
+          pitcher, blir idéen og historien i den filmen du planlegger å lage,
+          tydeligere for både deg selv og dem du eventuelt jobber sammen med i
+          klassen.
+        </p>
         <p>
           Pitching er også en god måte å bevisstgjøre seg selv på. Når du
           pitcher, blir idéen og historien i den filmen du planlegger å lage,

--- a/packages/ndla-ui/src/Figure/Figure.js
+++ b/packages/ndla-ui/src/Figure/Figure.js
@@ -100,7 +100,7 @@ export const FigureCaption = ({
     <footer {...classes('byline')}>
       <div {...classes('byline-licenselist')}>
         <LicenseByline licenseRights={licenseRights}>
-          <span className="article_meta">
+          <span {...classes('byline-authors')}>
             {authors.map(author => author.name).join(', ')}
           </span>
           <button {...classes('captionbtn')}>{reuseLabel}</button>

--- a/packages/ndla-ui/src/Figure/component.figure.scss
+++ b/packages/ndla-ui/src/Figure/component.figure.scss
@@ -36,6 +36,10 @@
     @include grids-expand(4,6,2);
   }
   transition: transform 0.2s, width 0.2s, height 0.2s;
+
+  .c-license-icons__list {
+    margin-right: $spacing--small;
+  }
 }
 
 /* 2. */
@@ -43,24 +47,21 @@
   background-color: $brand-grey--lightest;
   padding-top: $spacing--small;
   display: flex;
-  flex-direction: column-reverse;
+  flex-direction: column;
   position: relative;
 }
 .c-figure__captionbtn {
-  padding-left: $spacing--small;
   text-decoration: underline;
   background: none;
   border: none;
   cursor: pointer;
   color: $brand-color;
-  min-width: 90px;
+  padding: $spacing--small/2 0;
 }
 .c-figure__licensetag {
   display: none;
 }
 .c-figure__byline {
-  padding-right: $spacing;
-  margin-bottom: $spacing--small/2;
   text-align: left;
   display: flex;
   align-items: center;
@@ -82,15 +83,27 @@
     display: none;
   }
 }
+
+.c-figure__byline-authors {
+  @include inuit-font-size(14px);
+  border-right: 1px solid $brand-grey--light;
+  padding-right: $spacing--small;
+  margin-right: $spacing--small;
+}
+
+
+
 .c-figure__info {
   max-width: 650px;
   margin-bottom: $spacing--small;
   @include inuit-font-size(14px, 22px);
   @include mq($from: tablet) {
     flex: 2;
-    margin-bottom: 0;
+    margin-bottom: $spacing--small;
   }
 }
+
+
 .c-figure__list {
   background: $white;
   list-style: none;

--- a/packages/ndla-ui/src/LicenseByline/LicenseByline.jsx
+++ b/packages/ndla-ui/src/LicenseByline/LicenseByline.jsx
@@ -8,8 +8,15 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import BEMHelper from 'react-bem-helper';
+
 import LicenseIconList from './LicenseIconList';
 import LicenseIconDescriptionList from './LicenseIconDescriptionList';
+
+const classes = new BEMHelper({
+  name: 'license-byline',
+  prefix: 'c-',
+});
 
 const LicenseByline = ({
   children,
@@ -17,7 +24,7 @@ const LicenseByline = ({
   licenseRights,
   className,
 }) => (
-  <div className="license-byline">
+  <div {...classes()}>
     {!withDescription ? (
       <LicenseIconList className={className} licenseRights={licenseRights} />
     ) : (

--- a/packages/ndla-ui/src/LicenseByline/component.license-byline.scss
+++ b/packages/ndla-ui/src/LicenseByline/component.license-byline.scss
@@ -1,0 +1,6 @@
+.c-license-byline {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+}

--- a/packages/ndla-ui/src/global/elements/_elements.headings.scss
+++ b/packages/ndla-ui/src/global/elements/_elements.headings.scss
@@ -31,14 +31,17 @@ h1 {
   }
 }
 
-h2, h3, .u-heading3 {
-  line-height: 1;
+h2, h3, .u-heading3, h4, h5 {
   margin-top: $spacing * 2;
   margin-bottom: $spacing / 2;
   @include inuit-font-size(22px, 30px);
   @include mq(desktop) {
     line-height: 1.5;
   }
+}
+
+h3, h4, h5 {
+  @include inuit-font-size(18px, 24px);
 }
 
 h2 + h2 {

--- a/packages/ndla-ui/src/global/elements/_elements.headings.scss
+++ b/packages/ndla-ui/src/global/elements/_elements.headings.scss
@@ -41,7 +41,7 @@ h2, h3, .u-heading3, h4, h5 {
 }
 
 h3, h4, h5 {
-  @include inuit-font-size(18px, 24px);
+  @include inuit-font-size(18px, 26px);
 }
 
 h2 + h2 {

--- a/packages/ndla-ui/src/global/utilities/utilities.grids.scss
+++ b/packages/ndla-ui/src/global/utilities/utilities.grids.scss
@@ -28,7 +28,7 @@ $denominator: auto;
     }
     @include mq(desktop) {
       width: ($cols/$maxcols)*100% !important;
-      margin: 0 $spacing $spacing (-$colDifference/$maxcols*100%);
+      margin: 0 $spacing $spacing -25%;
     }
   }
   @if $direction == right {
@@ -42,7 +42,7 @@ $denominator: auto;
     }
     @include mq(desktop) {
       width: ($cols/$maxcols)*100% !important;
-      margin: 0 (-$colDifference/$maxcols*100%) $spacing $spacing;
+      margin: 0 -25% $spacing $spacing;
     }
   }
 

--- a/packages/ndla-ui/src/global/utilities/utilities.helpers.scss
+++ b/packages/ndla-ui/src/global/utilities/utilities.helpers.scss
@@ -20,12 +20,6 @@
   @include float(3, 4, 'right');
 }
 
-
-/* Float tools */
-.u-float-right {
-  float: right;
-}
-
 /* MISC */
 .u-hidden {
   display: none !important;

--- a/packages/ndla-ui/src/global/utilities/utilities.helpers.scss
+++ b/packages/ndla-ui/src/global/utilities/utilities.helpers.scss
@@ -19,6 +19,12 @@
 .u-float-right {
   @include float(3, 4, 'right');
 }
+.u-float-small-left {
+  @include float(2, 4, 'left');
+}
+.u-float-small-right {
+  @include float(2, 4, 'right');
+}
 
 /* MISC */
 .u-hidden {

--- a/packages/ndla-ui/src/global/utilities/utilities.helpers.scss
+++ b/packages/ndla-ui/src/global/utilities/utilities.helpers.scss
@@ -20,13 +20,6 @@
   @include float(3, 4, 'right');
 }
 
-// DEPRECATED TODO: remove when not in use
-.article_figure--float-left {
-  @include float(3, 4, 'left');
-}
-.article_figure--float-right {
-  @include float(3, 4, 'right');
-}
 
 /* Float tools */
 .u-float-right {

--- a/packages/ndla-ui/src/global/utilities/utilities.shame.scss
+++ b/packages/ndla-ui/src/global/utilities/utilities.shame.scss
@@ -9,27 +9,6 @@
   overflow-x: hidden;
 }
 
-.license-byline {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  flex-wrap: wrap;
-}
-.article_meta {
-  margin-left: $spacing--small;
-  @include inuit-font-size(14px);
-  border-right: 1px solid $brand-grey--light;
-  padding-right: $spacing--small;
-}
-.license-byline__body {
-  display: none;
-  margin-right: $spacing--small;
-  @include inuit-font-size(13px);
-  letter-spacing: 0.05em;
-  margin-top: 4px;
-  margin-left: $spacing--small;
-}
-
 /* Hack to differentiate CC-icon because it's not a license. Perhaps give it a class? */
 .c-figure-license__details .c-license-icons__item:first-child,
 .c-medialist__body .c-license-icons__item:first-child {

--- a/packages/ndla-ui/src/main.scss
+++ b/packages/ndla-ui/src/main.scss
@@ -77,6 +77,7 @@ $inuit-wrapper-width: 1024px;
 @import 'global/components/component.glossary-word';
 @import 'global/components/component.icon';
 @import 'LicenseByline/component.license-icons';
+@import 'LicenseByline/component.license-byline';
 @import 'ToggleLicenseBox/component.licensebox';
 @import 'global/components/component.logo';
 @import 'MediaList/component.medialist';


### PR DESCRIPTION
- Example in license box for thumbnail video
- Figure caption: Styling adjustments. Caption text moved to top
- Removed deprecated classes .article_figure--float-left and .article_figure--float-right NB! Breaking
- Fix floating bug on mobile
- New small version of figure. Example in design manual
- Example of centering text in design manual (used for math)
- Styling of h3.