### PR TITLE
Table in bodybox fix

### DIFF
--- a/packages/ndla-article-scripts/src/tableScripts.js
+++ b/packages/ndla-article-scripts/src/tableScripts.js
@@ -101,7 +101,7 @@ export const initTableScript = () => {
       // detect if parent has c-bodybox class and add container adjustment class
       // a hacky fix for table cropped when inside a c-bodybox.
       if (el.parentNode.classList.contains('c-bodybox')) {
-        el.parentNode.classList.add('c-bodybox--contains-table')
+        el.parentNode.classList.add('c-bodybox--contains-table');
       }
     });
 

--- a/packages/ndla-article-scripts/src/tableScripts.js
+++ b/packages/ndla-article-scripts/src/tableScripts.js
@@ -97,6 +97,12 @@ export const initTableScript = () => {
         el.classList.add('c-table__wrapper--has-scroll');
         table.addEventListener('scroll', throttledEventListner);
       }
+
+      // detect if parent has c-bodybox class and add container adjustment class
+      // a hacky fix for table cropped when inside a c-bodybox.
+      if (el.parentNode.classList.contains('c-bodybox')) {
+        el.parentNode.classList.add('c-bodybox--contains-table')
+      }
     });
 
     forEachElement('.c-table__expand-button', el =>

--- a/packages/ndla-ui/src/global/components/component.bodybox.scss
+++ b/packages/ndla-ui/src/global/components/component.bodybox.scss
@@ -29,6 +29,14 @@
   &--translation {
     padding: 0 $spacing--large $spacing--small $spacing;
   }
+
+  &--contains-table {
+    @include mq($from: desktop) {
+      @include grids-expand(4,6,2);
+      padding-left: 16.667%;
+      padding-right: 16.667%;
+    }
+  }
 }
 
 /* Hacks for complex content fetched inside bodybox */


### PR DESCRIPTION
Laget for å justere for tabeller som er inni en c-bodybox. Alle tabeller har default 133% bredde ved desktop + skjermstørrelser, noe som er problematisk når de er i en container med border eller overflow: hidden.

https://trello.com/c/pc0Wkh2J/691-tabeller-i-rammer