### PR TITLE
Fix for serif fallback fonts

### DIFF
--- a/packages/ndla-core/scss/global/settings/settings.global.scss
+++ b/packages/ndla-core/scss/global/settings/settings.global.scss
@@ -1,6 +1,8 @@
+@import url('https://fonts.googleapis.com/css?Source+Sans+Pro:400,600|Source+Serif+Pro:400,600&subset=latin-ext');
+
 $font: 'Source Sans Pro', Helvetica, Arial, STKaiti, 华文楷体, KaiTi, SimKai, 楷体,
   KaiU, DFKai-SB, 標楷體, SongTi, 宋体, sans-serif;
-$font-serif: 'Source Serif Pro', Georgia, STKaiti, 华文楷体, KaiTi, SimKai, 楷体, KaiU,
+$font-serif: 'Source Serif Pro', Times, STKaiti, 华文楷体, KaiTi, SimKai, 楷体, KaiU,
   DFKai-SB, 標楷體, SongTi, 宋体, serif;
 $font-weight-light: 300;
 $font-weight-normal: 400;
@@ -14,7 +16,7 @@ $font-weight-bold: 700;
 :root {
   --font: 'Source Sans Pro', Helvetica, Arial, STKaiti, 华文楷体, KaiTi, SimKai, 楷体,
     KaiU, DFKai-SB, 標楷體, SongTi, 宋体, sans-serif;
-  --font-serif: 'Source Serif Pro', Georgia, STKaiti, 华文楷体, KaiTi, SimKai, 楷体,
+  --font-serif: 'Source Serif Pro', Times, STKaiti, 华文楷体, KaiTi, SimKai, 楷体,
     KaiU, DFKai-SB, 標楷體, SongTi, 宋体, serif;
   --font-weight-light: 300;
   --font-weight-normal: 400;

--- a/packages/ndla-core/src/fonts.js
+++ b/packages/ndla-core/src/fonts.js
@@ -23,7 +23,7 @@ export default {
   sans:
     "'Source Sans Pro',Helvetica,Arial,STKaiti,'华文楷体',KaiTi,SimKai,'楷体',KaiU,DFKai-SB,'標楷體',SongTi,'宋体',sans-serif",
   serif:
-    "'Source Serif Pro',Georgia,STKaiti,'华文楷体',KaiTi,SimKai,'楷体',KaiU,DFKai-SB,'標楷體',SongTi,'宋体',serif",
+    "'Source Serif Pro',Times,STKaiti,'华文楷体',KaiTi,SimKai,'楷体',KaiU,DFKai-SB,'標楷體',SongTi,'宋体',serif",
   weight: {
     light: 300,
     normal: 400,


### PR DESCRIPTION
Bugfix for rending av noen font-tegn i serif som feks ǐ på PC + Chrome. 
Løst ved å bytte 2. valg av serif font til Times. (Chrome rendrer disse feil i Georgia på PC)

Trello: https://trello.com/c/MnvOPzHf/814-feil-visning-av-pinyin-for-kinesisk-i-google-chrome-p%C3%A5-pc