### PR TITLE
Prepared texts for how-to statuses

### DIFF
--- a/packages/designmanual/stories/produksjonssystem/HowtoExamples.jsx
+++ b/packages/designmanual/stories/produksjonssystem/HowtoExamples.jsx
@@ -78,6 +78,12 @@ const HowToExamples = () => (
     <FieldHeader title="Metabilde">
       {renderArticleInModal({ pageId: 'MetaImage', tooltip: 'Hva er dette?' })}
     </FieldHeader>
+    <br />
+    <br />
+    <h1>Status:</h1>
+    <FieldHeader title="Statusforklaringer">
+      {renderArticleInModal({ pageId: 'status', tooltip: 'Hva er dette?' })}
+    </FieldHeader>
   </div>
 );
 

--- a/packages/ndla-howto/src/StaticInfoComponents/index.js
+++ b/packages/ndla-howto/src/StaticInfoComponents/index.js
@@ -210,4 +210,8 @@ export const stories = {
     lead:
       'Alle ressurser må ha ett eller fagfilter. Fagfilterene du kan velge mellom blir gitt utfra emnetilknytningen og derav faget det tilhører. Itillegg til å velge fagfilter kan velge om ressursen skal være tilleggsstoff og kjernestoff under hvert av fagfilterene.',
   },
+  status: {
+    title: 'Forklaring for ulike statuser',
+    lead: 'Denne teksten kommer snart..',
+  },
 };


### PR DESCRIPTION
Tekst kommer senere, kan merges as is. Skal brukes i ed som info til status hjelpeikon. (branch: new-article-header)