### PR TITLE
added min-width to images in tables to avoid collapse on smaller devices …

### DIFF
--- a/packages/ndla-ui/src/Table/component.tables.scss
+++ b/packages/ndla-ui/src/Table/component.tables.scss
@@ -248,6 +248,7 @@ article table {
 
     img {
       max-width: 100%;
+      min-width: 120px;
     }
   }
 


### PR DESCRIPTION
…(will work in most cases)