### PR TITLE
Language selector in header

### DIFF
--- a/packages/core/scss/global/utilities/mixin_icons.scss
+++ b/packages/core/scss/global/utilities/mixin_icons.scss
@@ -13,4 +13,8 @@
   @if $id == search {
     background-image: url('data:image/svg+xml,%3Csvg fill="#{$color-rgb}" height="48" viewBox="0 0 48 48" width="48" xmlns="http://www.w3.org/2000/svg" data-license="Apache License 2.0" data-source="Material Design"%3E%3Cpath d="M31 28h-1.59l-.55-.55C30.82 25.18 32 22.23 32 19c0-7.18-5.82-13-13-13S6 11.82 6 19s5.82 13 13 13c3.23 0 6.18-1.18 8.45-3.13l.55.55V31l10 9.98L40.98 38 31 28zm-12 0c-4.97 0-9-4.03-9-9s4.03-9 9-9 9 4.03 9 9-4.03 9-9 9z" /%3E%3C/svg%3E');
   }
+
+  @if $id == done {
+    background-image: url('data:image/svg+xml,%3Csvg fill="#{$color-rgb}" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg" data-license="Apache License 2.0" data-source="Material Design"%3E%3Cpath d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" /%3E%3C/svg%3E');
+  }
 }

--- a/packages/designmanual/stories/molecules/mastheads.jsx
+++ b/packages/designmanual/stories/molecules/mastheads.jsx
@@ -286,15 +286,17 @@ class MastheadWithTopicMenu extends Component {
           </DisplayOnPageYOffset>
         </MastheadItem>
         <MastheadItem right>
-          <MastheadLanguageSelector
-            autoOpen={this.props.languageSelectorOpen}
-            urls={{
-              nb: '#',
-              nn: '#',
-              en: '#',
-            }}
-            currentLanguage="nb"
-          />
+          <DisplayOnPageYOffset yOffsetMin={0} yOffsetMax={150}>
+            <MastheadLanguageSelector
+              autoOpen={this.props.languageSelectorOpen}
+              urls={{
+                nb: '#',
+                nn: '#',
+                en: '#',
+              }}
+              currentLanguage="nb"
+            />
+          </DisplayOnPageYOffset>
           {this.renderSearchButtonView(true)}
           <Logo
             to="?selectedKind=Emnesider&selectedStory=1.%20Fagoversikt&full=0&addons=0&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel"

--- a/packages/designmanual/stories/molecules/mastheads.jsx
+++ b/packages/designmanual/stories/molecules/mastheads.jsx
@@ -288,11 +288,19 @@ class MastheadWithTopicMenu extends Component {
         <MastheadItem right>
           <DisplayOnPageYOffset yOffsetMin={0} yOffsetMax={150}>
             <MastheadLanguageSelector
-              autoOpen={this.props.languageSelectorOpen}
-              urls={{
-                nb: '#',
-                nn: '#',
-                en: '#',
+              options={{
+                nb: {
+                  name: 'Bokmål',
+                  url: '#',
+                },
+                nn: {
+                  name: 'Nynorsk',
+                  url: '#',
+                },
+                en: {
+                  name: 'English',
+                  url: '#',
+                },
               }}
               currentLanguage="nb"
             />

--- a/packages/designmanual/stories/molecules/mastheads.jsx
+++ b/packages/designmanual/stories/molecules/mastheads.jsx
@@ -14,6 +14,7 @@ import { injectT } from '@ndla/i18n';
 import {
   Masthead,
   MastheadItem,
+  MastheadLanguageSelector,
   Logo,
   TopicMenu,
   DisplayOnPageYOffset,
@@ -285,6 +286,15 @@ class MastheadWithTopicMenu extends Component {
           </DisplayOnPageYOffset>
         </MastheadItem>
         <MastheadItem right>
+          <MastheadLanguageSelector
+            autoOpen={this.props.languageSelectorOpen}
+            urls={{
+              nb: '#',
+              nn: '#',
+              en: '#',
+            }}
+            currentLanguage="nb"
+          />
           {this.renderSearchButtonView(true)}
           <Logo
             to="?selectedKind=Emnesider&selectedStory=1.%20Fagoversikt&full=0&addons=0&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel"

--- a/packages/designmanual/stories/pages/index.jsx
+++ b/packages/designmanual/stories/pages/index.jsx
@@ -269,6 +269,24 @@ storiesOf('Læringsressurser', module)
       </Content>
       <FooterExample />
     </PageContainer>
+  ))
+  .add('Endret språk (popup åpen)', () => (
+    <PageContainer backgroundWide>
+      <Content>
+        <MastheadWithTopicMenu languageSelectorOpen />
+        <SubjectMaterialHero>
+          <OneColumn>
+            <div className="c-hero__content">
+              <section>
+                <Breadcrumb />
+              </section>
+            </div>
+          </OneColumn>
+        </SubjectMaterialHero>
+        <ArticleLearningmaterial />
+      </Content>
+      <FooterExample />
+    </PageContainer>
   ));
 
 storiesOf('Emnesider', module)

--- a/packages/ndla-ui/src/Masthead/Masthead.jsx
+++ b/packages/ndla-ui/src/Masthead/Masthead.jsx
@@ -66,7 +66,6 @@ export const Masthead = ({
           <MastheadInfo>{infoContent}</MastheadInfo>
         </DisplayOnPageYOffset>
       )}
-
       <div className={`u-1/1 ${classes('content').className}`}>{children}</div>
     </div>
   </Fragment>

--- a/packages/ndla-ui/src/Masthead/MastheadLanguageSelector.jsx
+++ b/packages/ndla-ui/src/Masthead/MastheadLanguageSelector.jsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import BEMHelper from 'react-bem-helper';
 import FocusTrapReact from 'focus-trap-react';
@@ -18,92 +18,62 @@ const classes = new BEMHelper({
   prefix: 'c-',
 });
 
-class MastheadLanguageSelector extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isOpen: props.autoOpen,
-      infoLocale: props.currentLanguage,
-    };
-    this.handleOpen = this.handleOpen.bind(this);
-  }
-
-  handleOpen() {
-    this.setState({
-      isOpen: true,
-    });
-  }
-
-  toggleLanguage(lang) {
-    const infoLocale = lang || this.props.currentLanguage;
-    this.setState({
-      infoLocale,
-    });
-  }
-
-  render() {
-    const { options, currentLanguage, t } = this.props;
-    const { isOpen, infoLocale } = this.state;
-    return (
-      <div {...classes('change-language-wrapper')}>
-        <Button link onClick={this.handleOpen}>
-          Change language
-        </Button>
-        {isOpen && (
-          <FocusTrapReact
-            active
-            focusTrapOptions={{
-              onDeactivate: () => {
-                this.setState({
-                  isOpen: false,
-                });
-              },
-              clickOutsideDeactivates: true,
-              escapeDeactivates: true,
-            }}>
-            <div {...classes('change-language-modal', isOpen && 'animate-in')}>
-              <Button
-                link
-                onClick={() => {
-                  this.setState({
-                    isOpen: false,
-                  });
-                }}>
-                {t('masthead.menu.close')}
-              </Button>
-              <nav>
-                <ul>
-                  {Object.keys(options).map(key => (
-                    <li key={key}>
-                      {key === currentLanguage ? (
-                        <span {...classes('selected')}>
-                          {options[key].name}
-                        </span>
-                      ) : (
-                        <a
-                          href={options[key].url}
-                          onMouseOver={() => {
-                            this.toggleLanguage(key);
-                          }}
-                          onMouseOut={() => {
-                            this.toggleLanguage();
-                          }}
-                          aria-label={t(`changeLanguage.${key}`)}>
-                          {options[key].name}
-                        </a>
-                      )}
-                    </li>
-                  ))}
-                </ul>
-                <p>{t(`currentLanguageText.${infoLocale}`)}</p>
-              </nav>
-            </div>
-          </FocusTrapReact>
-        )}
-      </div>
-    );
-  }
-}
+const MastheadLanguageSelector = ({ options, currentLanguage, t }) => {
+  const [infoLocale, setInfoLocale] = useState(currentLanguage);
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <div {...classes('change-language-wrapper')}>
+      <Button link onClick={() => setIsOpen(true)}>
+        Change language
+      </Button>
+      {isOpen && (
+        <FocusTrapReact
+          active
+          focusTrapOptions={{
+            onDeactivate: () => {
+              setIsOpen(false);
+            },
+            clickOutsideDeactivates: true,
+            escapeDeactivates: true,
+          }}>
+          <div {...classes('change-language-modal', isOpen && 'animate-in')}>
+            <Button
+              link
+              onClick={() => {
+                setIsOpen(false);
+              }}>
+              {t('masthead.menu.close')}
+            </Button>
+            <nav>
+              <ul>
+                {Object.keys(options).map(key => (
+                  <li key={key}>
+                    {key === currentLanguage ? (
+                      <span {...classes('selected')}>{options[key].name}</span>
+                    ) : (
+                      <a
+                        href={options[key].url}
+                        onMouseOver={() => {
+                          setInfoLocale(key);
+                        }}
+                        onMouseOut={() => {
+                          setInfoLocale(currentLanguage);
+                        }}
+                        aria-label={t(`changeLanguage.${key}`)}>
+                        {options[key].name}
+                      </a>
+                    )}
+                  </li>
+                ))}
+              </ul>
+              <p>{t(`currentLanguageText.${infoLocale}`)}</p>
+            </nav>
+          </div>
+        </FocusTrapReact>
+      )}
+    </div>
+  );
+};
 
 MastheadLanguageSelector.propTypes = {
   options: PropTypes.objectOf(

--- a/packages/ndla-ui/src/Masthead/MastheadLanguageSelector.jsx
+++ b/packages/ndla-ui/src/Masthead/MastheadLanguageSelector.jsx
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2019-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import BEMHelper from 'react-bem-helper';
+import FocusTrapReact from 'focus-trap-react';
+import { injectT } from '@ndla/i18n';
+import Button from '@ndla/Button';
+
+const classes = new BEMHelper({
+  name: 'masthead',
+  prefix: 'c-',
+});
+
+class MastheadLanguageSelector extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpen: props.autoOpen,
+      manualOpen: false,
+    };
+    this.handleOpen = this.handleOpen.bind(this);
+  }
+
+  handleOpen() {
+    this.setState({
+      isOpen: true,
+      manualOpen: true,
+    });
+  }
+
+  render() {
+    const { urls, currentLanguage, t } = this.props;
+    const { isOpen, manualOpen } = this.state;
+    return (
+      <div {...classes('change-language-wrapper')}>
+        <Button link onClick={this.handleOpen}>
+          Change language
+        </Button>
+        {isOpen && (
+          <FocusTrapReact
+            active
+            focusTrapOptions={{
+              onDeactivate: () => {
+                this.setState({
+                  manualOpen: false,
+                  isOpen: false,
+                });
+              },
+              clickOutsideDeactivates: true,
+              escapeDeactivates: true,
+            }}>
+            <div
+              {...classes('change-language-modal', manualOpen && 'animate-in')}>
+              <Button
+                link
+                onClick={() => {
+                  this.setState({
+                    isOpen: false,
+                    manualOpen: false,
+                  });
+                }}>
+                {t('masthead.menu.close')}
+              </Button>
+              <nav>
+                <ul>
+                  {Object.keys(urls).map(key => (
+                    <li key={key}>
+                      {key === currentLanguage ? (
+                        <span {...classes('selected')}>
+                          {t(`languages.${key}`)}
+                        </span>
+                      ) : (
+                        <a
+                          href={`${urls[key].url}?langselector=true`}
+                          aria-label={t('changeLanguage', {
+                            language: t(`languages.${key}`),
+                          })}
+                          {...classes('selected')}>
+                          {t(`languages.${key}`)}
+                        </a>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+                <p>{t(`currentLanguageText.${currentLanguage}`)}</p>
+              </nav>
+            </div>
+          </FocusTrapReact>
+        )}
+      </div>
+    );
+  }
+}
+
+MastheadLanguageSelector.propTypes = {
+  urls: PropTypes.objectOf(PropTypes.string).isRequired,
+  currentLanguage: PropTypes.string.isRequired,
+  autoOpen: PropTypes.bool,
+};
+
+export default injectT(MastheadLanguageSelector);

--- a/packages/ndla-ui/src/Masthead/MastheadLanguageSelector.jsx
+++ b/packages/ndla-ui/src/Masthead/MastheadLanguageSelector.jsx
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import BEMHelper from 'react-bem-helper';
 import FocusTrapReact from 'focus-trap-react';
 import { injectT } from '@ndla/i18n';
-import Button from '@ndla/Button';
+import Button from '@ndla/button';
 
 const classes = new BEMHelper({
   name: 'masthead',

--- a/packages/ndla-ui/src/Masthead/MastheadLanguageSelector.jsx
+++ b/packages/ndla-ui/src/Masthead/MastheadLanguageSelector.jsx
@@ -23,7 +23,7 @@ class MastheadLanguageSelector extends Component {
     super(props);
     this.state = {
       isOpen: props.autoOpen,
-      manualOpen: false,
+      infoLocale: props.currentLanguage,
     };
     this.handleOpen = this.handleOpen.bind(this);
   }
@@ -31,13 +31,19 @@ class MastheadLanguageSelector extends Component {
   handleOpen() {
     this.setState({
       isOpen: true,
-      manualOpen: true,
+    });
+  }
+
+  toggleLanguage(lang) {
+    const infoLocale = lang || this.props.currentLanguage;
+    this.setState({
+      infoLocale,
     });
   }
 
   render() {
-    const { urls, currentLanguage, t } = this.props;
-    const { isOpen, manualOpen } = this.state;
+    const { options, currentLanguage, t } = this.props;
+    const { isOpen, infoLocale } = this.state;
     return (
       <div {...classes('change-language-wrapper')}>
         <Button link onClick={this.handleOpen}>
@@ -49,39 +55,40 @@ class MastheadLanguageSelector extends Component {
             focusTrapOptions={{
               onDeactivate: () => {
                 this.setState({
-                  manualOpen: false,
                   isOpen: false,
                 });
               },
               clickOutsideDeactivates: true,
               escapeDeactivates: true,
             }}>
-            <div
-              {...classes('change-language-modal', manualOpen && 'animate-in')}>
+            <div {...classes('change-language-modal', isOpen && 'animate-in')}>
               <Button
                 link
                 onClick={() => {
                   this.setState({
                     isOpen: false,
-                    manualOpen: false,
                   });
                 }}>
                 {t('masthead.menu.close')}
               </Button>
               <nav>
                 <ul>
-                  {Object.keys(urls).map(key => (
+                  {Object.keys(options).map(key => (
                     <li key={key}>
                       {key === currentLanguage ? (
                         <span {...classes('selected')}>
-                          {t(`languages.${key}`)}
+                          {options[key].name}
                         </span>
                       ) : (
                         <a
-                          href={`${urls[key].url}?langselector=true`}
-                          aria-label={t('changeLanguage', {
-                            language: t(`languages.${key}`),
-                          })}
+                          href={options[key].url}
+                          onMouseOver={() => {
+                            this.toggleLanguage(key);
+                          }}
+                          onMouseOut={() => {
+                            this.toggleLanguage();
+                          }}
+                          aria-label={t(`changeLanguage.${key}`)}
                           {...classes('selected')}>
                           {t(`languages.${key}`)}
                         </a>
@@ -89,7 +96,7 @@ class MastheadLanguageSelector extends Component {
                     </li>
                   ))}
                 </ul>
-                <p>{t(`currentLanguageText.${currentLanguage}`)}</p>
+                <p>{t(`currentLanguageText.${infoLocale}`)}</p>
               </nav>
             </div>
           </FocusTrapReact>
@@ -100,9 +107,13 @@ class MastheadLanguageSelector extends Component {
 }
 
 MastheadLanguageSelector.propTypes = {
-  urls: PropTypes.objectOf(PropTypes.string).isRequired,
+  options: PropTypes.objectOf(
+    PropTypes.shape({
+      name: PropTypes.string,
+      url: PropTypes.string,
+    }),
+  ).isRequired,
   currentLanguage: PropTypes.string.isRequired,
-  autoOpen: PropTypes.bool,
 };
 
 export default injectT(MastheadLanguageSelector);

--- a/packages/ndla-ui/src/Masthead/MastheadLanguageSelector.jsx
+++ b/packages/ndla-ui/src/Masthead/MastheadLanguageSelector.jsx
@@ -88,9 +88,8 @@ class MastheadLanguageSelector extends Component {
                           onMouseOut={() => {
                             this.toggleLanguage();
                           }}
-                          aria-label={t(`changeLanguage.${key}`)}
-                          {...classes('selected')}>
-                          {t(`languages.${key}`)}
+                          aria-label={t(`changeLanguage.${key}`)}>
+                          {options[key].name}
                         </a>
                       )}
                     </li>

--- a/packages/ndla-ui/src/Masthead/component.masthead.scss
+++ b/packages/ndla-ui/src/Masthead/component.masthead.scss
@@ -154,6 +154,9 @@
   &__change-language-wrapper {
     position: relative;
     padding-right: $spacing--large;
+    @include mq($until: desktop) {
+      display: none;
+    }
   }
 
   &__change-language-modal {

--- a/packages/ndla-ui/src/Masthead/component.masthead.scss
+++ b/packages/ndla-ui/src/Masthead/component.masthead.scss
@@ -150,6 +150,78 @@
       padding: 0;
     }
   }
+
+  &__change-language-wrapper {
+    position: relative;
+    padding-right: $spacing--large;
+  }
+
+  &__change-language-modal {
+    background: $brand-color--light;
+    position: absolute;
+    z-index: 9999;
+    right: $spacing;
+    top: -$spacing * 0.75;
+    padding: $spacing * 0.75 $spacing $spacing;
+    box-shadow: 0 0 6px rgba(0, 0, 0, 0.5);
+    border-radius: $border-radius;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    &--animate-in {
+      animation: fadeInTop 200ms ease;
+    }
+    nav {
+      width: 100%;
+      padding: $spacing--medium $spacing--large $spacing--small;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      ul {
+        margin: 0 $spacing--large;
+        padding: 0;
+        list-style: none;
+        li {
+          margin: 0 0 $spacing--small / 2;
+          padding: 0;
+        }
+        a, span {
+          width: 100%;
+          padding: $spacing--small $spacing--large * 1.25;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border-radius: $border-radius;
+        }
+        a {
+          background: transparent;
+          color: $brand-color--dark;
+          box-shadow: none;
+          transition: background 200ms ease;
+          &:hover, &:focus {
+            background: $brand-color--tertiary;
+          }
+        }
+        span {
+          background: $brand-color;
+          color: #fff;
+          &:before {
+            content: "";
+            position: absolute;
+            display: block;
+            @include svg_icon(done, #fff);
+            width: 26px;
+            height: 26px;
+            background-size: 24px 24px;
+            left: $spacing--large * 3;
+            background-position-x: center;
+            background-position-y: center;
+          }
+        }
+      }
+    }
+  }
 }
 
 .c-masthead,

--- a/packages/ndla-ui/src/Masthead/index.js
+++ b/packages/ndla-ui/src/Masthead/index.js
@@ -7,7 +7,8 @@
  */
 
 import Masthead, { MastheadItem } from './Masthead';
+import MastheadLanguageSelector from './MastheadLanguageSelector';
 
-export { MastheadItem };
+export { MastheadItem, MastheadLanguageSelector };
 
 export default Masthead;

--- a/packages/ndla-ui/src/index-javascript.js
+++ b/packages/ndla-ui/src/index-javascript.js
@@ -127,7 +127,11 @@ export {
   Hero,
   NdlaFilmHero,
 } from './Hero';
-export { default as Masthead, MastheadItem } from './Masthead';
+export {
+  default as Masthead,
+  MastheadItem,
+  MastheadLanguageSelector,
+} from './Masthead';
 export {
   Figure,
   FigureCaption,

--- a/packages/ndla-ui/src/locale/messages-en.js
+++ b/packages/ndla-ui/src/locale/messages-en.js
@@ -433,7 +433,11 @@ const messages = {
     zh: 'Chinese',
     unknown: 'Unknown',
   },
-  changeLanguage: 'Change language to {language}',
+  changeLanguage: {
+    nb: 'Endre språk til bokmål',
+    nn: 'Endre språk til nynorsk',
+    en: 'Change language to English',
+  },
   currentLanguageText: {
     nb: 'Sidene vises på bokmål',
     nn: 'Sidane vises på nynorsk',

--- a/packages/ndla-ui/src/locale/messages-en.js
+++ b/packages/ndla-ui/src/locale/messages-en.js
@@ -433,6 +433,13 @@ const messages = {
     zh: 'Chinese',
     unknown: 'Unknown',
   },
+  changeLanguage: 'Change language to {language}',
+  currentLanguageText: {
+    nb: 'Sidene vises på bokmål',
+    nn: 'Sidane vises på nynorsk',
+    en:
+      'Not all pages are available in English. These will be shown in Norwegian',
+  },
   breadcrumb: {
     toFrontpage: 'To the frontpage',
   },

--- a/packages/ndla-ui/src/locale/messages-nb.js
+++ b/packages/ndla-ui/src/locale/messages-nb.js
@@ -430,7 +430,11 @@ const messages = {
     zh: 'Kinesisk',
     unknown: 'Ukjent',
   },
-  changeLanguage: 'Endre språk til {language}',
+  changeLanguage: {
+    nb: 'Endre språk til bokmål',
+    nn: 'Endre språk til nynorsk',
+    en: 'Change language to English',
+  },
   currentLanguageText: {
     nb: 'Sidene vises på bokmål',
     nn: 'Sidane vises på nynorsk',

--- a/packages/ndla-ui/src/locale/messages-nb.js
+++ b/packages/ndla-ui/src/locale/messages-nb.js
@@ -430,6 +430,13 @@ const messages = {
     zh: 'Kinesisk',
     unknown: 'Ukjent',
   },
+  changeLanguage: 'Endre språk til {language}',
+  currentLanguageText: {
+    nb: 'Sidene vises på bokmål',
+    nn: 'Sidane vises på nynorsk',
+    en:
+      'Not all pages are available in English. These will be shown in Norwegian',
+  },
   breadcrumb: {
     toFrontpage: 'Til forsiden',
   },

--- a/packages/ndla-ui/src/locale/messages-nn.js
+++ b/packages/ndla-ui/src/locale/messages-nn.js
@@ -432,6 +432,13 @@ const messages = {
     zh: 'Kinesisk',
     unknown: 'Ukjent',
   },
+  changeLanguage: 'Endre språk til {language}',
+  currentLanguageText: {
+    nb: 'Sidene vises på bokmål',
+    nn: 'Sidane vises på nynorsk',
+    en:
+      'Not all pages are available in English. These will be shown in Norwegian',
+  },
   breadcrumb: {
     toFrontpage: 'Til framsida',
   },

--- a/packages/ndla-ui/src/locale/messages-nn.js
+++ b/packages/ndla-ui/src/locale/messages-nn.js
@@ -432,7 +432,11 @@ const messages = {
     zh: 'Kinesisk',
     unknown: 'Ukjent',
   },
-  changeLanguage: 'Endre språk til {language}',
+  changeLanguage: {
+    nb: 'Endre språk til bokmål',
+    nn: 'Endre språk til nynorsk',
+    en: 'Change language to English',
+  },
   currentLanguageText: {
     nb: 'Sidene vises på bokmål',
     nn: 'Sidane vises på nynorsk',


### PR DESCRIPTION
• Language selector in header (hides on scroll)
• Url should have params so we can pass autoOpen={true} to <MastheadLanguageSelector /> on changing language.
• Keep language selector in footer