### PR TITLE
Less padding. Prop to show copybutton. Prop to send in action for eit…

### DIFF
--- a/packages/designmanual/stories/codeblock/CodeblockExample.jsx
+++ b/packages/designmanual/stories/codeblock/CodeblockExample.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Button from '@ndla/button';
 import { Codeblock } from '@ndla/code';
 import { ArrowExpand } from '@ndla/icons/editor';
+import { Cross } from '@ndla/icons/action';
 import ComponentInfo from '../ComponentInfo';
 
 const htmlCode = `<div class="demo-content">
@@ -33,6 +34,12 @@ console.log(first);`;
 const fullscreenButton = (
   <Button stripped>
     <ArrowExpand />
+  </Button>
+);
+
+const edCloseButton = (
+  <Button stripped>
+    <Cross />
   </Button>
 );
 
@@ -72,7 +79,12 @@ const CodeExample = () => (
       title="HTML EKSEMPEL"
       showCopy={true}
     />
-    <Codeblock code={cssCode} format="css" title="CSS EKSEMPEL" />
+    <Codeblock
+      actionButton={edCloseButton}
+      code={cssCode}
+      format="css"
+      title="CSS EKSEMPEL"
+    />
     <Codeblock code={jsCode} format="jsx" title="JS EKSEMPEL" />
     <Codeblock
       code="Pure text without highlighting and no title"

--- a/packages/designmanual/stories/codeblock/CodeblockExample.jsx
+++ b/packages/designmanual/stories/codeblock/CodeblockExample.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import Button from '@ndla/button';
 import { Codeblock } from '@ndla/code';
+import { ArrowExpand } from '@ndla/icons/editor';
 import ComponentInfo from '../ComponentInfo';
 
 const htmlCode = `<div class="demo-content">
@@ -27,6 +29,12 @@ const cssCode = `body {
 const jsCode = `const arr = ["This", "Little", "Piggy"];
 const first = arr.shift();
 console.log(first);`;
+
+const fullscreenButton = (
+  <Button stripped>
+    <ArrowExpand />
+  </Button>
+);
 
 const CodeExample = () => (
   <ComponentInfo
@@ -57,7 +65,13 @@ const CodeExample = () => (
       'Language options: https://github.com/conorhastings/react-syntax-highlighter/blob/v11.0.2/AVAILABLE_LANGUAGES_PRISM.MD',
     ]}>
     <p>Kodekomponent for visning av kodesnutter</p>
-    <Codeblock code={htmlCode} format="markup" title="HTML EKSEMPEL" />
+    <Codeblock
+      actionButton={fullscreenButton}
+      code={htmlCode}
+      format="markup"
+      title="HTML EKSEMPEL"
+      showCopyButton={true}
+    />
     <Codeblock code={cssCode} format="css" title="CSS EKSEMPEL" />
     <Codeblock code={jsCode} format="jsx" title="JS EKSEMPEL" />
     <Codeblock

--- a/packages/designmanual/stories/codeblock/CodeblockExample.jsx
+++ b/packages/designmanual/stories/codeblock/CodeblockExample.jsx
@@ -55,8 +55,8 @@ const CodeExample = () => (
       {
         name: 'format',
         type: 'string',
-        default: 'markup',
-        description: 'Code type, defaults to markup',
+        default: 'Required',
+        description: 'Code type',
       },
       {
         name: 'code',

--- a/packages/designmanual/stories/codeblock/CodeblockExample.jsx
+++ b/packages/designmanual/stories/codeblock/CodeblockExample.jsx
@@ -70,7 +70,7 @@ const CodeExample = () => (
       code={htmlCode}
       format="markup"
       title="HTML EKSEMPEL"
-      showCopyButton={true}
+      showCopy={true}
     />
     <Codeblock code={cssCode} format="css" title="CSS EKSEMPEL" />
     <Codeblock code={jsCode} format="jsx" title="JS EKSEMPEL" />

--- a/packages/designmanual/stories/codeblock/CodeblockExample.jsx
+++ b/packages/designmanual/stories/codeblock/CodeblockExample.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Button from '@ndla/button';
 import { Codeblock } from '@ndla/code';
-import { ArrowExpand } from '@ndla/icons/editor';
 import { Cross } from '@ndla/icons/action';
 import ComponentInfo from '../ComponentInfo';
 
@@ -30,12 +29,6 @@ const cssCode = `body {
 const jsCode = `const arr = ["This", "Little", "Piggy"];
 const first = arr.shift();
 console.log(first);`;
-
-const fullscreenButton = (
-  <Button stripped>
-    <ArrowExpand />
-  </Button>
-);
 
 const edCloseButton = (
   <Button stripped>
@@ -73,14 +66,13 @@ const CodeExample = () => (
     ]}>
     <p>Kodekomponent for visning av kodesnutter</p>
     <Codeblock
-      actionButton={fullscreenButton}
+      actionButton={edCloseButton}
       code={htmlCode}
       format="markup"
       title="HTML EKSEMPEL"
       showCopy={true}
     />
     <Codeblock
-      actionButton={edCloseButton}
       code={cssCode}
       format="css"
       title="CSS EKSEMPEL"
@@ -89,6 +81,7 @@ const CodeExample = () => (
     <Codeblock
       code="Pure text without highlighting and no title"
       format="text"
+      title=" "
     />
   </ComponentInfo>
 );

--- a/packages/designmanual/stories/codeblock/CodeblockExample.jsx
+++ b/packages/designmanual/stories/codeblock/CodeblockExample.jsx
@@ -72,11 +72,7 @@ const CodeExample = () => (
       title="HTML EKSEMPEL"
       showCopy={true}
     />
-    <Codeblock
-      code={cssCode}
-      format="css"
-      title="CSS EKSEMPEL"
-    />
+    <Codeblock code={cssCode} format="css" title="CSS EKSEMPEL" />
     <Codeblock code={jsCode} format="jsx" title="JS EKSEMPEL" />
     <Codeblock
       code="Pure text without highlighting and no title"

--- a/packages/designmanual/stories/codeblock/CodeblockExample.jsx
+++ b/packages/designmanual/stories/codeblock/CodeblockExample.jsx
@@ -38,8 +38,14 @@ const edCloseButton = (
 
 const CodeExample = () => (
   <ComponentInfo
-    reactCode={`<Code\n  title="HTML EKSEMPEL"\n  format="markup"\n  code="<p>Hello world!</p>"\n/>\n\nconst cssCode = \`${cssCode}\`;\n<Code\n  code={cssCode}\n  format="css"\n  title="CSS EKSEMPEL"\n/>`}
+    reactCode={`<Codeblock\n title="HTML EKSEMPEL"\n format="markup"\n code="<p>Hello world!</p>"\n showCopy="true"\n/>\n\nconst cssCode = \`${cssCode}\`;\n<Codeblock\n  code={cssCode}\n  format="css"\n  title="CSS EKSEMPEL"\n/>`}
     usesPropTypes={[
+      {
+        name: 'actionButton',
+        type: 'Component',
+        default: 'Optional',
+        description: 'Button to show instead of fullscreen. Used in ed.',
+      },
       {
         name: 'title',
         type: 'string',
@@ -57,6 +63,12 @@ const CodeExample = () => (
         type: 'string',
         default: 'Required',
         description: 'Required code snippet',
+      },
+      {
+        name: 'showCopy',
+        type: 'boolean',
+        default: 'false',
+        description: 'Show copy code button',
       },
     ]}
     status={2}

--- a/packages/ndla-code/package.json
+++ b/packages/ndla-code/package.json
@@ -31,7 +31,6 @@
     "@ndla/core": "^0.6.30",
     "@ndla/i18n": "^0.5.1",
     "@ndla/icons": "^0.6.25",
-    "@ndla/modal": "0.4.31",
     "@ndla/util": "^0.4.4",
     "@types/react-syntax-highlighter": "^11.0.4",
     "prismjs": "^1.22.0",

--- a/packages/ndla-code/package.json
+++ b/packages/ndla-code/package.json
@@ -31,7 +31,7 @@
     "@ndla/core": "^0.6.30",
     "@ndla/i18n": "^0.5.1",
     "@ndla/icons": "^0.6.25",
-    "@ndla/modal": "0.4.25",
+    "@ndla/modal": "0.4.31",
     "@ndla/util": "^0.4.4",
     "@types/react-syntax-highlighter": "^11.0.4",
     "prismjs": "^1.22.0",

--- a/packages/ndla-code/package.json
+++ b/packages/ndla-code/package.json
@@ -31,6 +31,7 @@
     "@ndla/core": "^0.6.30",
     "@ndla/i18n": "^0.5.1",
     "@ndla/icons": "^0.6.25",
+    "@ndla/modal": "0.4.25",
     "@ndla/util": "^0.4.4",
     "@types/react-syntax-highlighter": "^11.0.4",
     "prismjs": "^1.22.0",

--- a/packages/ndla-code/src/Codeblock/Codeblock.tsx
+++ b/packages/ndla-code/src/Codeblock/Codeblock.tsx
@@ -22,7 +22,7 @@ import { Done } from '@ndla/icons/editor';
 import { getTitleFromFormat } from '../CodeBlockEditor';
 
 const Wrapper = styled.div`
-  padding: 20px 52px;
+  padding: 10px 26px;
   background: ${colors.brand.greyLighter};
   margin: 15px 0;
   code {
@@ -47,6 +47,12 @@ const Wrapper = styled.div`
   }
 `;
 
+const TitleBar = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+`;
+
 const Title = styled.h3`
   font-style: normal;
   font-weight: normal;
@@ -62,9 +68,18 @@ type Props = {
   code: string;
   format: string;
   title?: string | null;
+  actionButton?: FC | null;
+  showCopyButton?: boolean;
 };
 
-export const Codeblock: FC<Props & tType> = ({ code, format, t, title }) => {
+export const Codeblock: FC<Props & tType> = ({
+  actionButton,
+  code,
+  format,
+  showCopyButton = false,
+  t,
+  title,
+}) => {
   const [isCopied, setIsCopied] = useState(false);
 
   useEffect(() => {
@@ -79,7 +94,10 @@ export const Codeblock: FC<Props & tType> = ({ code, format, t, title }) => {
 
   return (
     <Wrapper>
-      <Title>{title ? title : getTitleFromFormat(format)}</Title>
+      <TitleBar>
+        <Title>{title ? title : getTitleFromFormat(format)}</Title>
+        {actionButton}
+      </TitleBar>
       <SyntaxHighlighter
         customStyle={{
           padding: '0',
@@ -97,17 +115,19 @@ export const Codeblock: FC<Props & tType> = ({ code, format, t, title }) => {
         {code}
       </SyntaxHighlighter>
 
-      <Button
-        title={t('codeBlock.copyButton')}
-        disabled={isCopied}
-        data-copy-string={code}
-        onClick={() => {
-          copyTextToClipboard(code);
-          setIsCopied(true);
-        }}>
-        {isCopied ? <Done /> : <Copy />}{' '}
-        {isCopied ? t('codeBlock.copiedCode') : t('codeBlock.copyCode')}
-      </Button>
+      {showCopyButton && (
+        <Button
+          title={t('codeBlock.copyButton')}
+          disabled={isCopied}
+          data-copy-string={code}
+          onClick={() => {
+            copyTextToClipboard(code);
+            setIsCopied(true);
+          }}>
+          {isCopied ? <Done /> : <Copy />}{' '}
+          {isCopied ? t('codeBlock.copiedCode') : t('codeBlock.copyCode')}
+        </Button>
+      )}
     </Wrapper>
   );
 };

--- a/packages/ndla-code/src/Codeblock/Codeblock.tsx
+++ b/packages/ndla-code/src/Codeblock/Codeblock.tsx
@@ -69,14 +69,14 @@ type Props = {
   format: string;
   title?: string | null;
   actionButton?: FC | null;
-  showCopyButton?: boolean;
+  showCopy?: boolean;
 };
 
 export const Codeblock: FC<Props & tType> = ({
   actionButton,
   code,
   format,
-  showCopyButton = false,
+  showCopy: showCopyButton = false,
   t,
   title,
 }) => {

--- a/packages/ndla-code/src/Codeblock/Codeblock.tsx
+++ b/packages/ndla-code/src/Codeblock/Codeblock.tsx
@@ -6,18 +6,12 @@
  *
  */
 
-import React, { FC, Fragment, useState, useEffect } from 'react';
+import React, { FC, useState, useEffect } from 'react';
 import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { coy } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import { colors } from '@ndla/core';
 import styled from '@emotion/styled';
-// @ts-ignore
-import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 import { copyTextToClipboard } from '@ndla/util';
-// @ts-ignore
-import { ArrowExpand } from '@ndla/icons/editor';
-// @ts-ignore
-import { ArrowCollapse } from '@ndla/icons/common';
 import { injectT, tType } from '@ndla/i18n';
 // @ts-ignore
 import Button from '@ndla/button';
@@ -93,7 +87,6 @@ export const Codeblock: FC<Props & tType> = ({
   title,
 }) => {
   const [isCopied, setIsCopied] = useState(false);
-  const [isFullscreen, setIsFullscreen] = useState(false);
 
   useEffect(() => {
     if (isCopied) {
@@ -105,21 +98,11 @@ export const Codeblock: FC<Props & tType> = ({
     }
   }, [isCopied]);
 
-  const toggleFullscreen = () => {
-    setIsFullscreen(!isFullscreen);
-  };
-
-  const fullscreenButton = (
-    <Button stripped onClick={() => toggleFullscreen()}>
-      {isFullscreen ? <ArrowCollapse /> : <ArrowExpand />}
-    </Button>
-  );
-
-  const codeElement = (
+  return (
     <Wrapper>
       <TitleBar>
         <Title>{title ? title : getTitleFromFormat(format)}</Title>
-        <ButtonBar>{actionButton || fullscreenButton}</ButtonBar>
+        <ButtonBar>{actionButton}</ButtonBar>
       </TitleBar>
       <SyntaxHighlighter
         customStyle={{
@@ -151,36 +134,6 @@ export const Codeblock: FC<Props & tType> = ({
         </Button>
       )}
     </Wrapper>
-  );
-
-  return (
-    <Fragment>
-      {codeElement}
-      {isFullscreen && (
-        <Modal
-          controllable
-          isOpen={isFullscreen}
-          onClose={() => toggleFullscreen()}
-          size="fullscreen"
-          animation="slide-up"
-          backgroundColor="light-gradient"
-          narrow>
-          {(close: Function) => (
-            <Fragment>
-              <ModalHeader modifier="white modal-body">
-                <ModalCloseButton
-                  onClick={close}
-                  title={t('modal.closeModal')}
-                />
-              </ModalHeader>
-              <ModalBody>
-                <div className="c-codeblock">{codeElement}</div>
-              </ModalBody>
-            </Fragment>
-          )}
-        </Modal>
-      )}
-    </Fragment>
   );
 };
 

--- a/packages/ndla-code/src/Codeblock/Codeblock.tsx
+++ b/packages/ndla-code/src/Codeblock/Codeblock.tsx
@@ -76,7 +76,7 @@ export const Codeblock: FC<Props & tType> = ({
   actionButton,
   code,
   format,
-  showCopy: showCopyButton = false,
+  showCopy = false,
   t,
   title,
 }) => {
@@ -115,7 +115,7 @@ export const Codeblock: FC<Props & tType> = ({
         {code}
       </SyntaxHighlighter>
 
-      {showCopyButton && (
+      {showCopy && (
         <Button
           title={t('codeBlock.copyButton')}
           disabled={isCopied}

--- a/packages/ndla-code/src/Codeblock/Codeblock.tsx
+++ b/packages/ndla-code/src/Codeblock/Codeblock.tsx
@@ -16,6 +16,8 @@ import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 import { copyTextToClipboard } from '@ndla/util';
 // @ts-ignore
 import { ArrowExpand } from '@ndla/icons/editor';
+// @ts-ignore
+import { ArrowCollapse } from '@ndla/icons/common';
 import { injectT, tType } from '@ndla/i18n';
 // @ts-ignore
 import Button from '@ndla/button';
@@ -109,7 +111,7 @@ export const Codeblock: FC<Props & tType> = ({
 
   const fullscreenButton = (
     <Button stripped onClick={() => toggleFullscreen()}>
-      <ArrowExpand />
+      {isFullscreen ? <ArrowCollapse /> : <ArrowExpand />}
     </Button>
   );
 
@@ -117,10 +119,7 @@ export const Codeblock: FC<Props & tType> = ({
     <Wrapper>
       <TitleBar>
         <Title>{title ? title : getTitleFromFormat(format)}</Title>
-        <ButtonBar>
-          {isFullscreen ? '' : fullscreenButton}
-          {actionButton}
-        </ButtonBar>
+        <ButtonBar>{actionButton || fullscreenButton}</ButtonBar>
       </TitleBar>
       <SyntaxHighlighter
         customStyle={{

--- a/packages/ndla-code/src/Codeblock/Codeblock.tsx
+++ b/packages/ndla-code/src/Codeblock/Codeblock.tsx
@@ -53,12 +53,6 @@ const TitleBar = styled.div`
   width: 100%;
 `;
 
-const ButtonBar = styled.div`
-  button {
-    padding-left: 10px;
-  }
-`;
-
 const Title = styled.h3`
   font-style: normal;
   font-weight: normal;
@@ -102,7 +96,7 @@ export const Codeblock: FC<Props & tType> = ({
     <Wrapper>
       <TitleBar>
         <Title>{title ? title : getTitleFromFormat(format)}</Title>
-        <ButtonBar>{actionButton}</ButtonBar>
+        {actionButton}
       </TitleBar>
       <SyntaxHighlighter
         customStyle={{

--- a/packages/ndla-code/src/Codeblock/Codeblock.tsx
+++ b/packages/ndla-code/src/Codeblock/Codeblock.tsx
@@ -6,12 +6,16 @@
  *
  */
 
-import React, { FC, useState, useEffect } from 'react';
+import React, { FC, Fragment, useState, useEffect } from 'react';
 import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { coy } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import { colors } from '@ndla/core';
 import styled from '@emotion/styled';
+// @ts-ignore
+import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 import { copyTextToClipboard } from '@ndla/util';
+// @ts-ignore
+import { ArrowExpand } from '@ndla/icons/editor';
 import { injectT, tType } from '@ndla/i18n';
 // @ts-ignore
 import Button from '@ndla/button';
@@ -53,6 +57,12 @@ const TitleBar = styled.div`
   width: 100%;
 `;
 
+const ButtonBar = styled.div`
+  button {
+    padding-left: 10px;
+  }
+`;
+
 const Title = styled.h3`
   font-style: normal;
   font-weight: normal;
@@ -81,6 +91,7 @@ export const Codeblock: FC<Props & tType> = ({
   title,
 }) => {
   const [isCopied, setIsCopied] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
   useEffect(() => {
     if (isCopied) {
@@ -92,11 +103,24 @@ export const Codeblock: FC<Props & tType> = ({
     }
   }, [isCopied]);
 
-  return (
+  const toggleFullscreen = () => {
+    setIsFullscreen(!isFullscreen);
+  };
+
+  const fullscreenButton = (
+    <Button stripped onClick={() => toggleFullscreen()}>
+      <ArrowExpand />
+    </Button>
+  );
+
+  const codeElement = (
     <Wrapper>
       <TitleBar>
         <Title>{title ? title : getTitleFromFormat(format)}</Title>
-        {actionButton}
+        <ButtonBar>
+          {isFullscreen ? '' : fullscreenButton}
+          {actionButton}
+        </ButtonBar>
       </TitleBar>
       <SyntaxHighlighter
         customStyle={{
@@ -114,7 +138,6 @@ export const Codeblock: FC<Props & tType> = ({
         showLineNumbers>
         {code}
       </SyntaxHighlighter>
-
       {showCopy && (
         <Button
           title={t('codeBlock.copyButton')}
@@ -129,6 +152,36 @@ export const Codeblock: FC<Props & tType> = ({
         </Button>
       )}
     </Wrapper>
+  );
+
+  return (
+    <Fragment>
+      {codeElement}
+      {isFullscreen && (
+        <Modal
+          controllable
+          isOpen={isFullscreen}
+          onClose={() => toggleFullscreen()}
+          size="fullscreen"
+          animation="slide-up"
+          backgroundColor="light-gradient"
+          narrow>
+          {(close: Function) => (
+            <Fragment>
+              <ModalHeader modifier="white modal-body">
+                <ModalCloseButton
+                  onClick={close}
+                  title={t('modal.closeModal')}
+                />
+              </ModalHeader>
+              <ModalBody>
+                <div className="c-codeblock">{codeElement}</div>
+              </ModalBody>
+            </Fragment>
+          )}
+        </Modal>
+      )}
+    </Fragment>
   );
 };
 


### PR DESCRIPTION
…her fullscreen or remove (in editor)

Basert på tilbakemeldinger fra https://trello.com/c/AYKfUhkI/361-kunne-skrive-kode-enlighter-vise-programmeringskode-i-artikkel

I ed vil innsending av en knapp for å fjerne kodeblokk sjå slik ut:
![image](https://user-images.githubusercontent.com/8956884/95989138-29584c80-0e2a-11eb-9fa3-0447e9f3f1f7.png)

Mulig fullscreenvisning skal implementeres internt i komponenten og ikkje som en komponent som sendes inn, men dette er første utkast.