### PR TITLE
Bugfix: Slateblockpicker

### DIFF
--- a/packages/ndla-editor/src/SlateBlockMenu.js
+++ b/packages/ndla-editor/src/SlateBlockMenu.js
@@ -114,6 +114,7 @@ const buttonCSS = css`
     .c-icon {
       transform: rotate(135deg);
     }
+    pointer-events: none;
   }
   &:hover,
   &:focus {
@@ -127,13 +128,12 @@ const buttonCSS = css`
 const FocusWrapper = ({ isOpen, onToggleOpen, children }) => (
   <FocusTrapReact
     focusTrapOptions={{
-      onDeactivate: () => {
+      onDeactivate: e => {
         onToggleOpen(false);
       },
       clickOutsideDeactivates: true,
       escapeDeactivates: true,
-    }}
-    active={isOpen}>
+    }}>
     {children}
   </FocusTrapReact>
 );
@@ -146,7 +146,7 @@ FocusWrapper.propTypes = {
 
 const SlateBlockMenu = React.forwardRef(
   ({ heading, actions, clickItem, onToggleOpen, isOpen, cy }, ref) => (
-    <FocusWrapper isOpen={isOpen} onToggleOpen={onToggleOpen}>
+    <>
       <button
         ref={ref}
         className={cx(buttonCSS, { '--open': isOpen })}
@@ -158,26 +158,28 @@ const SlateBlockMenu = React.forwardRef(
         <Plus />
       </button>
       {isOpen && (
-        <Wrapper>
-          <div>
-            <HeaderLabel>{heading}</HeaderLabel>
-            {actions.map(action => (
-              <Item key={action.data.object}>
-                <button
-                  className={itemButton}
-                  data-cy={`create-${action.data.object}`}
-                  type="button"
-                  onClick={() => clickItem(action.data)}>
-                  {action.icon && action.icon}
-                  <span>{action.label}</span>
-                </button>
-                {action.helpIcon}
-              </Item>
-            ))}
-          </div>
-        </Wrapper>
+        <FocusWrapper isOpen={isOpen} onToggleOpen={onToggleOpen}>
+          <Wrapper>
+            <div>
+              <HeaderLabel>{heading}</HeaderLabel>
+              {actions.map(action => (
+                <Item key={action.data.object}>
+                  <button
+                    className={itemButton}
+                    data-cy={`create-${action.data.object}`}
+                    type="button"
+                    onClick={() => clickItem(action.data)}>
+                    {action.icon && action.icon}
+                    <span>{action.label}</span>
+                  </button>
+                  {action.helpIcon}
+                </Item>
+              ))}
+            </div>
+          </Wrapper>
+        </FocusWrapper>
       )}
-    </FocusWrapper>
+    </>
   ),
 );
 

--- a/packages/ndla-editor/src/SlateBlockMenu.js
+++ b/packages/ndla-editor/src/SlateBlockMenu.js
@@ -125,7 +125,7 @@ const buttonCSS = css`
   }
 `;
 
-const FocusWrapper = ({ isOpen, onToggleOpen, children }) => (
+const FocusWrapper = ({ onToggleOpen, children }) => (
   <FocusTrapReact
     focusTrapOptions={{
       onDeactivate: e => {
@@ -156,7 +156,7 @@ const SlateBlockMenu = React.forwardRef(
         <Plus />
       </button>
       {isOpen && (
-        <FocusWrapper isOpen={isOpen} onToggleOpen={onToggleOpen}>
+        <FocusWrapper onToggleOpen={onToggleOpen}>
           <Wrapper>
             <div>
               <HeaderLabel>{heading}</HeaderLabel>

--- a/packages/ndla-editor/src/SlateBlockMenu.js
+++ b/packages/ndla-editor/src/SlateBlockMenu.js
@@ -152,9 +152,7 @@ const SlateBlockMenu = React.forwardRef(
         className={cx(buttonCSS, { '--open': isOpen })}
         type="button"
         data-cy={cy}
-        onClick={() => {
-          onToggleOpen(!isOpen);
-        }}>
+        onClick={() => onToggleOpen(!isOpen)}>
         <Plus />
       </button>
       {isOpen && (


### PR DESCRIPTION
SlateblockPicker krasjer når den åpnes. Usikker på hva som har skjedd / hvilken endring som trigget dette. 
2 feil fikset:
• "React.Children.only expected to receive a single React element child" (Fiks med </>)
• "FocusTrapReact Cannot read property 'ownerDocument' of null" (Trigget via Tabbable.js som FocusTrap bruker). Fikset ved å kun rendre Focustrap kun når den er aktiv.



