### PR TITLE
Utvide redigeringssiden til ndla film

### DIFF
--- a/packages/ndla-modal/src/Modal.js
+++ b/packages/ndla-modal/src/Modal.js
@@ -58,7 +58,7 @@ const Modal = ({
   let clonedComponent;
   if (activateButton) {
     clonedComponent = React.cloneElement(activateButton, {
-      onClick: (e) => {
+      onClick: e => {
         openModal();
         if (onClickEvent) {
           onClickEvent();

--- a/packages/ndla-modal/src/Modal.js
+++ b/packages/ndla-modal/src/Modal.js
@@ -58,11 +58,12 @@ const Modal = ({
   let clonedComponent;
   if (activateButton) {
     clonedComponent = React.cloneElement(activateButton, {
-      onClick: () => {
+      onClick: (e) => {
         openModal();
         if (onClickEvent) {
           onClickEvent();
         }
+        e.preventDefault();
       },
     });
   }


### PR DESCRIPTION
Har omstrukturert redigeringssiden til ndla film til å likne mer på fagforsideredigeringa, med accordions, header og lagreknapp. Themes-komponentene er de samme som før, og når modal til redigering av navn på dem åpnet, gjorde default at lagreknappen til editoren ble aktivert. La til en preventDefault for å hindre dette, og sjekket at ikke det knakk andre komponenter som bruker modal.