### PR TITLE
Search fix before launch

### DIFF
--- a/packages/designmanual/stories/molecules/mastheads.jsx
+++ b/packages/designmanual/stories/molecules/mastheads.jsx
@@ -122,70 +122,71 @@ class MastheadWithTopicMenu extends Component {
     return (
       <Masthead
         fixed
-        hideOnNarrowScreen={this.props.hideOnNarrowScreen}
         infoContent={this.props.beta && this.props.betaInfoContent}>
         <MastheadItem left>
-          <ClickToggle
-            isOpen={this.state.menuIsOpen}
-            onToggle={isOpen => {
-              this.setState({
-                menuIsOpen: isOpen,
-                expandedTopicId: null,
-                expandedSubtopicId: null,
-              });
-            }}
-            title="Meny"
-            openTitle="Lukk"
-            className="c-topic-menu-container"
-            buttonClassName="c-btn c-button--outline c-topic-menu-toggle-button">
-            {onClose => (
-              <TopicMenu
-                close={onClose}
-                isBeta={this.props.beta}
-                subjectTitle="Mediefag"
-                toSubject={() => '#'}
-                toTopic={() => '#'}
-                withSearchAndFilter
-                topics={topicMenu}
-                messages={messages}
-                onOpenSearch={() => {
-                  this.setState({
-                    menuIsOpen: false,
-                    searchIsOpen: true,
-                  });
-                }}
-                filterOptions={[
-                  {
-                    title: 'Medieuttrykk',
-                    value: 'Medieuttrykk',
-                  },
-                  {
-                    title: 'Mediesamfunnet',
-                    value: 'Mediesamfunnet',
-                  },
-                ]}
-                filterValues={['Medieuttrykk']}
-                competenceGoals={<CompetenceGoalsExample menu />}
-                onFilterClick={() => {}}
-                searchPageUrl="#"
-                resourceToLinkProps={() => {}}
-                expandedTopicId={this.state.expandedTopicId}
-                expandedSubtopicId={this.state.expandedSubtopicId}
-                expandedSubtopicLevel2Id={this.state.expandedSubtopicLevel2Id}
-                onNavigate={(
-                  expandedTopicId,
-                  expandedSubtopicId,
-                  expandedSubtopicLevel2Id,
-                ) => {
-                  this.setState({
+          {!this.props.hideMenu && (
+            <ClickToggle
+              isOpen={this.state.menuIsOpen}
+              onToggle={isOpen => {
+                this.setState({
+                  menuIsOpen: isOpen,
+                  expandedTopicId: null,
+                  expandedSubtopicId: null,
+                });
+              }}
+              title="Meny"
+              openTitle="Lukk"
+              className="c-topic-menu-container"
+              buttonClassName="c-btn c-button--outline c-topic-menu-toggle-button">
+              {onClose => (
+                <TopicMenu
+                  close={onClose}
+                  isBeta={this.props.beta}
+                  subjectTitle="Mediefag"
+                  toSubject={() => '#'}
+                  toTopic={() => '#'}
+                  withSearchAndFilter
+                  topics={topicMenu}
+                  messages={messages}
+                  onOpenSearch={() => {
+                    this.setState({
+                      menuIsOpen: false,
+                      searchIsOpen: true,
+                    });
+                  }}
+                  filterOptions={[
+                    {
+                      title: 'Medieuttrykk',
+                      value: 'Medieuttrykk',
+                    },
+                    {
+                      title: 'Mediesamfunnet',
+                      value: 'Mediesamfunnet',
+                    },
+                  ]}
+                  filterValues={['Medieuttrykk']}
+                  competenceGoals={<CompetenceGoalsExample menu />}
+                  onFilterClick={() => {}}
+                  searchPageUrl="#"
+                  resourceToLinkProps={() => {}}
+                  expandedTopicId={this.state.expandedTopicId}
+                  expandedSubtopicId={this.state.expandedSubtopicId}
+                  expandedSubtopicLevel2Id={this.state.expandedSubtopicLevel2Id}
+                  onNavigate={(
                     expandedTopicId,
                     expandedSubtopicId,
                     expandedSubtopicLevel2Id,
-                  });
-                }}
-              />
-            )}
-          </ClickToggle>
+                  ) => {
+                    this.setState({
+                      expandedTopicId,
+                      expandedSubtopicId,
+                      expandedSubtopicLevel2Id,
+                    });
+                  }}
+                />
+              )}
+            </ClickToggle>
+          )}
           <DisplayOnPageYOffset yOffsetMin={150}>
             <BreadcrumbBlock />
           </DisplayOnPageYOffset>
@@ -205,13 +206,14 @@ class MastheadWithTopicMenu extends Component {
 
 MastheadWithTopicMenu.propTypes = {
   searchFieldExpanded: PropTypes.bool,
-  hideOnNarrowScreen: PropTypes.bool,
   hideSearchButton: PropTypes.bool,
+  hideMenu: PropTypes.bool,
   beta: PropTypes.bool,
   betaInfoContent: PropTypes.node,
 };
 
 MastheadWithTopicMenu.defaultProps = {
+  hideMenu: false,
   searchFieldExpanded: false,
   betaInfoContent: (
     <Fragment>

--- a/packages/designmanual/stories/pages/SearchPageExample.jsx
+++ b/packages/designmanual/stories/pages/SearchPageExample.jsx
@@ -131,6 +131,7 @@ class SearchPageExample extends Component {
     this.state = {
       currentTab: 'all',
       competenceGoalsOpen: false,
+      exampleSubjectFilterValues: ['value'],
     };
   }
 
@@ -158,7 +159,7 @@ class SearchPageExample extends Component {
       ) : null;
 
     const contextFilter =
-      searchTabFilterOptions[currentTab] && currentResult.length > 0 ? (
+      searchTabFilterOptions[currentTab] ? (
         <SearchFilter
           contextFilter
           label="Egenskaper"
@@ -177,9 +178,32 @@ class SearchPageExample extends Component {
     const searchString = this.props.competenceGoals
       ? 'Kompetansemål'
       : 'Ideskaping';
+
+    const subjectFilterOptions = [
+      {
+        title: 'Brønnteknikk',
+        value: 'value2',
+      },
+      {
+        title: 'Kinesisk',
+        value: 'value1',
+      },
+      {
+        title: 'Markedsføring og ledelse',
+        value: 'value3',
+      },
+      {
+        title: 'Medieuttrykk og mediasamfunnet',
+        value: 'value',
+      },
+      {
+        title: 'Naturbruk',
+        value: 'value4',
+      },
+    ];
+
     return (
       <SearchPage
-        closeUrl="#"
         searchString={hasAuthor ? '«Cecilie Isaksen Eftedal»' : searchString}
         hideResultText={this.state.competenceGoalsOpen}
         onSearchFieldChange={() => {}}
@@ -219,7 +243,6 @@ class SearchPageExample extends Component {
           resultHeading: hasAuthor
             ? '37 artikler skrevet av Cecilie'
             : '43 treff i Ndla',
-          closeButton: 'Lukk',
           narrowScreenFilterHeading: '10 treff på «ideutvikling»',
           searchFieldTitle: 'Søk',
         }}
@@ -228,45 +251,26 @@ class SearchPageExample extends Component {
           <Fragment>
             <SearchFilter
               label="Fag:"
-              options={[
-                {
-                  title: 'Medieuttrykk og mediasamfunnet',
-                  value: 'value',
-                },
-              ]}
-              values={['value']}>
+              noFilterSelectedLabel="Ingen filter valgt"
+              options={subjectFilterOptions.filter(option => this.state.exampleSubjectFilterValues.indexOf(option.value) !== -1)
+                /*
+                  Note: We only pass along selected options to this component!
+                */
+              }
+              onChange={(values) => { this.setState({ exampleSubjectFilterValues: values }); }}
+              values={this.state.exampleSubjectFilterValues}>
               <SearchPopoverFilter
                 messages={{
                   backButton: 'Tilbake til filter',
                   filterLabel: 'Velg fag',
                   closeButton: 'Lukk',
-                  confirmButton: 'Bruk fag',
-                  hasValuesButtonText: 'Vis flere fag',
+                  confirmButton: 'Oppdater filter',
+                  hasValuesButtonText: 'Flere fag',
                   noValuesButtonText: 'Filtrer på fag',
                 }}
-                options={[
-                  {
-                    title: 'Brønnteknikk',
-                    value: 'value2',
-                  },
-                  {
-                    title: 'Kinesisk',
-                    value: 'value1',
-                  },
-                  {
-                    title: 'Markedsføring og ledelse',
-                    value: 'value3',
-                  },
-                  {
-                    title: 'Medieuttrykk og mediasamfunnet',
-                    value: 'value',
-                  },
-                  {
-                    title: 'Naturbruk',
-                    value: 'value4',
-                  },
-                ]}
-                values={['value']}
+                options={subjectFilterOptions}
+                values={this.state.exampleSubjectFilterValues}
+                onChange={(values) => { this.setState({ exampleSubjectFilterValues: values }); }}
               />
             </SearchFilter>
             <SearchFilter

--- a/packages/designmanual/stories/pages/SearchPageExample.jsx
+++ b/packages/designmanual/stories/pages/SearchPageExample.jsx
@@ -158,15 +158,14 @@ class SearchPageExample extends Component {
         />
       ) : null;
 
-    const contextFilter =
-      searchTabFilterOptions[currentTab] ? (
-        <SearchFilter
-          contextFilter
-          label="Egenskaper"
-          options={searchTabFilterOptions[currentTab]}
-          values={['value']}
-        />
-      ) : null;
+    const contextFilter = searchTabFilterOptions[currentTab] ? (
+      <SearchFilter
+        contextFilter
+        label="Egenskaper"
+        options={searchTabFilterOptions[currentTab]}
+        values={['value']}
+      />
+    ) : null;
 
     const onSearch = evt => {
       evt.preventDefault();
@@ -252,12 +251,20 @@ class SearchPageExample extends Component {
             <SearchFilter
               label="Fag:"
               noFilterSelectedLabel="Ingen filter valgt"
-              options={subjectFilterOptions.filter(option => this.state.exampleSubjectFilterValues.indexOf(option.value) !== -1)
+              options={
+                subjectFilterOptions.filter(
+                  option =>
+                    this.state.exampleSubjectFilterValues.indexOf(
+                      option.value,
+                    ) !== -1,
+                )
                 /*
                   Note: We only pass along selected options to this component!
                 */
               }
-              onChange={(values) => { this.setState({ exampleSubjectFilterValues: values }); }}
+              onChange={values => {
+                this.setState({ exampleSubjectFilterValues: values });
+              }}
               values={this.state.exampleSubjectFilterValues}>
               <SearchPopoverFilter
                 messages={{
@@ -270,7 +277,9 @@ class SearchPageExample extends Component {
                 }}
                 options={subjectFilterOptions}
                 values={this.state.exampleSubjectFilterValues}
-                onChange={(values) => { this.setState({ exampleSubjectFilterValues: values }); }}
+                onChange={values => {
+                  this.setState({ exampleSubjectFilterValues: values });
+                }}
               />
             </SearchFilter>
             <SearchFilter

--- a/packages/designmanual/stories/search.js
+++ b/packages/designmanual/stories/search.js
@@ -18,7 +18,7 @@ storiesOf('Søk', module)
   .add('Søkeside', () => (
     <PageContainer background>
       <Content>
-        <MastheadWithTopicMenu hideOnNarrowScreen hideSearchButton />
+        <MastheadWithTopicMenu hideSearchButton />
         <OneColumn cssModifier="clear-desktop" wide>
           <SearchPageExample />
         </OneColumn>
@@ -29,7 +29,7 @@ storiesOf('Søk', module)
   .add('Søk kompetansemål', () => (
     <PageContainer background>
       <Content>
-        <MastheadWithTopicMenu hideOnNarrowScreen hideSearchButton />
+        <MastheadWithTopicMenu hideSearchButton />
         <OneColumn cssModifier="clear-desktop" wide>
           <SearchPageExample competenceGoals />
         </OneColumn>
@@ -40,7 +40,7 @@ storiesOf('Søk', module)
   .add('Søkeside opphavsmann', () => (
     <PageContainer background>
       <Content>
-        <MastheadWithTopicMenu hideOnNarrowScreen hideSearchButton />
+        <MastheadWithTopicMenu hideSearchButton />
         <OneColumn cssModifier="clear-desktop" wide>
           <SearchPageExample showAuthor />
         </OneColumn>

--- a/packages/designmanual/stories/search.js
+++ b/packages/designmanual/stories/search.js
@@ -29,7 +29,7 @@ storiesOf('Søk', module)
   .add('Søk kompetansemål', () => (
     <PageContainer background>
       <Content>
-        <MastheadWithTopicMenu hideSearchButton />
+        <MastheadWithTopicMenu hideSearchButton hideMenu />
         <OneColumn cssModifier="clear-desktop" wide>
           <SearchPageExample competenceGoals />
         </OneColumn>

--- a/packages/ndla-ui/src/Filter/FilterList.jsx
+++ b/packages/ndla-ui/src/Filter/FilterList.jsx
@@ -48,8 +48,12 @@ class FilterList extends Component {
     return (
       <section {...filterClasses('list', modifiers)}>
         <h1 {...filterClasses('label', labelModifiers)}>{label}</h1>
-        {this.props.noFilterSelectedLabel && options.length === 0 &&
-          <span {...filterClasses('no-filter-selected')}>{this.props.noFilterSelectedLabel}</span>}
+        {this.props.noFilterSelectedLabel &&
+          options.length === 0 && (
+            <span {...filterClasses('no-filter-selected')}>
+              {this.props.noFilterSelectedLabel}
+            </span>
+          )}
         <ul {...filterClasses('item-wrapper')}>
           {options.map((option, index) => {
             const itemModifiers = [];

--- a/packages/ndla-ui/src/Filter/FilterList.jsx
+++ b/packages/ndla-ui/src/Filter/FilterList.jsx
@@ -48,6 +48,8 @@ class FilterList extends Component {
     return (
       <section {...filterClasses('list', modifiers)}>
         <h1 {...filterClasses('label', labelModifiers)}>{label}</h1>
+        {this.props.noFilterSelectedLabel && options.length === 0 &&
+          <span {...filterClasses('no-filter-selected')}>{this.props.noFilterSelectedLabel}</span>}
         <ul {...filterClasses('item-wrapper')}>
           {options.map((option, index) => {
             const itemModifiers = [];
@@ -151,6 +153,7 @@ FilterList.propTypes = {
   values: PropTypes.arrayOf(valueShape),
   defaultVisibleCount: PropTypes.number,
   showLabel: PropTypes.string,
+  noFilterSelectedLabel: PropTypes.string,
   hideLabel: PropTypes.string,
 };
 

--- a/packages/ndla-ui/src/Filter/component.filter.scss
+++ b/packages/ndla-ui/src/Filter/component.filter.scss
@@ -317,4 +317,8 @@
       }
     }
   }
+  &__no-filter-selected {
+    color: $text-light-color;
+    @include font-size(16px, 16px);
+  }
 }

--- a/packages/ndla-ui/src/Masthead/Masthead.jsx
+++ b/packages/ndla-ui/src/Masthead/Masthead.jsx
@@ -50,11 +50,7 @@ MastheadInfo.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-export const Masthead = ({
-  children,
-  fixed,
-  infoContent,
-}) => (
+export const Masthead = ({ children, fixed, infoContent }) => (
   <Fragment>
     <div {...classes('placeholder', { infoContent })} />
     <div {...classes('', { fixed, infoContent })}>

--- a/packages/ndla-ui/src/Masthead/Masthead.jsx
+++ b/packages/ndla-ui/src/Masthead/Masthead.jsx
@@ -53,12 +53,11 @@ MastheadInfo.propTypes = {
 export const Masthead = ({
   children,
   fixed,
-  hideOnNarrowScreen,
   infoContent,
 }) => (
   <Fragment>
     <div {...classes('placeholder', { infoContent })} />
-    <div {...classes('', { fixed, hideOnNarrowScreen, infoContent })}>
+    <div {...classes('', { fixed, infoContent })}>
       {infoContent && (
         <DisplayOnPageYOffset yOffsetMin={0} yOffsetMax={90}>
           <MastheadInfo>{infoContent}</MastheadInfo>
@@ -73,7 +72,6 @@ export const Masthead = ({
 Masthead.propTypes = {
   children: PropTypes.node,
   fixed: PropTypes.bool,
-  hideOnNarrowScreen: PropTypes.bool,
   infoContent: PropTypes.node,
 };
 

--- a/packages/ndla-ui/src/Masthead/component.masthead.scss
+++ b/packages/ndla-ui/src/Masthead/component.masthead.scss
@@ -15,14 +15,6 @@
     position: fixed;
   }
 
-  &--hideOnNarrowScreen {
-    display: none;
-
-    @include mq(desktop) {
-      display: block;
-    }
-  }
-
   &__placeholder {
     min-height: $masthead-height;
     width: 100%;

--- a/packages/ndla-ui/src/Search/SearchFilter.jsx
+++ b/packages/ndla-ui/src/Search/SearchFilter.jsx
@@ -22,6 +22,7 @@ const SearchFilter = ({
   narrowScreenOnly,
   contextFilter,
   onChange,
+  noFilterSelectedLabel,
   children,
 }) => {
   const modifiers = [];
@@ -46,6 +47,7 @@ const SearchFilter = ({
         showLabel={showLabel}
         hideLabel={hideLabel}
         onChange={onChange}
+        noFilterSelectedLabel={noFilterSelectedLabel}
       />
       {children}
     </div>
@@ -67,6 +69,7 @@ SearchFilter.propTypes = {
   showLabel: PropTypes.string,
   hideLabel: PropTypes.string,
   narrowScreenOnly: PropTypes.bool,
+  noFilterSelectedLabel: PropTypes.string,
   contextFilter: PropTypes.bool,
   children: PropTypes.node,
 };

--- a/packages/ndla-ui/src/Search/SearchPage.jsx
+++ b/packages/ndla-ui/src/Search/SearchPage.jsx
@@ -2,12 +2,10 @@ import React, { Component } from 'react';
 import BEMHelper from 'react-bem-helper';
 import PropTypes from 'prop-types';
 import { Back } from 'ndla-icons/common';
-import { Cross } from 'ndla-icons/action';
 import createFocusTrap from 'focus-trap';
 import { noScroll } from 'ndla-util';
 import Button from '../Button';
 
-import SafeLink from '../common/SafeLink';
 import SearchField from './SearchField';
 import ActiveFilters from './ActiveFilters';
 
@@ -75,7 +73,6 @@ export default class SearchPage extends Component {
       filters,
       children,
       messages,
-      closeUrl,
       author,
       hideResultText,
     } = this.props;
@@ -88,9 +85,6 @@ export default class SearchPage extends Component {
 
     return (
       <main {...classes()}>
-        <SafeLink to={closeUrl} {...classes('close-button')}>
-          <span>{messages.closeButton}</span> <Cross />
-        </SafeLink>
         <div {...classes('search-field-wrapper')}>
           <SearchField
             value={searchString}
@@ -184,10 +178,8 @@ SearchPage.propTypes = {
     filterHeading: PropTypes.string.isRequired,
     narrowScreenFilterHeading: PropTypes.string.isRequired,
     resultHeading: PropTypes.string,
-    closeButton: PropTypes.string.isRequired,
     searchFieldTitle: PropTypes.string.isRequired,
   }).isRequired,
-  closeUrl: PropTypes.string.isRequired,
   author: PropTypes.node,
   hideResultText: PropTypes.bool,
 };

--- a/packages/ndla-ui/src/Search/SearchPopoverFilter.jsx
+++ b/packages/ndla-ui/src/Search/SearchPopoverFilter.jsx
@@ -35,7 +35,6 @@ class Popover extends Component {
 
   render() {
     const { messages, close, options, onChange } = this.props;
-    // const disabled = this.state.values.length === 0;
 
     return (
       <Fragment>

--- a/packages/ndla-ui/src/Search/SearchPopoverFilter.jsx
+++ b/packages/ndla-ui/src/Search/SearchPopoverFilter.jsx
@@ -35,7 +35,7 @@ class Popover extends Component {
 
   render() {
     const { messages, close, options, onChange } = this.props;
-    const disabled = this.state.values.length === 0;
+    // const disabled = this.state.values.length === 0;
 
     return (
       <Fragment>
@@ -69,7 +69,6 @@ class Popover extends Component {
             }}
           />
           <Button
-            disabled={disabled}
             className={classes('confirm-button')}
             onClick={() => {
               close();
@@ -105,7 +104,7 @@ export class PopoverFilter extends Component {
   }
 
   render() {
-    const { messages, values, ...rest } = this.props;
+    const { messages, values, onChange, ...rest } = this.props;
     const buttonText =
       values.length > 0
         ? messages.hasValuesButtonText
@@ -113,7 +112,7 @@ export class PopoverFilter extends Component {
 
     const buttonContent = (
       <Fragment>
-        <span className={classes('button-text')}>{buttonText}</span>
+        <span>{buttonText}</span>
         <ChevronRight />
       </Fragment>
     );
@@ -129,10 +128,11 @@ export class PopoverFilter extends Component {
         title={buttonContent}
         className={classes()}
         noScrollDisabled
-        buttonClassName={classes('button')}>
+        buttonClassName={`${classes('button')} c-button--stripped`}>
         {onClose => (
           <Popover
             close={onClose}
+            onChange={onChange}
             messages={messages}
             {...rest}
             values={values}
@@ -146,6 +146,7 @@ export class PopoverFilter extends Component {
 PopoverFilter.propTypes = {
   values: PropTypes.arrayOf(PropTypes.string).isRequired,
   messages: messagesShape.isRequired,
+  onChange: PropTypes.func.isRequired,
 };
 
 export default PopoverFilter;

--- a/packages/ndla-ui/src/Search/component.search-page.scss
+++ b/packages/ndla-ui/src/Search/component.search-page.scss
@@ -42,11 +42,10 @@ $search-field-wrapper-margin: $filter-width + $spacing--small;
   }
 
   &__search-field-wrapper {
-    padding: $spacing--large 0 $spacing 0;
+    padding: $spacing 0 $spacing 0;
 
     @include mq(desktop) {
       padding: $spacing--large 0;
-
       margin-left: $search-field-wrapper-margin;
     }
   }

--- a/packages/ndla-ui/src/Search/component.search-popover-filter.scss
+++ b/packages/ndla-ui/src/Search/component.search-popover-filter.scss
@@ -102,24 +102,21 @@
   &__button {
     background: none;
     color: $brand-color;
-    width: 100%;
     border: 0;
     display: flex;
+    margin-top: -26px;
     justify-content: space-between;
     align-items: center;
     padding: $spacing--small $spacing;
     cursor: pointer;
     border-radius: 0;
 
+    @include font-size(16px, 32px);
+
     @include mq(desktop) {
       box-shadow: $link;
       padding: 0;
       margin: 0 $spacing;
-      width: auto;
-
-      .c-icon {
-        display: none;
-      }
     }
 
     &:hover,

--- a/packages/ndla-ui/src/Search/component.search-result-author.scss
+++ b/packages/ndla-ui/src/Search/component.search-result-author.scss
@@ -4,6 +4,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
+  margin-bottom: $spacing;
   &--desktop {
     @include mq($until: desktop) {
       display: none;

--- a/packages/ndla-ui/src/Search/component.search-result.scss
+++ b/packages/ndla-ui/src/Search/component.search-result.scss
@@ -1,6 +1,7 @@
 .c-search-result {
   background: $white;
-  padding: $spacing 0;
+  padding: 0 0 $spacing 0;
+  margin-bottom: $spacing--large;
   border: 1px solid $brand-grey--light;
 
   @include mq(desktop) {
@@ -73,8 +74,11 @@
   }
 
   &__current-goal-info {
-    margin: $spacing--small 0 $spacing--large ($spacing--small + 2px);
+    margin: $spacing--small 0 $spacing--large $spacing--large + 2;
     @include font-size(16px, 20px);
+    @include mq(desktop) {
+      margin-left: $spacing--small + 4px;
+    }
   }
 
   &__competence-goals {
@@ -115,20 +119,17 @@
 
 .c-search-result-item {
   border-bottom: 1px solid $brand-grey--light;
-  padding: $spacing--medium $spacing 0 $spacing;
+  padding: 0 $spacing 0 $spacing;
 
   @include mq(desktop) {
-    padding: $spacing--medium 0 0 0;
+    padding: 0;
   }
 
-  margin: 0;
-
-  &:first-child {
-    padding-top: 0;
-  }
+  margin: 0 0 $spacing;
 
   &:last-child {
     border-bottom: 0;
+    margin-bottom: 0;
   }
 
   &__content {

--- a/packages/ndla-ui/src/global/components/component.tabs.scss
+++ b/packages/ndla-ui/src/global/components/component.tabs.scss
@@ -32,7 +32,7 @@ $tabs-spacing: 12px;
     }
 
     &--button-based {
-      padding: 0 $spacing--medium / 2;
+      padding: 0 $spacing--small;
       &:first-child {
         padding-left: 0;
       }
@@ -43,7 +43,7 @@ $tabs-spacing: 12px;
         font-weight: $font-weight-bold;
         border: 0;
         background: 0;
-        padding: $spacing--small ($spacing--small / 4);
+        padding: $spacing--small 0;
         font-size: inherit;
         font-family: inherit;
         color: inherit;
@@ -127,7 +127,7 @@ $tabs-spacing: 12px;
 
   &__list {
     max-width: 100%;
-    font-size: 18px;
+    @include font-size(18px);
     font-weight: $font-weight-bold;
     list-style: none;
     margin: $spacing/1.4 0 $spacing--small;


### PR DESCRIPTION
Fixes includes:
• Added Menu Button to header on Search page (btw, it should ALWAYS be there unless on frontpage)
• Keep Filter for Tabs on Searchpage on desktop, even if not results matched.
• On searchpage: Only show checked filter subjects under Subjects. 
• Allow to remove all subject filters in <SearchPopoverFilter />
• Some css changes

Label text corrections will come..