### PR TITLE
Avoid using useLayoutEffect hook on server

### DIFF
--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -9,3 +9,4 @@
 export { useWindowSize } from './useWindowSize';
 export { useComponentSize } from './useComponentSize';
 export { useIntersectionObserver } from './useIntersect';
+export { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';

--- a/packages/hooks/src/useComponentSize.ts
+++ b/packages/hooks/src/useComponentSize.ts
@@ -10,7 +10,7 @@ import { useCallback, useState } from 'react';
 import { resizeObserver } from '@ndla/util';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
-function getSize(el?: HTMLElement) {
+function getSize(el?: HTMLElement | null) {
   if (!el) {
     return {
       width: 0,
@@ -25,7 +25,7 @@ function getSize(el?: HTMLElement) {
 }
 
 interface Ref {
-  current?: HTMLElement;
+  current: HTMLElement | undefined | null;
 }
 
 export function useComponentSize(ref: Ref = { current: undefined }) {

--- a/packages/hooks/src/useComponentSize.ts
+++ b/packages/hooks/src/useComponentSize.ts
@@ -6,8 +6,9 @@
  *
  */
 
-import { useCallback, useState, useLayoutEffect } from 'react';
+import { useCallback, useState } from 'react';
 import { resizeObserver } from '@ndla/util';
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
 function getSize(el?: HTMLElement) {
   if (!el) {
@@ -37,7 +38,7 @@ export function useComponentSize(ref: Ref = { current: undefined }) {
     },
     [ref],
   );
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!ref.current) {
       return;
     }

--- a/packages/hooks/src/useComponentSize.ts
+++ b/packages/hooks/src/useComponentSize.ts
@@ -10,7 +10,9 @@ import { useCallback, useState } from 'react';
 import { resizeObserver } from '@ndla/util';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
-function getSize(el?: HTMLElement | null) {
+type NullableHtmlElement = HTMLElement | null | undefined;
+
+function getSize(el: NullableHtmlElement) {
   if (!el) {
     return {
       width: 0,
@@ -25,7 +27,7 @@ function getSize(el?: HTMLElement | null) {
 }
 
 interface Ref {
-  current: HTMLElement | undefined | null;
+  current: NullableHtmlElement;
 }
 
 export function useComponentSize(ref: Ref = { current: undefined }) {

--- a/packages/hooks/src/useIsomorphicLayoutEffect.ts
+++ b/packages/hooks/src/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2019-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useEffect, useLayoutEffect } from 'react';
+
+// Hack to allow for useLayoutEffect on client, but not logging nasty errors on server
+// https://medium.com/@alexandereardon/uselayouteffect-and-ssr-192986cdcf7a
+export const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;

--- a/packages/ndla-ui/src/Breadcrumb/Breadcrumb.tsx
+++ b/packages/ndla-ui/src/Breadcrumb/Breadcrumb.tsx
@@ -7,18 +7,34 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
-import BEMHelper from 'react-bem-helper';
+import BEMHelper, { ReturnObject } from 'react-bem-helper';
 import { uuid } from '@ndla/util';
+
+// @ts-ignore
 import { Home } from '@ndla/icons/common';
 import BreadcrumbItem from './BreadcrumbItem';
 
-const classes = BEMHelper({
+const classes: BEMHelper<ReturnObject> = BEMHelper({
   name: 'breadcrumb',
   prefix: 'c-',
 });
 
-const Breadcrumb = ({ children, items, invertedStyle }) => (
+interface BreadcrumbItemI {
+  to: string;
+  name: string;
+}
+
+interface Props {
+  children: React.ReactNode;
+  items: BreadcrumbItemI[];
+  invertedStyle: boolean;
+}
+
+const Breadcrumb: React.FunctionComponent<Props> = ({
+  children,
+  items,
+  invertedStyle,
+}) => (
   <div>
     {children}
     <ol {...classes('list')}>
@@ -37,16 +53,5 @@ const Breadcrumb = ({ children, items, invertedStyle }) => (
     </ol>
   </div>
 );
-
-Breadcrumb.propTypes = {
-  children: PropTypes.node,
-  invertedStyle: PropTypes.bool,
-  items: PropTypes.arrayOf(
-    PropTypes.shape({
-      to: PropTypes.string.isRequired,
-      name: PropTypes.string.isRequired,
-    }),
-  ),
-};
 
 export default Breadcrumb;

--- a/packages/ndla-ui/src/Breadcrumb/Breadcrumb.tsx
+++ b/packages/ndla-ui/src/Breadcrumb/Breadcrumb.tsx
@@ -19,7 +19,7 @@ const classes: BEMHelper<ReturnObject> = BEMHelper({
   prefix: 'c-',
 });
 
-interface BreadcrumbItemI {
+export interface BreadcrumbItemI {
   to: string;
   name: string;
 }

--- a/packages/ndla-ui/src/Breadcrumb/BreadcrumbBlock.jsx
+++ b/packages/ndla-ui/src/Breadcrumb/BreadcrumbBlock.jsx
@@ -6,10 +6,10 @@
  *
  */
 
-import React, { useRef, useLayoutEffect } from 'react';
+import React, { useRef} from 'react';
 import PropTypes from 'prop-types';
 import BEMHelper from 'react-bem-helper';
-import { useComponentSize } from '@ndla/hooks';
+import { useComponentSize, useIsomorphicLayoutEffect } from '@ndla/hooks';
 import BreadcrumbItem from './BreadcrumbItem';
 
 const classes = BEMHelper({
@@ -25,7 +25,7 @@ const BreadcrumbBlock = ({ children, items }) => {
   const breadcrumbItemRefs = useRef(new Map()).current;
   const size = useComponentSize(containerRef);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     // Create an array of all breadcrumb item refs
     const items = Array.from(breadcrumbItemRefs).map(([key, value]) => value);
 

--- a/packages/ndla-ui/src/Breadcrumb/BreadcrumbBlock.tsx
+++ b/packages/ndla-ui/src/Breadcrumb/BreadcrumbBlock.tsx
@@ -10,16 +10,12 @@ import React, { useRef } from 'react';
 import BEMHelper, { ReturnObject } from 'react-bem-helper';
 import { useComponentSize, useIsomorphicLayoutEffect } from '@ndla/hooks';
 import BreadcrumbItem from './BreadcrumbItem';
+import { BreadcrumbItemI } from './Breadcrumb';
 
 const classes: BEMHelper<ReturnObject> = BEMHelper({
   name: 'breadcrumb-block',
   prefix: 'c-',
 });
-
-interface BreadcrumbItemI {
-  to: string;
-  name: string;
-}
 
 interface Props {
   children: React.ReactNode;

--- a/packages/ndla-ui/src/Breadcrumb/BreadcrumbBlock.tsx
+++ b/packages/ndla-ui/src/Breadcrumb/BreadcrumbBlock.tsx
@@ -6,20 +6,32 @@
  *
  */
 
-import React, { useRef} from 'react';
-import PropTypes from 'prop-types';
-import BEMHelper from 'react-bem-helper';
+import React, { useRef } from 'react';
+import BEMHelper, { ReturnObject } from 'react-bem-helper';
 import { useComponentSize, useIsomorphicLayoutEffect } from '@ndla/hooks';
 import BreadcrumbItem from './BreadcrumbItem';
 
-const classes = BEMHelper({
+const classes: BEMHelper<ReturnObject> = BEMHelper({
   name: 'breadcrumb-block',
   prefix: 'c-',
 });
 
-const BreadcrumbBlock = ({ children, items }) => {
-  const olRef = useRef(null);
-  const containerRef = useRef(null);
+interface BreadcrumbItemI {
+  to: string;
+  name: string;
+}
+
+interface Props {
+  children: React.ReactNode;
+  items: BreadcrumbItemI[];
+}
+
+const BreadcrumbBlock: React.FunctionComponent<Props> = ({
+  children,
+  items,
+}) => {
+  const olRef = useRef<any>();
+  const containerRef = useRef<HTMLDivElement>(null);
   // No idiomatic way of dealing with sets of refs yet
   // See: https://github.com/facebook/react/issues/14072#issuecomment-446777406
   const breadcrumbItemRefs = useRef(new Map()).current;
@@ -58,23 +70,16 @@ const BreadcrumbBlock = ({ children, items }) => {
             classes={classes}
             key={item.to}
             isCurrent={i === items.length - 1}
-            to={item.to}>
+            to={item.to}
+            name={item.name}
+            home={false}
+            invertedStyle={false}>
             {item.name}
           </BreadcrumbItem>
         ))}
       </ol>
     </div>
   );
-};
-
-BreadcrumbBlock.propTypes = {
-  children: PropTypes.node,
-  items: PropTypes.arrayOf(
-    PropTypes.shape({
-      to: PropTypes.string.isRequired,
-      name: PropTypes.string.isRequired,
-    }),
-  ),
 };
 
 export default BreadcrumbBlock;

--- a/packages/ndla-ui/src/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/ndla-ui/src/Breadcrumb/BreadcrumbItem.tsx
@@ -7,15 +7,27 @@
  */
 
 import React, { useRef, useImperativeHandle } from 'react';
-import PropTypes from 'prop-types';
+// @ts-ignore
 import { ChevronRight } from '@ndla/icons/common';
 import SafeLink from '@ndla/safelink';
+import BEMHelper, { ReturnObject } from 'react-bem-helper';
+import * as H from 'history';
 
-const BreadcrumbItem = React.forwardRef(
+interface Props {
+  classes: BEMHelper<ReturnObject>;
+  isCurrent: boolean;
+  children: React.ReactNode;
+  to: H.LocationDescriptor;
+  home: boolean;
+  name: string;
+  invertedStyle: boolean;
+}
+
+const BreadcrumbItem = React.forwardRef<any, Props>(
   ({ to, children, classes, isCurrent, home, invertedStyle, name }, ref) => {
-    const liRef = useRef();
+    const liRef = useRef<any>();
     useImperativeHandle(ref, () => ({
-      setMaxWidth: maxWidth => {
+      setMaxWidth: (maxWidth: number) => {
         liRef.current.children[0].style.maxWidth = maxWidth;
       },
     }));
@@ -24,7 +36,7 @@ const BreadcrumbItem = React.forwardRef(
         {isCurrent ? (
           <span>{children}</span>
         ) : (
-          <SafeLink to={to} aria-label={home ? name : null}>
+          <SafeLink to={to} aria-label={home ? name : undefined}>
             {children}
           </SafeLink>
         )}
@@ -33,18 +45,5 @@ const BreadcrumbItem = React.forwardRef(
     );
   },
 );
-
-BreadcrumbItem.propTypes = {
-  classes: PropTypes.func.isRequired,
-  children: PropTypes.node.isRequired,
-  to: PropTypes.string.isRequired,
-  isCurrent: PropTypes.bool,
-  home: PropTypes.bool,
-  name: PropTypes.string,
-};
-
-BreadcrumbItem.defaultProps = {
-  home: false,
-};
 
 export default BreadcrumbItem;


### PR DESCRIPTION
Ingen funksjonelle endringer å teste, men kan fint teste at sidene (Spesielt de med brødsmulesti i headeren i guess) fortsatt fungerer som forventet. (Og at det ikke lager warning på useLayoutEffect)

Grunnen til å lage denne `useIsomorphicLayoutEffect` er at `useLayoutEffect` lager en støyete warning på server og på denne måten så bruker vi bare `useEffect` på server istedet. I følge han i [medium blog'en](https://medium.com/@alexandereardon/uselayouteffect-and-ssr-192986cdcf7a) så er det en workaround brukt av smarte folk også :smile: ([react-redux](https://github.com/reduxjs/react-redux/blob/d16262582b2eeb62c05313fca3eb59dc0b395955/src/components/connectAdvanced.js#L40))

_Eeeegentlig_ så merket jeg ikke store forskjellene dersom vi bruke `useEffect` på klient også, men ser at vi gjør målinger/endringer på DOM'en i `useLayoutEffect`'en og det skal vel egentlig ikke skje i vanlige `useEffect`(? kaller alle smartinger )
