### PR TITLE
Add missing text

### DIFF
--- a/packages/ndla-ui/src/locale/messages-en.js
+++ b/packages/ndla-ui/src/locale/messages-en.js
@@ -448,6 +448,7 @@ const messages = {
     es: 'Spanish',
     zh: 'Chinese',
     unknown: 'Unknown',
+    prefixChangeLanguage: 'Choose language',
   },
   changeLanguage: {
     nb: 'Endre språk til bokmål',


### PR DESCRIPTION
Dersom vi skal kunne vise artikler på engelsk med url ndla.no/en/article/id må denne teksten være på plass.