### PR TITLE
running shift on the same object on different renders gives undefined

### DIFF
--- a/packages/ndla-video-search/src/VideoSearchResultYouTube.jsx
+++ b/packages/ndla-video-search/src/VideoSearchResultYouTube.jsx
@@ -29,8 +29,7 @@ export default function VideoSearchResultYouTube({
 }) {
   const videoData = video?.pagemap?.videoobject[0];
   const activeVideo =
-    selectedVideo?.pagemap?.videoobject[0]?.videoid ===
-    videoData?.videoid;
+    selectedVideo?.pagemap?.videoobject[0]?.videoid === videoData?.videoid;
 
   if (videoData) {
     return (

--- a/packages/ndla-video-search/src/VideoSearchResultYouTube.jsx
+++ b/packages/ndla-video-search/src/VideoSearchResultYouTube.jsx
@@ -27,9 +27,9 @@ export default function VideoSearchResultYouTube({
   translations,
   locale,
 }) {
-  const videoData = video?.pagemap?.videoobject?.shift();
+  const videoData = video?.pagemap?.videoobject[0];
   const activeVideo =
-    selectedVideo?.pagemap?.videoobject?.shift()?.videoid ===
+    selectedVideo?.pagemap?.videoobject[0]?.videoid ===
     videoData?.videoid;
 
   if (videoData) {


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2191

`Shift` metoden som ble kjørt på videooobjectet gjorde selve videoobjectet undefined til neste rerender.