### PR TITLE
Adds correct button selector for related articles since classnames ar…

### DIFF
--- a/packages/ndla-article-scripts/src/relatedArticlesToggle.js
+++ b/packages/ndla-article-scripts/src/relatedArticlesToggle.js
@@ -12,7 +12,9 @@ export const toggleRelatedArticles = () => {
   const shownItem = classes('item--shown').className;
 
   forEachElement('.c-related-articles', el => {
-    const button = el.querySelector(`.${classes('button').className}`);
+    const button = el.querySelector(
+      `button[data-type='related-article-button']`,
+    );
 
     if (button && typeof button.onclick !== 'function') {
       button.onclick = e => {

--- a/packages/ndla-ui/src/RelatedArticleList/RelatedArticleList.jsx
+++ b/packages/ndla-ui/src/RelatedArticleList/RelatedArticleList.jsx
@@ -85,6 +85,7 @@ const RelatedArticleList = ({
       </div>
       {childrenCount > 2 && (
         <Button
+          data-type="related-article-button"
           data-showmore={messages.showMore}
           data-showless={messages.showLess}
           outline>


### PR DESCRIPTION
Since buttons now use emotion, the classnames are no longer used and article scripts will not work since it depended on class names. Added a data-type instead, but if someone has better solution, tell me! 
