### PR TITLE
2393 større marger i læringssti footer

### DIFF
--- a/packages/designmanual/stories/pages/LearningPathExample.jsx
+++ b/packages/designmanual/stories/pages/LearningPathExample.jsx
@@ -9,6 +9,7 @@
 import React, { useReducer, useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
+import { LearningPath } from '@ndla/icons/contentType';
 import { injectT } from '@ndla/i18n';
 import {
   LearningPathWrapper,
@@ -19,6 +20,7 @@ import {
   LearningPathSticky,
   LearningPathStickySibling,
   LearningPathMobileStepInfo,
+  showLearningPathButtonToggleCss,
 } from '@ndla/ui';
 import { getCookie, setCookie } from '@ndla/util';
 import { animations, shadows } from '@ndla/core';
@@ -118,7 +120,7 @@ const dataReducer = (state, action) => {
 const toLearningPathUrl = () => {
   return '';
 };
-const LearningPathExample = ({ invertedStyle }) => {
+const LearningPathExample = ({ invertedStyle, t }) => {
   const [currentState, dispatch] = useReducer(dataReducer, {});
   const [hideHelp, toggleHelp] = useState(true);
   const [learningPathId, updateLearningPathId] = useState(
@@ -225,6 +227,12 @@ const LearningPathExample = ({ invertedStyle }) => {
   const fetchedCookies = getCookie(cookieKey, document.cookie);
   const useCookies = fetchedCookies ? JSON.parse(fetchedCookies) : {};
   const isLastStep = currentLearningStepNumber === learningsteps.length - 1;
+  const showLearningPathButton = (
+    <Button css={showLearningPathButtonToggleCss}>
+      <LearningPath />
+      <span>{t('learningPath.openMenuTooltip')}</span>
+    </Button>
+  );
   return (
     <>
       <LearningPathWrapper invertedStyle={invertedStyle}>
@@ -246,6 +254,7 @@ const LearningPathExample = ({ invertedStyle }) => {
             name={learningStepsData.title.title}
             cookies={useCookies}
             learningPathURL="https://stier.ndla.no"
+            showLearningPathButton={showLearningPathButton}
           />
           {currentLearningStep && (
             <div>
@@ -275,6 +284,7 @@ const LearningPathExample = ({ invertedStyle }) => {
           )}
         </LearningPathContent>
         <LearningPathSticky>
+          {showLearningPathButton}
           {currentLearningStepNumber > 0 ? (
             <LearningPathStickySibling
               arrow="left"

--- a/packages/ndla-ui/src/LearningPaths/LearningPathMenu.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathMenu.tsx
@@ -104,6 +104,7 @@ interface Props {
   };
   learningPathId: number;
   toLearningPathUrl(pathId: number, stepId: number): string;
+  showLearningPathButton: Object;
 }
 
 const LearningPathMenu: React.FunctionComponent<Props & tType> = ({
@@ -119,6 +120,7 @@ const LearningPathMenu: React.FunctionComponent<Props & tType> = ({
   invertedStyle,
   cookies,
   t,
+  showLearningPathButton,
 }) => {
   const [isOpen, toggleOpenState] = useState(false);
   const { innerWidth } = useWindowSize(100);
@@ -127,7 +129,8 @@ const LearningPathMenu: React.FunctionComponent<Props & tType> = ({
     <StyledMenu isOpen={isOpen}>
       <LearningPathMenuModalWrapper
         innerWidth={innerWidth}
-        closeLabel={t('modal.closeModal')}>
+        closeLabel={t('modal.closeModal')}
+        activateButton={showLearningPathButton}>
         <>
           <div
             css={css`

--- a/packages/ndla-ui/src/LearningPaths/LearningPathMenuModalWrapper.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathMenuModalWrapper.tsx
@@ -8,30 +8,12 @@
 
 import React from 'react';
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 import { injectT, tType } from '@ndla/i18n';
 import { colors, spacing, fonts } from '@ndla/core';
 // @ts-ignore
 import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 // @ts-ignore
-import Button from '@ndla/button';
-// @ts-ignore
-import { LearningPath } from '@ndla/icons/contentType';
-// @ts-ignore
 import { LearningPathBadge } from '../index-javascript';
-
-const buttonToggleCss = css`
-  position: fixed;
-  z-index: 999;
-  bottom: ${spacing.xsmall};
-  left: ${spacing.normal};
-  svg {
-    width: 20px;
-    height: 20px;
-    margin-right: ${spacing.xsmall};
-    transform: translateY(-2px);
-  }
-`;
 
 const StyledWrapper = styled.div`
   display: flex;
@@ -49,11 +31,12 @@ const StyledMiniHeader = styled.span`
 type ModalWrapperProps = {
   innerWidth: number;
   closeLabel: string;
+  activateButton: Object;
   children: JSX.Element;
 };
 
 const ModalWrapperComponent: React.FunctionComponent<ModalWrapperProps &
-  tType> = ({ innerWidth, closeLabel, children, t }) => {
+  tType> = ({ innerWidth, closeLabel, children, t, activateButton }) => {
   if (innerWidth < 601) {
     return (
       <StyledWrapper>
@@ -62,12 +45,7 @@ const ModalWrapperComponent: React.FunctionComponent<ModalWrapperProps &
           animation="slide-up"
           animationDuration={200}
           size="fullscreen"
-          activateButton={
-            <Button css={buttonToggleCss}>
-              <LearningPath />
-              <span>Vis læringssti</span>
-            </Button>
-          }>
+          activateButton={activateButton}>
           {(onClose: Function) => (
             <>
               <ModalHeader>

--- a/packages/ndla-ui/src/LearningPaths/LearningPathSticky.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathSticky.tsx
@@ -130,3 +130,19 @@ export const LearningPathStickySibling: React.FunctionComponent<PropsSiblings> =
     {arrow === 'right' && <Forward className="c-icon--medium" />}
   </SafeLink>
 );
+
+export const showLearningPathButtonToggleCss = css`
+  ${mq.range({ from: breakpoints.tablet })} {
+    display: none;
+  }
+  position: fixed;
+  z-index: 100;
+  bottom: ${spacing.xsmall};
+  left: ${spacing.normal};
+  svg {
+    width: 20px;
+    height: 20px;
+    margin-right: ${spacing.xsmall};
+    transform: translateY(-2px);
+  }
+`;

--- a/packages/ndla-ui/src/LearningPaths/LearningPathSticky.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathSticky.tsx
@@ -30,6 +30,7 @@ const StyledFooter = styled.nav`
     left: 0;
     right: 0;
     justify-content: flex-end;
+    padding-bottom: env(safe-area-inset-bottom);
   }
   background: ${colors.brand.lighter};
   align-items: center;
@@ -53,14 +54,16 @@ const SafeLinkCSS = css`
   display: flex;
   box-shadow: none;
   align-items: center;
+  justify-content: center;
   color: ${colors.brand.primary};
   height: ${FOOTER_HEIGHT};
   ${mq.range({ until: breakpoints.tablet })} {
     height: ${FOOTER_HEIGHT_MOBILE};
+    width: ${FOOTER_HEIGHT_MOBILE};
   }
   padding: 0 ${spacing.normal} 0 ${spacing.normal};
   ${mq.range({ until: breakpoints.tablet })} {
-    padding: 0 ${spacing.small} 0 ${spacing.small};
+    padding: 0;
   }
   transition: background 200ms ease;
   > .c-icon--medium {

--- a/packages/ndla-ui/src/LearningPaths/index.ts
+++ b/packages/ndla-ui/src/LearningPaths/index.ts
@@ -21,4 +21,5 @@ export { LearningPathInformation } from './LearningPathInformation';
 export {
   LearningPathSticky,
   LearningPathStickySibling,
+  showLearningPathButtonToggleCss,
 } from './LearningPathSticky';

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -40,6 +40,7 @@ export {
   LearningPathSticky,
   LearningPathInformation,
   LearningPathStickySibling,
+  showLearningPathButtonToggleCss,
   LearningPathLastStepNavigation,
   LearningPathMobileStepInfo,
 } from './LearningPaths';


### PR DESCRIPTION
Fixes NDLANO/Issues#2393

- Lagt til safe-area padding nederst på navbaren på læringsstier på mobil, for å legge til nødvendig margin rundt iPhoner med notch (i stedet for hjemknapp).
- Flyttet "Vis læringsstier"-knappen på mobil til å ligge inni LearningPathSticky-komponenten, for at den skal følge samme oppførsel som resten av navbaren.

Med navbars i web på iPhone så er det alltid sånn at man må trykke på den en gang, sånn at navbaren til safari vises, før man får til å trykke på en knapp i den. Så sånn er det fortsatt. Men nå ligger det hvertfall ikke oppå notchen.

**Testing**
- [Designmanual](https://frontend-packages-pr-747.ndla.sh/?path=/story/sidevisninger--l%C3%A6ringssti)(skru på mobilvisning): Ser helt lik ut som før, og på iphone hvertfall forsvinner ikke navbarene til safari når man scroller, så får egentlig ikke sett annet enn at det ikke breaker det som er.

Slet med å få testet det skikkelig når jeg var linka til ndla-frontend:
- Verken emulatorer eller de ulike device-visningene i web-inspector klarer å slå ut riktig på `env(safe-area-padding-bottom)`. Så der blir det seende likt ut som det gjorde før. 
- Som jeg skrev på slack blir det dårlig rendering når jeg kjører det over mobil [(se video)](https://user-images.githubusercontent.com/55005434/105057064-2302ed80-5a75-11eb-86c7-40a5d9bae15f.mov). Men der slår den ut riktig med paddingen, så da ser man at navbaren legger seg riktig i forhold til notchen. Den rendrer på samme måte fra master også, men ikke når jeg kjører prod på mobil. 

Selve utseende på komponenten ser jo riktig ut på emulator og i web-inspector, og paddingen funker riktig på mobil, så tror egentlig det er good da😅