### PR TITLE
Skjule box-shadow for bildelenker.

### DIFF
--- a/packages/ndla-ui/src/Image/ImageLink.js
+++ b/packages/ndla-ui/src/Image/ImageLink.js
@@ -8,21 +8,23 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { isEqual } from 'lodash';
+import styled from '@emotion/styled';
 import { makeSrcQueryString } from './Image';
 import { FocalPointShape, CropShape } from './shapes';
 
-export function ImageLink({ src, crop, children, contentType = '', ...rest }) {
-  const className = isEqual(contentType, 'image/svg+xml') ? 'svg' : ''; // Forces no underline for svg images.
+const StyledLink = styled.a`
+  box-shadow: inset 0 0;
+`;
+
+export function ImageLink({ src, crop, children, ...rest }) {
   return (
-    <a
+    <StyledLink
       target="_blank"
       href={`${src}?${makeSrcQueryString(10720, crop)}`}
       rel="noopener noreferrer"
-      className={className}
       {...rest}>
       {children}
-    </a>
+    </StyledLink>
   );
 }
 

--- a/packages/ndla-ui/src/Image/ImageLink.js
+++ b/packages/ndla-ui/src/Image/ImageLink.js
@@ -8,15 +8,18 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { isEqual } from 'lodash';
 import { makeSrcQueryString } from './Image';
 import { FocalPointShape, CropShape } from './shapes';
 
-export function ImageLink({ src, crop, children, ...rest }) {
+export function ImageLink({ src, crop, children, contentType = '', ...rest }) {
+  const className = isEqual(contentType, 'image/svg+xml') ? 'svg' : ''; // Forces no underline for svg images.
   return (
     <a
       target="_blank"
       href={`${src}?${makeSrcQueryString(10720, crop)}`}
       rel="noopener noreferrer"
+      className={className}
       {...rest}>
       {children}
     </a>

--- a/packages/ndla-ui/src/Image/component.image.scss
+++ b/packages/ndla-ui/src/Image/component.image.scss
@@ -1,0 +1,3 @@
+.svg {
+  box-shadow: inset 0 0;
+}

--- a/packages/ndla-ui/src/Image/component.image.scss
+++ b/packages/ndla-ui/src/Image/component.image.scss
@@ -1,3 +1,0 @@
-.svg {
-  box-shadow: inset 0 0;
-}

--- a/packages/ndla-ui/src/main.scss
+++ b/packages/ndla-ui/src/main.scss
@@ -3,6 +3,7 @@
 // COMPONENTS
 @import 'Logo/component.logo';
 @import 'Hero/component.hero';
+@import 'Image/component.image';
 @import 'Masthead/component.masthead';
 @import 'Article/component.article';
 @import 'Article/component.article-byline';

--- a/packages/ndla-ui/src/main.scss
+++ b/packages/ndla-ui/src/main.scss
@@ -3,7 +3,6 @@
 // COMPONENTS
 @import 'Logo/component.logo';
 @import 'Hero/component.hero';
-@import 'Image/component.image';
 @import 'Masthead/component.masthead';
 @import 'Article/component.article';
 @import 'Article/component.article-byline';


### PR DESCRIPTION
Dette ser hackete ut og det er det vel også. Svg-bilder som vises inne i ei lenke får en strek i gjennom seg på grunn av box-shadow som er satt på alle lenker. Ingen andre bildetyper får dette.

Løsninga her er å legge til contentType, og sjekke om denne er lik 'image/svg+xml'. Dersom den er lik settes en class som skjuler box-shadow for lenka.

For at dette skal fungere kreves det at imagePlugin i article-converter oppdateres til å sende inn contentType.