### PR TITLE
Kopierknapp for kodeblokk i artikler

### DIFF
--- a/packages/ndla-code/src/Codeblock/Codeblock.tsx
+++ b/packages/ndla-code/src/Codeblock/Codeblock.tsx
@@ -121,6 +121,7 @@ export const Codeblock: FC<Props & tType> = ({
         <Button
           title={t('codeBlock.copyButton')}
           disabled={isCopied}
+          data-copied-title={t('codeBlock.copiedCode')}
           data-copy-string={code}
           onClick={() => {
             copyTextToClipboard(code);


### PR DESCRIPTION
For NDLANO/Issues#2387

Lagt til `data-copied-title` til knappen for at lagre-utseende skal fungere med article-converter. Gir ikke noe effekt på komponenten i designmanualen.