### PR TITLE
Custom styling prop for Notion

### DIFF
--- a/packages/designmanual/stories/organisms/NotionExample.jsx
+++ b/packages/designmanual/stories/organisms/NotionExample.jsx
@@ -18,7 +18,7 @@ import Tabs from '@ndla/tabs';
 import { addShowConceptDefinitionClickListeners } from '@ndla/article-scripts';
 
 import ArticleBylineExample from '../molecules/ArticleBylineExample';
-import { FigureImage } from '../article/FigureImage';
+import FigureImage from '../article/FigureImage';
 
 class NotionExample extends Component {
   componentDidMount() {

--- a/packages/designmanual/stories/pages/ArticleAssessmentResource.jsx
+++ b/packages/designmanual/stories/pages/ArticleAssessmentResource.jsx
@@ -22,7 +22,7 @@ import {
 import { CompetenceGoalListExample } from '../organisms/CompetenceGoalsExample';
 import Resources from '../molecules/resources';
 import ArticleBylineExample from '../molecules/ArticleBylineExample';
-import { FigureImage } from '../article/FigureImage';
+import FigureImage from '../article/FigureImage';
 
 const { contentTypes } = constants;
 

--- a/packages/designmanual/stories/pages/ArticleExercise.jsx
+++ b/packages/designmanual/stories/pages/ArticleExercise.jsx
@@ -23,7 +23,7 @@ import Resources from '../molecules/resources';
 import ArticleBylineExample from '../molecules/ArticleBylineExample';
 
 import { CompetenceGoalListExample } from '../organisms/CompetenceGoalsExample';
-import { FigureImage } from '../article/FigureImage';
+import FigureImage from '../article/FigureImage';
 
 const { contentTypes } = constants;
 

--- a/packages/designmanual/stories/pages/ArticleExternalLearningResource.jsx
+++ b/packages/designmanual/stories/pages/ArticleExternalLearningResource.jsx
@@ -24,7 +24,7 @@ import ArticleBylineExample from '../molecules/ArticleBylineExample';
 
 import { CompetenceGoalListExample } from '../organisms/CompetenceGoalsExample';
 import Resources from '../molecules/resources';
-import { FigureImage } from '../article/FigureImage';
+import FigureImage from '../article/FigureImage';
 
 const { contentTypes } = constants;
 

--- a/packages/designmanual/stories/pages/ArticleLearningPaths.jsx
+++ b/packages/designmanual/stories/pages/ArticleLearningPaths.jsx
@@ -17,7 +17,7 @@ import {
   ArticleHeaderWrapper,
 } from '@ndla/ui';
 
-import { FigureImage } from '../article/FigureImage';
+import FigureImage from '../article/FigureImage';
 import ArticleBylineExample from '../molecules/ArticleBylineExample';
 
 export default ({ title, description }) => (

--- a/packages/designmanual/stories/pages/ArticleLearningmaterial.jsx
+++ b/packages/designmanual/stories/pages/ArticleLearningmaterial.jsx
@@ -24,7 +24,7 @@ import Resources from '../molecules/resources';
 import ArticleBylineExample from '../molecules/ArticleBylineExample';
 
 import { CompetenceGoalListExample } from '../organisms/CompetenceGoalsExample';
-import { FigureImage } from '../article/FigureImage';
+import FigureImage from '../article/FigureImage';
 
 const { contentTypes } = constants;
 

--- a/packages/designmanual/stories/pages/ArticleSourceMaterial.jsx
+++ b/packages/designmanual/stories/pages/ArticleSourceMaterial.jsx
@@ -19,7 +19,7 @@ import {
   constants,
 } from '@ndla/ui';
 
-import { FigureImage } from '../article/FigureImage';
+import FigureImage from '../article/FigureImage';
 import RelatedArticleListExample from '../article/RelatedArticleListExample';
 
 import { CompetenceGoalListExample } from '../organisms/CompetenceGoalsExample';

--- a/packages/ndla-notion/package.json
+++ b/packages/ndla-notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndla/notion",
-  "version": "0.2.62",
+  "version": "0.3.0",
   "description": "Notions and dictionary-notions for NDLA",
   "license": "GPL-3.0",
   "main": "lib/index.js",

--- a/packages/ndla-notion/package.json
+++ b/packages/ndla-notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndla/notion",
-  "version": "0.3.0",
+  "version": "0.2.62",
   "description": "Notions and dictionary-notions for NDLA",
   "license": "GPL-3.0",
   "main": "lib/index.js",

--- a/packages/ndla-notion/src/Notion.jsx
+++ b/packages/ndla-notion/src/Notion.jsx
@@ -77,6 +77,7 @@ Notion.propTypes = {
   ariaLabel: PropTypes.string.isRequired,
   children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   content: PropTypes.node,
+  customCSS: PropTypes.object,
 };
 
 export default Notion;

--- a/packages/ndla-notion/src/NotionDialog.js
+++ b/packages/ndla-notion/src/NotionDialog.js
@@ -176,13 +176,21 @@ export const NotionDialogStyledWrapper = styled.div`
   }
 `;
 
-const NotionDialog = ({ title, children, id, subTitle, ariaHidden }) => (
+const NotionDialog = ({
+  title,
+  children,
+  id,
+  subTitle,
+  ariaHidden,
+  customCSS,
+}) => (
   <NotionDialogStyledWrapper
     aria-hidden={ariaHidden}
     role="dialog"
     data-concept-id={id}
     aria-labelledby={id}
-    aria-describedby={id}>
+    aria-describedby={id}
+    css={customCSS}>
     <NotionHeader title={title} subTitle={subTitle} />
     <NotionBody>{children}</NotionBody>
   </NotionDialogStyledWrapper>


### PR DESCRIPTION
Grunnen til at Notion oppfører seg rart når den er brukt i article-converter er fordi den ikke legger seg i roten av editorial-frontend, men heller i roten av HTMLen som blir sendt fra article-converter. Slik Notion posisjoneres nå går den ut fra at den finnes i roten av nettsiden.

Forslaget til løsningen er å legge til en prop `customCSS` som gjør at man kan sende med custom css for NotionDialog (og andre elementer i NotionDialog). For noen av stylene som eksisterer fra før kan `!important` være nødvendig å bruke.


PR for article-converter som skal ta i bruk den oppdaterte komponenten:
https://github.com/NDLANO/article-converter/pull/217