### PR TITLE
Komprimering av bilder

### DIFF
--- a/packages/designmanual/stories/article/FigureImage.jsx
+++ b/packages/designmanual/stories/article/FigureImage.jsx
@@ -42,6 +42,22 @@ function ImageWrapper({ typeClass, src, hasHiddenCation, children, t }) {
   );
 }
 
+const calculateSizesFromType = type => {
+  switch (type) {
+    case 'left':
+    case 'right':
+      return '470px';
+    case 'small-left':
+    case 'small-right':
+      return '320px';
+    case 'xsmall-right':
+    case 'xsmall-left':
+      return '200px';
+    default:
+      return '(min-width: 1024px) 1024px, 100vw';
+  }
+};
+
 export function FigureImage({
   type,
   alt,
@@ -54,7 +70,7 @@ export function FigureImage({
     initArticleScripts();
   });
   const figureId = `figure-${id}`;
-
+  const sizes = calculateSizesFromType(type);
   return (
     <Trans>
       {({ t }) => (
@@ -66,7 +82,7 @@ export function FigureImage({
                 typeClass={typeClass}
                 t={t}
                 src={src}>
-                <Image alt={alt} src={src} />
+                <Image alt={alt} src={src} sizes={sizes} />
               </ImageWrapper>
               <FigureCaptionExample
                 id={id}

--- a/packages/ndla-article-scripts/src/figureScripts.js
+++ b/packages/ndla-article-scripts/src/figureScripts.js
@@ -103,13 +103,14 @@ export const addEventListenerForFigureZoomButton = () => {
     const target = el;
     target.onclick = () => {
       const parentFigure = target.closest('figure');
-      const sourceTag = parentFigure.getElementsByTagName('source')[0];
-      if (target.dataset.expanded) {
+      const sourceTag =
+        parentFigure && parentFigure.getElementsByTagName('source')[0];
+      if (parentFigure && target.dataset.expanded) {
         target.setAttribute('aria-label', target.dataset.aria);
         target.classList.remove('c-figure__fullscreen-btn--expanded');
         parentFigure.classList.add(target.dataset.classtype);
         delete target.dataset.expanded;
-      } else {
+      } else if (sourceTag) {
         sourceTag.setAttribute('sizes', '(min-width: 1024px) 1024px, 100vw');
         target.setAttribute('aria-label', target.dataset.ariaexpanded);
         parentFigure.classList.remove(target.dataset.classtype);

--- a/packages/ndla-article-scripts/src/figureScripts.js
+++ b/packages/ndla-article-scripts/src/figureScripts.js
@@ -103,12 +103,14 @@ export const addEventListenerForFigureZoomButton = () => {
     const target = el;
     target.onclick = () => {
       const parentFigure = target.closest('figure');
+      const sourceTag = parentFigure.getElementsByTagName('source')[0];
       if (target.dataset.expanded) {
         target.setAttribute('aria-label', target.dataset.aria);
         target.classList.remove('c-figure__fullscreen-btn--expanded');
         parentFigure.classList.add(target.dataset.classtype);
         delete target.dataset.expanded;
       } else {
+        sourceTag.setAttribute('sizes', '(min-width: 1024px) 1024px, 100vw');
         target.setAttribute('aria-label', target.dataset.ariaexpanded);
         parentFigure.classList.remove(target.dataset.classtype);
         target.classList.add('c-figure__fullscreen-btn--expanded');

--- a/packages/ndla-ui/src/Figure/Figure.js
+++ b/packages/ndla-ui/src/Figure/Figure.js
@@ -106,7 +106,10 @@ const Figure = ({ children, type, resizeIframe, t, ...rest }) => {
   const typeClass =
     type === 'full-column' ? 'c-figure--full-column' : `u-float-${type}`;
   return (
-    <figure {...classes('', { resize: resizeIframe }, typeClass)} {...rest}>
+    <figure
+      data-sizetype={type}
+      {...classes('', { resize: resizeIframe }, typeClass)}
+      {...rest}>
       {isFunction(children) ? children({ typeClass }) : children}
     </figure>
   );

--- a/packages/ndla-ui/src/Image/Image.jsx
+++ b/packages/ndla-ui/src/Image/Image.jsx
@@ -56,10 +56,10 @@ const Image = ({
   crop,
   focalPoint,
   contentType,
+  sizes,
   ...rest
 }) => {
   const srcSet = defined(rest.srcSet, getSrcSet(src, crop, focalPoint));
-  const sizes = defined(rest.sizes, '(min-width: 1024px) 1024px, 100vw'); // min-width === inuit-wrapper-width
   const fallbackWidth = defined(rest.fallbackWidth, 1024);
   const queryString = makeSrcQueryString(fallbackWidth, crop, focalPoint);
 
@@ -73,15 +73,17 @@ const Image = ({
         alt={alt}
         src={`${src}?${queryString}`}
         srcSet={srcSet}
-        sizes={sizes}
+        sizes={useSizes}
         lazyLoadSrc={lazyLoadSrc}
       />
     );
   }
 
+  console.log('sizes', sizes);
+
   return (
     <picture>
-      <source type={contentType} srcSet={srcSet} />
+      <source type={contentType} srcSet={srcSet} sizes={sizes} />
       <img alt={alt} src={`${src}?${queryString}`} {...rest} />
     </picture>
   );
@@ -106,6 +108,10 @@ Image.propTypes = {
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired,
   }),
+};
+
+Image.defaultProps = {
+  sizes: '(min-width: 1024px) 1024px, 100vw',
 };
 
 export default Image;

--- a/packages/ndla-ui/src/Image/Image.jsx
+++ b/packages/ndla-ui/src/Image/Image.jsx
@@ -80,13 +80,10 @@ const Image = ({
   }
 
   return (
-    <img
-      alt={alt}
-      srcSet={srcSet}
-      sizes={sizes}
-      src={`${src}?${queryString}`}
-      {...rest}
-    />
+    <picture>
+      <source type={contentType} srcSet={srcSet} />
+      <img alt={alt} src={`${src}?${queryString}`} {...rest} />
+    </picture>
   );
 };
 

--- a/packages/ndla-ui/src/Image/Image.jsx
+++ b/packages/ndla-ui/src/Image/Image.jsx
@@ -73,13 +73,11 @@ const Image = ({
         alt={alt}
         src={`${src}?${queryString}`}
         srcSet={srcSet}
-        sizes={useSizes}
+        sizes={sizes}
         lazyLoadSrc={lazyLoadSrc}
       />
     );
   }
-
-  console.log('sizes', sizes);
 
   return (
     <picture>

--- a/packages/ndla-ui/src/Image/__tests__/__snapshots__/Image-test.jsx.snap
+++ b/packages/ndla-ui/src/Image/__tests__/__snapshots__/Image-test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`Image renderers correctly 1`] = `
 <picture>
   <source
+    sizes="(min-width: 1024px) 1024px, 100vw"
     srcSet="https://example.com/image.png?width=2720 2720w, https://example.com/image.png?width=2080 2080w, https://example.com/image.png?width=1760 1760w, https://example.com/image.png?width=1440 1440w, https://example.com/image.png?width=1120 1120w, https://example.com/image.png?width=1000 1000w, https://example.com/image.png?width=960 960w, https://example.com/image.png?width=800 800w, https://example.com/image.png?width=640 640w, https://example.com/image.png?width=480 480w, https://example.com/image.png?width=320 320w, https://example.com/image.png?width=240 240w, https://example.com/image.png?width=180 180w"
   />
   <img
@@ -15,6 +16,7 @@ exports[`Image renderers correctly 1`] = `
 exports[`Image with crop and focalpoint props renderers correctly 1`] = `
 <picture>
   <source
+    sizes="(min-width: 1024px) 1024px, 100vw"
     srcSet="https://example.com/image.png?width=2720&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 2720w, https://example.com/image.png?width=2080&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 2080w, https://example.com/image.png?width=1760&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 1760w, https://example.com/image.png?width=1440&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 1440w, https://example.com/image.png?width=1120&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 1120w, https://example.com/image.png?width=1000&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 1000w, https://example.com/image.png?width=960&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 960w, https://example.com/image.png?width=800&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 800w, https://example.com/image.png?width=640&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 640w, https://example.com/image.png?width=480&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 480w, https://example.com/image.png?width=320&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 320w, https://example.com/image.png?width=240&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 240w, https://example.com/image.png?width=180&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 180w"
   />
   <img

--- a/packages/ndla-ui/src/Image/__tests__/__snapshots__/Image-test.jsx.snap
+++ b/packages/ndla-ui/src/Image/__tests__/__snapshots__/Image-test.jsx.snap
@@ -1,21 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Image renderers correctly 1`] = `
-<img
-  alt="example"
-  sizes="(min-width: 1024px) 1024px, 100vw"
-  src="https://example.com/image.png?width=1024"
-  srcSet="https://example.com/image.png?width=2720 2720w, https://example.com/image.png?width=2080 2080w, https://example.com/image.png?width=1760 1760w, https://example.com/image.png?width=1440 1440w, https://example.com/image.png?width=1120 1120w, https://example.com/image.png?width=1000 1000w, https://example.com/image.png?width=960 960w, https://example.com/image.png?width=800 800w, https://example.com/image.png?width=640 640w, https://example.com/image.png?width=480 480w, https://example.com/image.png?width=320 320w, https://example.com/image.png?width=240 240w, https://example.com/image.png?width=180 180w"
-/>
+<picture>
+  <source
+    srcSet="https://example.com/image.png?width=2720 2720w, https://example.com/image.png?width=2080 2080w, https://example.com/image.png?width=1760 1760w, https://example.com/image.png?width=1440 1440w, https://example.com/image.png?width=1120 1120w, https://example.com/image.png?width=1000 1000w, https://example.com/image.png?width=960 960w, https://example.com/image.png?width=800 800w, https://example.com/image.png?width=640 640w, https://example.com/image.png?width=480 480w, https://example.com/image.png?width=320 320w, https://example.com/image.png?width=240 240w, https://example.com/image.png?width=180 180w"
+  />
+  <img
+    alt="example"
+    src="https://example.com/image.png?width=1024"
+  />
+</picture>
 `;
 
 exports[`Image with crop and focalpoint props renderers correctly 1`] = `
-<img
-  alt="example"
-  sizes="(min-width: 1024px) 1024px, 100vw"
-  src="https://example.com/image.png?width=1024&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28"
-  srcSet="https://example.com/image.png?width=2720&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 2720w, https://example.com/image.png?width=2080&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 2080w, https://example.com/image.png?width=1760&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 1760w, https://example.com/image.png?width=1440&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 1440w, https://example.com/image.png?width=1120&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 1120w, https://example.com/image.png?width=1000&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 1000w, https://example.com/image.png?width=960&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 960w, https://example.com/image.png?width=800&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 800w, https://example.com/image.png?width=640&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 640w, https://example.com/image.png?width=480&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 480w, https://example.com/image.png?width=320&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 320w, https://example.com/image.png?width=240&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 240w, https://example.com/image.png?width=180&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 180w"
-/>
+<picture>
+  <source
+    srcSet="https://example.com/image.png?width=2720&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 2720w, https://example.com/image.png?width=2080&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 2080w, https://example.com/image.png?width=1760&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 1760w, https://example.com/image.png?width=1440&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 1440w, https://example.com/image.png?width=1120&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 1120w, https://example.com/image.png?width=1000&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 1000w, https://example.com/image.png?width=960&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 960w, https://example.com/image.png?width=800&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 800w, https://example.com/image.png?width=640&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 640w, https://example.com/image.png?width=480&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 480w, https://example.com/image.png?width=320&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 320w, https://example.com/image.png?width=240&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 240w, https://example.com/image.png?width=180&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 180w"
+  />
+  <img
+    alt="example"
+    src="https://example.com/image.png?width=1024&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28"
+  />
+</picture>
 `;
 
 exports[`Lazyloaded image renderers correctly 1`] = `


### PR DESCRIPTION
Bildeoppløsning oppdaterer seg ikke ved ekspandering av bilde i artikkeltekst. 

https://trello.com/c/w6mXO2i1/244-komprimering-av-bilder
```
Fra Albertine: Sjekk f.eks det sidestilte bilde i denne artikkelen: https://stier.ndla.no/learningpaths/913/step/7242
Fra Johannes: Godt observert - her bytter de ikke ut bildekvaliteten når man klikker på forstørrknappen. Det er en frontendfeil som Cecilie følger mot design-Keyteq tenker jeg. Denne kvaliteten har bildet egentlig Cecilie: https://api.ndla.no/image-api/raw/YJELF8WX.jpg?width=2720
Kan vi fikse dette, @sivmundal og @ivarborthen2?
```

Vi Wrapper img i en picture tag med source element, som ser ut til å fikse problemet, men vanskelig å verifisere.