### PR TITLE
Fix: Figures with class u-float-full

### DIFF
--- a/packages/ndla-ui/src/Figure/component.figure.scss
+++ b/packages/ndla-ui/src/Figure/component.figure.scss
@@ -44,7 +44,7 @@
     margin-right: $spacing--small;
   }
 
-  &--full-column {
+  &--full-column, &.u-float-full {
     left: auto !important;
     right: auto !important;
     width: auto !important;


### PR DESCRIPTION
Fix: Prevent floating figures from floating (spolte fag).
Trello: https://trello.com/c/vwyOHVdf/810-ramme-over-bilde