### PR TITLE
Don't add scroll-listener to search on front-page if modal is closed

### DIFF
--- a/packages/ndla-ui/src/Frontpage/FrontpageSearch.tsx
+++ b/packages/ndla-ui/src/Frontpage/FrontpageSearch.tsx
@@ -83,6 +83,8 @@ const FrontpageSearch: React.FunctionComponent<Props> = ({
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const searchFieldRef = useRef<HTMLDivElement>(null);
+  const inputHasFocusRef = useRef(inputHasFocus);
+  inputHasFocusRef.current = inputHasFocus;
 
   useEffect(() => {
     const onKeyEsc = (e: KeyboardEvent) => {
@@ -134,7 +136,12 @@ const FrontpageSearch: React.FunctionComponent<Props> = ({
       // Because change in content(click on show more elements button) triggers some strange scroll in browser,
       // we must ensure that the scrollPos is the same all the time
       // setTimeout is used so the 'smooth' scroll effect can finish
-      setTimeout(() => window.addEventListener('scroll', resetScroll), 1000);
+      setTimeout(() => {
+        // If user has closed modal search before timeout. Don't add event-listener
+        if (inputHasFocusRef.current) {
+          window.addEventListener('scroll', resetScroll);
+        }
+      }, 1000);
     } else {
       noScroll(false, 'preventPageScroll');
       window.removeEventListener('scroll', resetScroll);


### PR DESCRIPTION
Dersom bruker åpner søket på forsiden og lukker det før det er gått 1 sekund så legges scroll-listener på etterpå som gjør at man ikke kan scrolle. Dette fikser det