### PR TITLE
Småfiksing på paginering i nedtrekkssøk

### DIFF
--- a/packages/ndla-forms/src/DropdownMenu.js
+++ b/packages/ndla-forms/src/DropdownMenu.js
@@ -108,10 +108,10 @@ const DropdownMenu = ({
           />
         ))}
       </StyledResultList>
-      {page && !loading && (
+      {page && totalCount > maxRender && (
         <Pager
           page={parseInt(page, 10)}
-          lastPage={totalCount ? Math.ceil(totalCount / 10) : 1}
+          lastPage={totalCount ? Math.ceil(totalCount / maxRender) : 1}
           onClick={handlePageChange}
           pageItemComponentClass="button"
         />


### PR DESCRIPTION
Viser kun paginering hvis antall elementer er flere enn antall elementer per side.

- Testes: https://frontend-packages-pr-735.ndla.sh/?path=/story/produksjonssystem--dropdown-with-multiselect
- Velg *med* paginering
- Antall elementer per side defaulter til 10, så sjekk søk som gir færre enn 10 resultater

Har ikke lagt til funksjonalitet for å bytte side i designmanualen.