### PR TITLE
Fix wrong direction prop in navigation-box

### DIFF
--- a/packages/ndla-ui/src/Frontpage/FrontpageProgramMenu.tsx
+++ b/packages/ndla-ui/src/Frontpage/FrontpageProgramMenu.tsx
@@ -69,7 +69,7 @@ const FrontpageProgramMenu = ({
         <NavigationBox
           colorMode="lighterGrey"
           items={programItems}
-          listDirection="horizontal"
+          listDirection="vertical"
         />
       )}
     </StyledWrapper>

--- a/packages/ndla-ui/src/Navigation/NavigationBox.tsx
+++ b/packages/ndla-ui/src/Navigation/NavigationBox.tsx
@@ -44,7 +44,7 @@ const StyledList = styled.ul<listProps>`
     column-count: 2;
     column-gap: 20px;
     ${props =>
-      props.direction === 'vertical' &&
+      props.direction === 'horizontal' &&
       css`
         display: grid;
         grid-template-columns: repeat(2, 1fr);
@@ -54,7 +54,7 @@ const StyledList = styled.ul<listProps>`
     column-count: 3;
     column-gap: 20px;
     ${props =>
-      props.direction === 'vertical' &&
+      props.direction === 'horizontal' &&
       css`
         grid-template-columns: repeat(3, 1fr);
       `}
@@ -174,7 +174,7 @@ export const NavigationBox = ({
   onClick,
   hasAdditionalResources,
   showAdditionalResources = false,
-  listDirection = 'vertical',
+  listDirection = 'horizontal',
   invertedStyle,
   onToggleAdditionalResources = () => {},
   t,


### PR DESCRIPTION
Dette skal ikke ha innvirkning på front-end annet at det blir slik som det er tenkt. Horisontal retning under utdaninng og på emner under fag. Vertikal retning på forsiden i listen over utdanninger.