### PR TITLE
Add data-copy-string property to trigger script

### DIFF
--- a/packages/ndla-ui/src/Article/ArticleByline.tsx
+++ b/packages/ndla-ui/src/Article/ArticleByline.tsx
@@ -120,6 +120,7 @@ const ArticleByline = ({
             size="small"
             borderShape="rounded"
             outline
+            data-copy-string={copyPageUrlLink}
             copyNode={t('article.copyPageLinkCopied')}>
             {t('article.copyPageLink')}
           </CopyButton>

--- a/packages/ndla-ui/src/Article/ArticleSideBar.tsx
+++ b/packages/ndla-ui/src/Article/ArticleSideBar.tsx
@@ -67,7 +67,8 @@ const ArticleSideBar = ({
             size="small"
             width="full"
             outline
-            copyNode={t('article.copyPageLinkCopied')}>
+            copyNode={t('article.copyPageLinkCopied')}
+            data-copy-string={copyPageUrlLink}>
             {t('article.copyPageLink')}
           </CopyButton>
         </ButtonWrapper>

--- a/packages/ndla-ui/src/Codeblock/Codeblock.tsx
+++ b/packages/ndla-ui/src/Codeblock/Codeblock.tsx
@@ -83,6 +83,7 @@ export const Codeblock = ({ title, code, format = 'markup' }: Props) => {
       <Button
         title="Kopier kode"
         disabled={isCopied}
+        data-copy-string={code}
         onClick={() => {
           copyTextToClipboard(code);
           setIsCopied(true);


### PR DESCRIPTION
NDLANO/Issues#2276

For at figureScripts skal kunne plukke opp tekst som skal kopieres må button ha en property med teksten. Mangla dette i forrige PR.