### PR TITLE
Fix for articles title first-line width when compentencegoals

### DIFF
--- a/packages/ndla-ui/src/Article/Article.jsx
+++ b/packages/ndla-ui/src/Article/Article.jsx
@@ -53,10 +53,14 @@ ArticleHeaderWrapper.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-export const ArticleTitle = ({ children, icon, label }) => {
+export const ArticleTitle = ({ children, icon, label, hasCompetenceGoals }) => {
   const modifiers = [];
   if (icon) {
     modifiers.push('icon');
+  }
+
+  if (hasCompetenceGoals) {
+    modifiers.push('with-competence-goals');
   }
 
   let labelView = null;
@@ -75,6 +79,7 @@ export const ArticleTitle = ({ children, icon, label }) => {
 };
 
 ArticleTitle.propTypes = {
+  hasCompetenceGoals: PropTypes.bool,
   children: PropTypes.node.isRequired,
   label: PropTypes.string,
   icon: PropTypes.node,
@@ -134,7 +139,10 @@ export const Article = ({
       <LayoutItem layout="center">
         <ArticleHeaderWrapper>
           {competenceGoals}
-          <ArticleTitle icon={icon} label={messages.label}>
+          <ArticleTitle
+            icon={icon}
+            label={messages.label}
+            hasCompetenceGoals={competenceGoals !== null}>
             {title}
           </ArticleTitle>
           <ArticleIntroduction>{introduction}</ArticleIntroduction>

--- a/packages/ndla-ui/src/Article/component.article.scss
+++ b/packages/ndla-ui/src/Article/component.article.scss
@@ -89,7 +89,7 @@
   p {
     margin-top: 0;
   }
-  
+
   a:not([class]):visited {
     color: $link-visited;
   }
@@ -121,6 +121,18 @@
     margin: 0;
     @include mq($until: tablet) {
       line-height: 2rem;
+    }
+  }
+
+  &--with-competence-goals {
+    // Adjust first line width if article has competence goals
+    @include mq(desktop) {
+      h1:before {
+        content: '';
+        float: right;
+        width: 140px;
+        height: 1em;
+      }
     }
   }
 


### PR DESCRIPTION
Minor fix, adding pseudo element making first-line of articles short to adjust competence button on desktop+ screens