### PR TITLE
Support locale in logo on frontpage-header

### DIFF
--- a/packages/designmanual/stories/simple-components.jsx
+++ b/packages/designmanual/stories/simple-components.jsx
@@ -876,6 +876,13 @@ storiesOf('Enkle komponenter', module)
           to="/"
           label="Nasjonal digital læringsarena"
         />
+        <h2>Engelsk logo</h2>
+        <Logo
+          cssModifier="large"
+          locale="en"
+          name
+          label="Norwegian digital learning arena"
+        />
       </StoryBody>
     </div>
   ))

--- a/packages/ndla-ui/src/Frontpage/FrontpageHeader.tsx
+++ b/packages/ndla-ui/src/Frontpage/FrontpageHeader.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { colors, spacing, mq, breakpoints } from '@ndla/core';
 import SafeLink from '@ndla/safelink';
+// @ts-ignore
+import { injectT } from '@ndla/i18n';
 import FrontpageHeaderIllustration from './illustrations/FrontpageHeaderIllustration';
 // @ts-ignore
 import SvgLogo from '../Logo/SvgLogo';
@@ -52,6 +54,7 @@ export type FrontPageHeaderProps = {
   languageOptions: string;
   locale: string;
   showHeader: boolean;
+  t(arg: string, obj?: { [key: string]: string | boolean | number }): string;
 };
 
 const FrontpageHeader: React.FunctionComponent<FrontPageHeaderProps> = ({
@@ -59,11 +62,12 @@ const FrontpageHeader: React.FunctionComponent<FrontPageHeaderProps> = ({
   locale,
   showHeader = true,
   children,
+  t,
 }) => (
   <StyledHeaderWrapper>
     <StyledHeader>
-      <StyledLogo to="/">
-        <SvgLogo />
+      <StyledLogo to="/" aria-label={t('logo.altText')}>
+        <SvgLogo locale={locale} />
       </StyledLogo>
       {showHeader && (
         <HeaderIllustrationWrapper>
@@ -75,4 +79,4 @@ const FrontpageHeader: React.FunctionComponent<FrontPageHeaderProps> = ({
   </StyledHeaderWrapper>
 );
 
-export default FrontpageHeader;
+export default injectT(FrontpageHeader);


### PR DESCRIPTION
https://trello.com/c/Yyml13vf/665-dagens-logo-er-p%C3%A5-norsk-b%C3%A5de-i-engelsk-og-p%C3%A5-norsk-burde-v%C3%A6rt-p%C3%A5-engelsk-n%C3%A5r-spr%C3%A5kvelgeren-er-valgt-til-engelsk