### PR TITLE
2389 flytte tekster fra article converter til UI

### DIFF
--- a/packages/designmanual/stories/article/AudioExample.jsx
+++ b/packages/designmanual/stories/article/AudioExample.jsx
@@ -1,24 +1,21 @@
 import React from 'react';
+import { initArticleScripts } from '@ndla/article-scripts';
+import { injectT } from '@ndla/i18n';
 import { AudioPlayer, Figure } from '@ndla/ui';
 import { uuid } from '@ndla/util';
-import { getLicenseByAbbreviation } from '@ndla/licenses';
-import { initArticleScripts } from '@ndla/article-scripts';
-import { FigureCaptionExample } from './FigureCaptionExample';
+import PropTypes from 'prop-types';
+import FigureCaptionExample from './FigureCaptionExample';
 import { useRunOnlyOnce } from './useRunOnlyOnce';
 
-function AudioExample() {
+function AudioExample({ t }) {
   const id = useRunOnlyOnce(uuid(), () => {
     initArticleScripts();
   });
-  const license = getLicenseByAbbreviation('CC-BY-ND-4.0', 'nb');
 
   const messages = {
-    close: 'Lukk',
-    rulesForUse: 'Regler for bruk av lydklippet',
-    learnAboutLicenses: license.linkText,
-    source: 'Kilde',
-    title: 'Tittel',
-    mediaType: 'lydklipp',
+    rulesForUse: t('license.audio.rules'),
+    reuse: t('audio.reuse'),
+    download: t('audio.download'),
   };
 
   const caption = 'Familien som spela vekk jula';
@@ -43,6 +40,8 @@ function AudioExample() {
   );
 }
 
-AudioExample.propTypes = {};
+AudioExample.propTypes = {
+  t: PropTypes.func.isRequired,
+};
 
-export default AudioExample;
+export default injectT(AudioExample);

--- a/packages/designmanual/stories/article/FigureCaptionExample.js
+++ b/packages/designmanual/stories/article/FigureCaptionExample.js
@@ -29,6 +29,9 @@ function FigureCaptionExample({
     close: t('close'),
     learnAboutLicenses: license ? license.linkText : t('license.learnMore'),
     source: t('source'),
+    rulesForUse: t('license.images.rules'),
+    reuse: t('image.reuse'),
+    download: t('image.download'),
     ...providedMessages,
   };
 
@@ -70,13 +73,6 @@ FigureCaptionExample.propTypes = {
 FigureCaptionExample.defaultProps = {
   authors: [{ type: 'Opphaver', name: 'Gary Waters' }],
   licenseAbbreviation: 'CC-BY-ND-4.0',
-  messages: {
-    rulesForUse: 'Regler for bruk av bildet',
-    modelPremission:
-      'Personen(e) på bildet har godkjent at det kan brukes videre.',
-    reuse: 'Bruk bildet',
-    download: 'Last ned bildet',
-  },
   caption: '',
   hasHiddenCaption: false,
 };

--- a/packages/designmanual/stories/article/FigureCaptionExample.js
+++ b/packages/designmanual/stories/article/FigureCaptionExample.js
@@ -8,21 +8,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { getLicenseByAbbreviation } from '@ndla/licenses';
-import { Trans } from '@ndla/i18n';
+import { injectT } from '@ndla/i18n';
 import { FigureCaption, FigureLicenseDialog } from '@ndla/ui';
 import Button from '@ndla/button';
 
-const defaultMessages = {
-  close: 'Lukk',
-  rulesForUse: 'Regler for bruk av bildet',
-  modelPremission:
-    'Personen(e) på bildet har godkjent at det kan brukes videre.',
-  source: 'Kilde',
-  mediaType: 'bilde',
-  title: 'Tittel',
-};
-
-export function FigureCaptionExample({
+function FigureCaptionExample({
   id,
   figureId,
   caption,
@@ -31,41 +21,40 @@ export function FigureCaptionExample({
   licenseAbbreviation,
   hasHiddenCaption,
   link,
+  t,
 }) {
   const license = getLicenseByAbbreviation(licenseAbbreviation, 'nb');
   const messages = {
-    ...defaultMessages,
-    learnAboutLicenses: license.linkText,
+    title: t('title'),
+    close: t('close'),
+    learnAboutLicenses: license ? license.linkText : t('license.learnMore'),
+    source: t('source'),
     ...providedMessages,
   };
 
   return (
-    <Trans>
-      {({ t }) => (
-        <FigureCaption
-          hideFigcaption={hasHiddenCaption}
-          figureId={figureId}
-          id={id}
-          locale="nb"
-          caption={caption}
-          reuseLabel={`Bruk ${messages.mediaType}`}
-          licenseRights={license.rights}
-          authors={authors}
-          link={link}>
-          <FigureLicenseDialog
-            id={id}
-            authors={authors}
-            license={license}
-            origin="https://www.wikimedia.com"
-            title="Mann med lupe"
-            locale="nb"
-            messages={messages}>
-            <Button outline>Kopier referanse</Button>
-            <Button outline>Last ned {messages.mediaType}</Button>
-          </FigureLicenseDialog>
-        </FigureCaption>
-      )}
-    </Trans>
+    <FigureCaption
+      hideFigcaption={hasHiddenCaption}
+      figureId={figureId}
+      id={id}
+      locale="nb"
+      caption={caption}
+      reuseLabel={messages.reuse}
+      licenseRights={license.rights}
+      authors={authors}
+      link={link}>
+      <FigureLicenseDialog
+        id={id}
+        authors={authors}
+        license={license}
+        origin="https://www.wikimedia.com"
+        title="Mann med lupe"
+        locale="nb"
+        messages={messages}>
+        <Button outline>{t('license.copyTitle')}</Button>
+        <Button outline>{messages.download}</Button>
+      </FigureLicenseDialog>
+    </FigureCaption>
   );
 }
 
@@ -82,14 +71,14 @@ FigureCaptionExample.defaultProps = {
   authors: [{ type: 'Opphaver', name: 'Gary Waters' }],
   licenseAbbreviation: 'CC-BY-ND-4.0',
   messages: {
-    close: 'Lukk',
     rulesForUse: 'Regler for bruk av bildet',
     modelPremission:
       'Personen(e) på bildet har godkjent at det kan brukes videre.',
-    source: 'Kilde',
-    mediaType: 'bilde',
-    title: 'Tittel',
+    reuse: 'Bruk bildet',
+    download: 'Last ned bildet',
   },
   caption: '',
   hasHiddenCaption: false,
 };
+
+export default injectT(FigureCaptionExample);

--- a/packages/designmanual/stories/article/FigureImage.jsx
+++ b/packages/designmanual/stories/article/FigureImage.jsx
@@ -69,6 +69,8 @@ function FigureImage({ type, alt, src, caption, hasHiddenCaption, link, t }) {
     zoomImageButtonLabel: t('license.images.itemImage.zoomImageButtonLabel'),
     reuse: t('image.reuse'),
     download: t('image.download'),
+    modelPermission:
+      'Personen(e) på bildet har godkjent at det kan brukes videre.',
   };
   return (
     <Figure id={figureId} type={type}>

--- a/packages/designmanual/stories/article/FigureImage.jsx
+++ b/packages/designmanual/stories/article/FigureImage.jsx
@@ -8,11 +8,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { uuid } from '@ndla/util';
-import { Trans } from '@ndla/i18n';
+import { injectT } from '@ndla/i18n';
 import { initArticleScripts } from '@ndla/article-scripts';
 
 import { Figure, Image, FigureExpandButton, ImageLink } from '@ndla/ui';
-import { FigureCaptionExample } from './FigureCaptionExample';
+import FigureCaptionExample from './FigureCaptionExample';
 import { useRunOnlyOnce } from './useRunOnlyOnce';
 
 function ImageWrapper({ typeClass, src, hasHiddenCation, children, t }) {
@@ -58,44 +58,40 @@ const calculateSizesFromType = type => {
   }
 };
 
-export function FigureImage({
-  type,
-  alt,
-  src,
-  caption,
-  hasHiddenCaption,
-  link,
-}) {
+function FigureImage({ type, alt, src, caption, hasHiddenCaption, link, t }) {
   const id = useRunOnlyOnce(uuid(), () => {
     initArticleScripts();
   });
   const figureId = `figure-${id}`;
   const sizes = calculateSizesFromType(type);
+  const messages = {
+    rulesForUse: t('license.images.rules'),
+    zoomImageButtonLabel: t('license.images.itemImage.zoomImageButtonLabel'),
+    reuse: t('image.reuse'),
+    download: t('image.download'),
+  };
   return (
-    <Trans>
-      {({ t }) => (
-        <Figure id={figureId} type={type}>
-          {({ typeClass }) => (
-            <>
-              <ImageWrapper
-                hasHiddenCation={hasHiddenCaption}
-                typeClass={typeClass}
-                t={t}
-                src={src}>
-                <Image alt={alt} src={src} sizes={sizes} />
-              </ImageWrapper>
-              <FigureCaptionExample
-                id={id}
-                figureId={figureId}
-                caption={caption}
-                hasHiddenCaption={hasHiddenCaption}
-                link={link}
-              />
-            </>
-          )}
-        </Figure>
+    <Figure id={figureId} type={type}>
+      {({ typeClass }) => (
+        <>
+          <ImageWrapper
+            hasHiddenCation={hasHiddenCaption}
+            typeClass={typeClass}
+            t={t}
+            src={src}>
+            <Image alt={alt} src={src} sizes={sizes} />
+          </ImageWrapper>
+          <FigureCaptionExample
+            id={id}
+            figureId={figureId}
+            caption={caption}
+            hasHiddenCaption={hasHiddenCaption}
+            link={link}
+            messages={messages}
+          />
+        </>
       )}
-    </Trans>
+    </Figure>
   );
 }
 
@@ -120,3 +116,5 @@ FigureImage.defaultProps = {
   caption: '',
   hasHiddenCaption: false,
 };
+
+export default injectT(FigureImage);

--- a/packages/designmanual/stories/article/FigureWithLicense.jsx
+++ b/packages/designmanual/stories/article/FigureWithLicense.jsx
@@ -7,11 +7,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { uuid } from '@ndla/util';
 import { initArticleScripts } from '@ndla/article-scripts';
-
+import { injectT } from '@ndla/i18n';
 import { Figure } from '@ndla/ui';
-import { FigureCaptionExample } from './FigureCaptionExample';
+import { uuid } from '@ndla/util';
+import FigureCaptionExample from './FigureCaptionExample';
 import { useRunOnlyOnce } from './useRunOnlyOnce';
 
 function FigureWithLicense({
@@ -21,6 +21,7 @@ function FigureWithLicense({
   resizeIframe,
   caption,
   type,
+  t,
 }) {
   const id = useRunOnlyOnce(uuid(), () => {
     initArticleScripts();
@@ -36,7 +37,9 @@ function FigureWithLicense({
           id={id}
           figureId={figureId}
           caption={caption}
-          messages={messages}
+          messages={
+            messages || { reuse: t('video.reuse'), modelPermission: null }
+          }
           hasHiddenCaption={hasHiddenCaption}
         />
       )}
@@ -69,4 +72,4 @@ FigureWithLicense.defaultProps = {
   hasHiddenCaption: false,
 };
 
-export default FigureWithLicense;
+export default injectT(FigureWithLicense);

--- a/packages/designmanual/stories/article/RelatedArticleListExample.jsx
+++ b/packages/designmanual/stories/article/RelatedArticleListExample.jsx
@@ -7,6 +7,9 @@
  */
 
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { toggleRelatedArticles } from '@ndla/article-scripts';
+import { injectT } from '@ndla/i18n';
 import {
   RelatedArticleList,
   RelatedArticle,
@@ -17,11 +20,10 @@ import {
   SubjectBadge,
   SourceMaterialBadge,
 } from '@ndla/ui';
-import { toggleRelatedArticles } from '@ndla/article-scripts';
 import { articleResources, exerciseResources } from '../../dummydata/index';
 
-export const RelatedArticleExerciseList = () => (
-  <RelatedArticleList messages={{ title: 'Relaterte artikler' }}>
+export const RelatedArticleExerciseList = ({ t }) => (
+  <RelatedArticleList messages={{ title: t('related.title') }}>
     <RelatedArticle
       title={exerciseResources[0].name}
       icon={<TasksAndActivitiesBadge background />}
@@ -39,8 +41,8 @@ export const RelatedArticleExerciseList = () => (
   </RelatedArticleList>
 );
 
-export const RelatedArticleMixedList = () => (
-  <RelatedArticleList messages={{ title: 'Relaterte artikler' }}>
+export const RelatedArticleMixedList = ({ t }) => (
+  <RelatedArticleList messages={{ title: t('related.title') }}>
     <RelatedArticle
       title={exerciseResources[0].name}
       icon={<TasksAndActivitiesBadge background />}
@@ -58,8 +60,8 @@ export const RelatedArticleMixedList = () => (
   </RelatedArticleList>
 );
 
-export const RelatedArticleExternal = () => (
-  <RelatedArticleList messages={{ title: 'Relaterte artikler' }}>
+export const RelatedArticleExternal = ({ t }) => (
+  <RelatedArticleList messages={{ title: t('related.title') }}>
     <RelatedArticle
       title="Bioteknologinemda"
       icon={<ExternalLearningResourcesBadge background />}
@@ -85,6 +87,7 @@ class ExpandExample extends Component {
   }
 
   render() {
+    const { t } = this.props;
     const articles = [
       <RelatedArticle
         title={articleResources[0].name}
@@ -132,9 +135,9 @@ class ExpandExample extends Component {
     return (
       <RelatedArticleList
         messages={{
-          title: 'Relaterte artikler',
-          showMore: 'Vis flere relaterte artikler',
-          showLess: 'Vis mindre',
+          title: t('related.title'),
+          showMore: t('related.showMore'),
+          showLess: t('related.showLess'),
         }}>
         {articles}
       </RelatedArticleList>
@@ -142,4 +145,8 @@ class ExpandExample extends Component {
   }
 }
 
-export default ExpandExample;
+ExpandExample.propTypes = {
+  t: PropTypes.func.isRequired,
+};
+
+export default injectT(ExpandExample);

--- a/packages/designmanual/stories/collated-components.jsx
+++ b/packages/designmanual/stories/collated-components.jsx
@@ -31,10 +31,11 @@ import {
 } from '@ndla/ui';
 import Pager from '@ndla/pager';
 
+import { Trans } from '@ndla/i18n';
 import { StoryIntro, StoryBody } from './wrappers';
 import { Center } from './helpers';
 import ArticleLoader from './article/ArticleLoader';
-import { FigureImage } from './article/FigureImage';
+import FigureImage from './article/FigureImage';
 import { topicList, mockFooterLinks } from '../dummydata/index';
 import MastheadWithTopicMenu, { MastheadWithLogo } from './molecules/mastheads';
 import Tabs, { TabsControlled } from './molecules/tabs';
@@ -495,24 +496,29 @@ storiesOf('Sammensatte moduler', module)
     </Center>
   ))
   .add('Relaterte artikler', () => (
-    <div>
-      <StoryIntro title="Relaterte artikler">
-        <p>Kan brukes i slutten av artikler, eller midt i.</p>
-      </StoryIntro>
-      <StoryBody>
-        <h2 className="u-heading">Oppgave og aktivitet eksempel</h2>
-        <RelatedArticleExerciseList />
-        <h2 className="u-heading">Fagstoff og oppgave eksempel</h2>
-        <RelatedArticleMixedList />
-        <h2 className="u-heading">Eksterne ressurser eksempel</h2>
-        <p>
-          Dersom en ekstern relatert artikkel ikke har metatekst, skal url vise.
-        </p>
-        <RelatedArticleExternal />
-        <h2 className="u-heading">Eksempel med vis mer</h2>
-        <RelatedArticleListExample />
-      </StoryBody>
-    </div>
+    <Trans>
+      {({ t }) => (
+        <div>
+          <StoryIntro title="Relaterte artikler">
+            <p>Kan brukes i slutten av artikler, eller midt i.</p>
+          </StoryIntro>
+          <StoryBody>
+            <h2 className="u-heading">Oppgave og aktivitet eksempel</h2>
+            <RelatedArticleExerciseList t={t} />
+            <h2 className="u-heading">Fagstoff og oppgave eksempel</h2>
+            <RelatedArticleMixedList t={t} />
+            <h2 className="u-heading">Eksterne ressurser eksempel</h2>
+            <p>
+              Dersom en ekstern relatert artikkel ikke har metatekst, skal url
+              vise.
+            </p>
+            <RelatedArticleExternal t={t} />
+            <h2 className="u-heading">Eksempel med vis mer</h2>
+            <RelatedArticleListExample t={t} />
+          </StoryBody>
+        </div>
+      )}
+    </Trans>
   ))
   .add('Sidefot', () => (
     <Center>

--- a/packages/designmanual/stories/pages/SearchResultTypeExample.jsx
+++ b/packages/designmanual/stories/pages/SearchResultTypeExample.jsx
@@ -171,11 +171,7 @@ const initNotionResult = () => {
                 <FigureWithLicense
                   type="full-column"
                   resizeIframe
-                  caption="Utholdenhet - animasjon av oksygentransporten"
-                  messages={{
-                    mediaType: 'videoen',
-                    modelPremission: null,
-                  }}>
+                  caption="Utholdenhet - animasjon av oksygentransporten">
                   <iframe
                     title="Video: Utholdenhet - animasjon av oksygentransporten"
                     height="270"
@@ -197,11 +193,7 @@ const initNotionResult = () => {
                 <FigureWithLicense
                   type="full-column"
                   resizeIframe
-                  caption="Utholdenhet - animasjon av oksygentransporten"
-                  messages={{
-                    mediaType: 'videoen',
-                    modelPremission: null,
-                  }}>
+                  caption="Utholdenhet - animasjon av oksygentransporten">
                   <iframe
                     title="Ekskresjon"
                     loading="lazy"

--- a/packages/designmanual/stories/simple-components.jsx
+++ b/packages/designmanual/stories/simple-components.jsx
@@ -19,7 +19,7 @@ import {
 import { colors } from '@ndla/core';
 import { StoryIntro, IconList, StoryBody } from './wrappers';
 import FigureWithLicense from './article/FigureWithLicense';
-import { FigureImage } from './article/FigureImage';
+import FigureImage from './article/FigureImage';
 import AudioExample from './article/AudioExample';
 import FootnotesExample from './article/FootnotesExample';
 import ArticleBylineExample from './molecules/ArticleBylineExample';
@@ -42,11 +42,7 @@ const floatVideo = left => (
     <FigureWithLicense
       type={left ? 'left' : 'right'}
       resizeIframe
-      caption="Utholdenhet - animasjon av oksygentransporten"
-      messages={{
-        mediaType: 'videoen',
-        modelPremission: null,
-      }}>
+      caption="Utholdenhet - animasjon av oksygentransporten">
       <iframe
         title="Video: Utholdenhet - animasjon av oksygentransporten"
         height="270"
@@ -504,11 +500,7 @@ storiesOf('Enkle komponenter', module)
         </h2>
         <FigureWithLicense
           resizeIframe
-          caption="Utholdenhet - animasjon av oksygentransporten"
-          messages={{
-            mediaType: 'videoen',
-            modelPremission: null,
-          }}>
+          caption="Utholdenhet - animasjon av oksygentransporten">
           <iframe
             title="Video: Utholdenhet - animasjon av oksygentransporten"
             height="270"
@@ -543,13 +535,7 @@ storiesOf('Enkle komponenter', module)
           Denne varianten skal kun brukes om det er nødvendig. Visningen fases
           bort når høyrespalte fases bort.
         </p>
-        <FigureWithLicense
-          resizeIframe
-          noCaption
-          messages={{
-            mediaType: 'videoen',
-            modelPremission: null,
-          }}>
+        <FigureWithLicense resizeIframe noCaption>
           <iframe
             src="https://www.youtube.com/embed/wOgIkxAfJsk?feature=oembed"
             title="Video without dimensions"

--- a/packages/ndla-ui/src/locale/messages-en.js
+++ b/packages/ndla-ui/src/locale/messages-en.js
@@ -6,6 +6,7 @@
  *
  */
 
+import { contributorTypes } from '@ndla/licenses';
 import constants from '../model';
 
 const { contentTypes } = constants;
@@ -273,7 +274,8 @@ const messages = {
   },
   resource: {
     errorDescription:
-      'Sorry, an error occurd while loading the topic resources.',
+      'Sorry, an error occurred while loading the topic resources.',
+    error: 'Sorry, a part of the content could not be shown.',
     noCoreResourcesAvailableUnspecific: 'There is no core content available.',
     noCoreResourcesAvailable: 'There is no core content available for {name}.',
     activateAdditionalResources: 'Show additional content',
@@ -755,6 +757,51 @@ const messages = {
   multidisciplinarySubject: {
     subjectsLinksDescription: 'Case in',
   },
+  close: 'Close',
+  title: 'Title',
+  image: {
+    download: 'Download image',
+    reuse: 'Use image',
+    largeSize: 'View original',
+    error: {
+      url: 'Error loading the image.',
+      caption: 'Sorry, an error occurred while loading the image.',
+    },
+  },
+  audio: {
+    download: 'Download audio',
+    reuse: 'Use audio',
+    error: {
+      url: 'Error loading the audio.',
+      caption: 'Sorry, an error occurred while loading the audio.',
+    },
+  },
+  video: {
+    download: 'Download video',
+    reuse: 'Use video',
+    error:
+      'Sorry, an error occurred while loading the video or metadata about the video.',
+  },
+  concept: {
+    showDescription: 'Show concept description',
+    error: {
+      title: 'An error occurred',
+      content: 'Could not load the description of the concept.',
+    },
+  },
+  source: 'Source',
+  related: {
+    title: 'Related content',
+    linkInfo: 'Web page at',
+    showMore: 'Show more related content',
+    showLess: 'Show less',
+  },
+  'external.error': 'An error occurred while loading an external resource.',
+  'h5p.error': 'An error occurred while loading the H5P.',
+  files: 'Files',
+  download: 'Download file: ',
+  expandButton: 'Show large version',
+  ...contributorTypes.en,
 };
 
 export default messages;

--- a/packages/ndla-ui/src/locale/messages-nb.js
+++ b/packages/ndla-ui/src/locale/messages-nb.js
@@ -6,6 +6,7 @@
  *
  */
 
+import { contributorTypes } from '@ndla/licenses';
 import constants from '../model';
 
 const { contentTypes } = constants;
@@ -276,6 +277,7 @@ const messages = {
   resource: {
     errorDescription:
       'Beklager, men en feil oppsto under lasting av emneressurser.',
+    error: 'Beklager, en del av innholdet kunne ikke vises.',
     noCoreResourcesAvailableUnspecific:
       'Det er ikke noe kjernestoff tilgjengelig.',
     noCoreResourcesAvailable: 'Det er ikke noe kjernestoff for {name}.',
@@ -764,6 +766,51 @@ const messages = {
   multidisciplinarySubject: {
     subjectsLinksDescription: 'Case innen',
   },
+  close: 'Lukk',
+  title: 'Tittel',
+  image: {
+    download: 'Last ned bildet',
+    reuse: 'Bruk bildet',
+    largeSize: 'Se stor utgave av bilde',
+    error: {
+      url: 'Feil ved lasting av bildet.',
+      caption: 'Beklager, en feil oppsto ved lasting av bildet.',
+    },
+  },
+  audio: {
+    download: 'Last ned lydklipp',
+    reuse: 'Bruk lydklipp',
+    error: {
+      url: 'Feil ved lasting av lydklippet.',
+      caption: 'Beklager, en feil oppsto ved lasting av lydklipp.',
+    },
+  },
+  video: {
+    download: 'Last ned video',
+    reuse: 'Bruk video',
+    error:
+      'Beklager, en feil oppstod ved lasting av videoen eller metadata om videoen.',
+  },
+  concept: {
+    showDescription: 'Vis beskrivelsen av forklaringen.',
+    error: {
+      title: 'En feil oppstod ikke',
+      content: 'Kunne ikke laste beskrivelsen av forklaringen.',
+    },
+  },
+  source: 'Kilde',
+  related: {
+    title: 'Relatert innhold',
+    linkInfo: 'Nettside hos',
+    showMore: 'Vis mer relatert innhold',
+    showLess: 'Vis mindre',
+  },
+  'external.error': 'En feil oppstod ved lasting av en ekstern ressurs.',
+  'h5p.error': 'En feil oppstod ved lasting av H5P.',
+  files: 'Filer',
+  download: 'Last ned fil: ',
+  expandButton: 'Vis stor versjon',
+  ...contributorTypes.nb,
 };
 
 export default messages;

--- a/packages/ndla-ui/src/locale/messages-nn.js
+++ b/packages/ndla-ui/src/locale/messages-nn.js
@@ -6,6 +6,7 @@
  *
  */
 
+import { contributorTypes } from '@ndla/licenses';
 import constants from '../model';
 
 const { contentTypes } = constants;
@@ -278,6 +279,7 @@ const messages = {
   },
   resource: {
     errorDescription: 'Orsak, ein feil oppstod under lasting av emneressursar.',
+    error: 'Orsak, ein del av innhaldet kunne ikkje visast.',
     noCoreResourcesAvailableUnspecific:
       'Det er ikkje noko kjernestoff tilgjengeleg.',
     noCoreResourcesAvailable:
@@ -768,6 +770,51 @@ const messages = {
   multidisciplinarySubject: {
     subjectsLinksDescription: 'Case innan',
   },
+  close: 'Lukk',
+  title: 'Tittel',
+  image: {
+    download: 'Last ned biletet',
+    reuse: 'Bruk biletet',
+    largeSize: 'Sjå stor utgave av biletet',
+    error: {
+      url: 'Feil ved lasting av biletet.',
+      caption: 'Orsak, ein feil oppstod ved lasting av biletet.',
+    },
+  },
+  audio: {
+    download: 'Last ned lydklipp',
+    reuse: 'Bruk lydklipp',
+    error: {
+      url: 'Feil ved lasting av lydklippet.',
+      caption: 'Orsak, ein feil oppstod ved lasting av lydklipp.',
+    },
+  },
+  video: {
+    download: 'Last ned video',
+    reuse: 'Bruk video',
+    error:
+      'Orsak, ein feil oppstod ved lasting av videoen eller metadata om videoen.',
+  },
+  concept: {
+    showDescription: 'Vis skildring av forklaringa',
+    error: {
+      title: 'Ein feil oppstod ikke',
+      content: 'Kunne ikkje laste skildringa av forklaringa.',
+    },
+  },
+  related: {
+    title: 'Relatert innhald',
+    linkInfo: 'Nettside hos',
+    showMore: 'Vis meir relatert innhald',
+    showLess: 'Vis mindre',
+  },
+  'external.error': 'Ein feil oppsto ved lasting av ein ekstern ressurs.',
+  'h5p.error': 'Ein feil oppsto ved lasting av H5P.',
+  source: 'Kjelde',
+  files: 'Filer',
+  download: 'Last ned fil: ',
+  expandButton: 'Vis stor versjon',
+  ...contributorTypes.nn,
 };
 
 export default messages;


### PR DESCRIPTION
NDLANO/Issues#2389

- Lagt til messages fra article-converter
- Byttet ut hardkoda meldinger med å hente de fra messages i @ndla/ui i disse komponentene:
  - [AudioExample](https://frontend-packages-pr-738.ndla.sh/?path=/story/enkle-komponenter--lydavspiller)
  - [FigureImage](https://frontend-packages-pr-738.ndla.sh/?path=/story/enkle-komponenter--bilde)
  - [FigureWithLicense](https://frontend-packages-pr-738.ndla.sh/?path=/story/enkle-komponenter--embedded-innhold)
  - [RelatedArticleListExample](https://frontend-packages-pr-738.ndla.sh/?path=/story/sammensatte-moduler--relatert-innhold)