### PR TITLE
phone input and scroll fix + minor dialog css and tooltip updates

### DIFF
--- a/packages/ndla-ui/src/Dialog/component.dialog.scss
+++ b/packages/ndla-ui/src/Dialog/component.dialog.scss
@@ -1,4 +1,5 @@
 .c-dialog {
+  text-align: left;
   position: fixed;
   top: 0;
   bottom: 0;
@@ -18,7 +19,7 @@
       @include inuit-font-size(22px, 26px);
     }
   }
-  
+
   &--active {
     display: flex;
     .o-backdrop {
@@ -44,12 +45,16 @@
   &--active &__content {
     background-color: $brand-color--lighter;
     box-shadow: 0 0 30px rgba($black, 0.2);
-    padding: $spacing;
+    padding: $spacing--large $spacing;
     animation-name: zoomIn;
     animation-duration: 0.3s;
     overflow: auto;
     height: 100vh;
     width: 100vw;
+
+    .c-tabs {
+      margin-left: 0;
+    }
 
     @include mq(tablet) {
       width: 90%;

--- a/packages/ndla-ui/src/Tooltip/Tooltip.jsx
+++ b/packages/ndla-ui/src/Tooltip/Tooltip.jsx
@@ -9,6 +9,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import BEMHelper from 'react-bem-helper';
+import { uuid } from 'ndla-util';
 
 import { Fade } from '../Animation';
 
@@ -27,6 +28,10 @@ class Tooltip extends Component {
     this.handleShowTooltip = this.handleShowTooltip.bind(this);
     this.handleHideTooltip = this.handleHideTooltip.bind(this);
     this.delayTimer = null;
+    this.contentRef = null;
+    this.widthRef = 0;
+    this.heightRef = 0;
+    this.uuid = uuid();
   }
 
   componentDidMount() {
@@ -45,6 +50,8 @@ class Tooltip extends Component {
 
   handleShowTooltip() {
     if (!this.state.showTooltip && this.state.disabled) {
+      this.widthRef = this.contentRef.offsetWidth;
+      this.heightRef = this.contentRef.offsetHeight;
       this.setState({ showtooltip: true });
     }
   }
@@ -54,19 +61,59 @@ class Tooltip extends Component {
   }
 
   render() {
+    let transform;
+    switch (this.props.align) {
+      case 'top':
+        transform = `translate3d(calc(-50% + ${this.widthRef /
+          2}px), calc(-100% - 0.25rem), 0)`;
+        break;
+      case 'left':
+        transform = `translate3d(calc(-100% - 0.25rem), calc(-50% + ${this
+          .heightRef / 2}px), 0)`;
+        break;
+      case 'right':
+        transform = `translate3d(calc(${
+          this.widthRef
+        }px + 0.25rem), calc(-50% + ${this.heightRef / 2}px), 0)`;
+        break;
+      case 'bottom':
+        transform = `translate3d(calc(-50% + ${this.widthRef / 2}px), calc(${
+          this.heightRef
+        }px + 0.25rem), 0)`;
+        break;
+      default:
+        break;
+    }
+
     return (
-      <div>
+      <div
+        className={`${classes('').className} ${
+          this.props.tooltipContainerClass
+        }`}>
         <Fade in={this.state.showtooltip}>
-          <span {...classes('', this.props.align)}>{this.props.tooltip}</span>
+          <span
+            role="tooltip"
+            id={this.uuid}
+            {...classes('tooltip')}
+            style={{ transform }}>
+            {this.props.tooltip}
+          </span>
         </Fade>
-        <div
-          onMouseEnter={this.handleShowTooltip}
+        <span
+          role="button"
+          tabIndex={0}
+          aria-describedby={this.uuid}
+          ref={r => {
+            this.contentRef = r;
+          }}
           onMouseMove={this.handleShowTooltip}
+          onMouseEnter={this.handleShowTooltip}
           onMouseLeave={this.handleHideTooltip}
           onFocus={this.handleShowTooltip}
-          onBlur={this.handleHideTooltip}>
+          onBlur={this.handleHideTooltip}
+          className={`c-tooltip__content ${this.props.className}`}>
           {this.props.children}
-        </div>
+        </span>
       </div>
     );
   }
@@ -77,13 +124,17 @@ Tooltip.propTypes = {
   tooltip: PropTypes.string.isRequired,
   delay: PropTypes.number,
   disabled: PropTypes.bool,
-  align: PropTypes.oneOf(['left', 'right']),
+  align: PropTypes.oneOf(['left', 'right', 'top', 'bottom']),
+  className: PropTypes.string,
+  tooltipContainerClass: PropTypes.string,
 };
 
 Tooltip.defaultProps = {
-  align: undefined,
+  align: 'top',
   disabled: false,
   delay: 0,
+  className: '',
+  tooltipContainerClass: '',
 };
 
 export default Tooltip;

--- a/packages/ndla-ui/src/Tooltip/component.tooltip.scss
+++ b/packages/ndla-ui/src/Tooltip/component.tooltip.scss
@@ -1,19 +1,19 @@
 .c-tooltip {
-  display: block;
-  position: absolute;
-  z-index: 9000;
-  background: $brand-color;
-  padding: $spacing--small;
-  font-family: $font;
-  @include font-size(14px, 18px);
-  color: $white;
-  transform: translate3d(-50%, calc(-100% - 0.25rem), 0);
-  text-align: center;
-  white-space: nowrap;
-  &--right {
-    transform: translate3d(calc(-100% + 2rem), calc(-100% - 0.25rem), 0);
+  position: relative;
+  &__tooltip {
+    display: block;
+    position: absolute;
+    z-index: 9999;
+    background: $brand-color;
+    padding: $spacing--small;
+    font-family: $font;
+    font-weight: $font-weight-normal;
+    @include font-size(14px, 18px);
+    color: $white;
+    text-align: center;
+    white-space: nowrap;
   }
-  &--left {
-    transform: translate3d(0, calc(-100% - 0.25rem), 0);
+  &__content {
+    display: inline-block;
   }
 }

--- a/packages/ndla-ui/src/TopicIntroductionList/TopicIntroductionList.jsx
+++ b/packages/ndla-ui/src/TopicIntroductionList/TopicIntroductionList.jsx
@@ -53,13 +53,13 @@ const TopicIntroduction = ({
             {contentTypeDescription}
           </span>
           {additional && (
-            <Tooltip tooltip={messages.tooltipAdditionalTopic} align="right">
+            <Tooltip tooltip={messages.tooltipAdditionalTopic} align="left">
               <Additional className="c-icon--20 u-margin-left-tiny" />
             </Tooltip>
           )}
           {!additional &&
             showAdditionalCores && (
-              <Tooltip tooltip={messages.tooltipCoreTopic} align="right">
+              <Tooltip tooltip={messages.tooltipCoreTopic} align="left">
                 <Core className="c-icon--20 u-margin-left-tiny" />
               </Tooltip>
             )}

--- a/packages/ndla-ui/src/TopicIntroductionList/TopicIntroductionShortcuts.jsx
+++ b/packages/ndla-ui/src/TopicIntroductionList/TopicIntroductionShortcuts.jsx
@@ -1,12 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import BEMHelper from 'react-bem-helper';
-import { TransitionGroup } from 'react-transition-group';
 import { Forward } from 'ndla-icons/common';
 
 import ShortcutItem from './TopicShortcutItem';
-
-import Fade from '../Animation/Fade';
 
 import { ShortcutShape } from '../shapes';
 
@@ -15,41 +12,28 @@ const classes = new BEMHelper({
   prefix: 'c-',
 });
 
-const animationDelay = 50;
-const animationDuration = 300;
-
 class TopicIntroductionShortcuts extends Component {
   constructor(props) {
     super(props);
     this.state = {
       open: props.alwaysExpanded,
+      returned: false,
       showButtonText: true,
-      disableToolTip: false,
     };
     this.handleOnToggle = this.handleOnToggle.bind(this);
-    this.disableToolTipTimeout = null;
   }
 
   handleOnToggle(open) {
-    clearInterval(this.disableToolTipTimeout);
-    if (open) {
-      this.setState({ open, showButtonText: false, disableToolTip: true });
-      this.disableToolTipTimeout = setTimeout(() => {
-        this.setState({ disableToolTip: false });
-      }, 400);
-    } else {
-      this.setState({ open, disableToolTip: false });
-      const { shortcuts } = this.props;
-
-      setTimeout(() => {
-        this.setState({ showButtonText: true });
-      }, shortcuts.length * animationDelay + animationDuration);
-    }
+    this.setState({
+      open,
+      showButtonText: !open,
+      returned: !open,
+    });
   }
 
   render() {
     const { shortcuts, messages, id, alwaysExpanded } = this.props;
-    const { open, showButtonText, disableToolTip } = this.state;
+    const { open, returned, showButtonText } = this.state;
 
     let onMouseEnter = null;
     let onMouseLeave = null;
@@ -65,7 +49,7 @@ class TopicIntroductionShortcuts extends Component {
           aria-expanded={this.state.open}
           aria-label={messages.toggleButtonText}
           aria-controls={id}
-          {...classes('button')}
+          {...classes('button', returned ? 're-enter' : '')}
           onClick={() => {
             this.handleOnToggle(!open);
           }}>
@@ -82,22 +66,15 @@ class TopicIntroductionShortcuts extends Component {
         onMouseLeave={onMouseLeave}
         {...classes()}>
         {buttonView}
-        <TransitionGroup className={classes('list').className} component="ul">
-          {(open ? shortcuts : []).map((shortcut, index, array) => (
-            <Fade
-              timeout={animationDuration}
-              key={shortcut.id}
-              delay={index * animationDelay}
-              exitDelay={(array.length - index) * animationDelay}>
-              <li {...classes('item')}>
-                <ShortcutItem
-                  shortcut={shortcut}
-                  disableToolTip={disableToolTip}
-                />
+        {open && (
+          <ul className={classes('list', open ? 'visible' : '').className}>
+            {shortcuts.map(shortcut => (
+              <li {...classes('item')} key={shortcut.id}>
+                <ShortcutItem shortcut={shortcut} />
               </li>
-            </Fade>
-          ))}
-        </TransitionGroup>
+            ))}
+          </ul>
+        )}
       </div>
     );
   }

--- a/packages/ndla-ui/src/TopicIntroductionList/TopicShortcutItem.jsx
+++ b/packages/ndla-ui/src/TopicIntroductionList/TopicShortcutItem.jsx
@@ -13,7 +13,7 @@ const classes = new BEMHelper({
 });
 
 const ShortcutItem = ({ shortcut: { tooltip, contentType, url, count } }) => (
-  <Tooltip tooltip={tooltip} delay={400}>
+  <Tooltip tooltip={tooltip} delay={400} align="bottom">
     <SafeLink {...classes('item-link')} aria-label={tooltip} to={url}>
       <ContentTypeBadge type={contentType} size="x-small" background />
       <span {...classes('count')}>{count}</span>

--- a/packages/ndla-ui/src/TopicIntroductionList/component.topic-shortcuts.scss
+++ b/packages/ndla-ui/src/TopicIntroductionList/component.topic-shortcuts.scss
@@ -25,6 +25,11 @@
     padding: 0;
     cursor: pointer;
     margin-right: $spacing--small / 2;
+    &--re-enter {
+      span {
+        animation: fadeInLeft 200ms;
+      }
+    }
   }
 
   &__label {
@@ -37,11 +42,15 @@
 
   &__list {
     list-style: none;
-    display: flex;
     align-items: center;
     padding: 0;
     margin: 0;
     line-height: 1rem;
+    display: none;
+    &--visible {
+      display: flex;
+      @include fadeInLeftItems(li, 10);
+    }
   }
 
   &__item {

--- a/packages/ndla-ui/src/global/utilities/utilities.shame.scss
+++ b/packages/ndla-ui/src/global/utilities/utilities.shame.scss
@@ -7,6 +7,11 @@
 */
 #root {
   overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
+  input {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+  }
 }
 
 /* IE-10+ fix for footer */

--- a/packages/ndla-util/src/noScroll.js
+++ b/packages/ndla-util/src/noScroll.js
@@ -25,9 +25,15 @@ const noScroll = enable => {
     const scrollWidth = getScrollbarWidth();
     htmlElement.style.overflow = 'hidden';
     htmlElement.style.paddingRight = `${scrollWidth}px`;
+    htmlElement.style.position = 'fixed'; // iOS scrolling fix
+    htmlElement.style.left = 0;
+    htmlElement.style.right = 0;
   } else {
     htmlElement.style.overflow = null;
     htmlElement.style.paddingRight = null;
+    htmlElement.style.position = 'static';
+    htmlElement.style.left = 'auto';
+    htmlElement.style.right = 'auto';
   }
 };
 


### PR DESCRIPTION
• Semi hack to prevent scrolling on iOS with noScroll function, using position: absolute to #root.
• Minor Tooltip adjustments for better position handling
• Prevent native input on text-fields iOS
• Improved Icons and tooltip for Topiclist (css / internal component fixes)