### PR TITLE
Better naming

### DIFF
--- a/packages/ndla-ui/src/locale/messages-en.js
+++ b/packages/ndla-ui/src/locale/messages-en.js
@@ -706,8 +706,8 @@ const messages = {
     cursorText: 'Find teaching material, assignments, movies and more.',
   },
   navigation: {
-    showLongerDescription: 'Longer description',
-    showShorterDescription: 'Shorter description',
+    showLongerDescription: 'Show more',
+    showShorterDescription: 'Show less',
     topics: 'Topics',
     additionalTopic: 'Additional topic',
     additionalTopics: 'Additional topics',

--- a/packages/ndla-ui/src/locale/messages-nb.js
+++ b/packages/ndla-ui/src/locale/messages-nb.js
@@ -715,8 +715,8 @@ const messages = {
     cursorText: 'Finn lærestoff, oppgaver, filmer m.m.',
   },
   navigation: {
-    showLongerDescription: 'Lengre beskrivelse',
-    showShorterDescription: 'Kortere beskrivelse',
+    showLongerDescription: 'Vis mer',
+    showShorterDescription: 'Vis mindre',
     topics: 'Emner',
     additionalTopic: 'Tillegsemne',
     additionalTopics: 'Tillegsemner',

--- a/packages/ndla-ui/src/locale/messages-nn.js
+++ b/packages/ndla-ui/src/locale/messages-nn.js
@@ -719,8 +719,8 @@ const messages = {
     cursorText: 'Finn lærestoff, oppgåver, filmar m.m.',
   },
   navigation: {
-    showLongerDescription: 'Lengre beskriving',
-    showShorterDescription: 'Kortere beskriving',
+    showLongerDescription: 'Vis meir',
+    showShorterDescription: 'Vis mindre',
     topics: 'Emner',
     additionalTopic: 'Tillegsemne',
     additionalTopics: 'Tillegsemner',


### PR DESCRIPTION
beskrivning er ikkje et gangbart ord på nynorsk så i samråd med språkavdelinga i NDLA endres dette til Vis mer og Vis mindre. Brukes for ekspandering av emnetekster.