### PR TITLE
B-feil. Hotfix table in expandable box

### DIFF
--- a/packages/ndla-article-scripts/src/tableScripts.js
+++ b/packages/ndla-article-scripts/src/tableScripts.js
@@ -103,6 +103,9 @@ export const initTableScript = () => {
       if (el.parentNode.classList.contains('c-bodybox')) {
         el.parentNode.classList.add('c-bodybox--contains-table');
       }
+      if (el.parentNode.classList.contains('wrapper')) {
+        el.classList.remove('c-table__wrapper');
+      }
     });
 
     forEachElement('.c-table__expand-button', el =>


### PR DESCRIPTION
• Denne og tabell i ramme fiksen burde vært løst serverside på sikt. Ref:

// detect if parent has c-bodybox class and add container adjustment class
      // a hacky fix for table cropped when inside a c-bodybox.
      if (el.parentNode.classList.contains('c-bodybox')) {
        el.parentNode.classList.add('c-bodybox--contains-table');
      }
      if (el.parentNode.classList.contains('wrapper')) {
        el.classList.remove('c-table__wrapper');
      }