### PR TITLE
Add children to search item

### DIFF
--- a/packages/ndla-ui/src/SearchTypeResult/SearchItem.tsx
+++ b/packages/ndla-ui/src/SearchTypeResult/SearchItem.tsx
@@ -213,6 +213,7 @@ export type SearchItemType = {
   image: React.ReactNode | null;
   img?: { url: string; alt: string };
   labels?: string[];
+  children?: React.ReactNode;
 };
 type Props = {
   item: SearchItemType;
@@ -271,6 +272,7 @@ const SearchItem = ({ item, type, t }: Props & tType) => {
           <ItemTitle>
             <SafeLink to={url}>{title}</SafeLink>
           </ItemTitle>
+          {item.children}
           <ItemText>{parse(ingress)}</ItemText>
           {mainContext && <Breadcrumb breadcrumb={mainContext.breadcrumb} />}
           {contexts.length > 1 && (


### PR DESCRIPTION
Gir mulighet til å legge til et element mellom tittel og tekst i SearchItem. Er tenkt til å brukes for å legge til en 'Sett inn' knapp for LTI.

Har ikke fått testet hvordan det ser ut i /lti på grunn av yarn link problemer, men det fungerer fint i /search. 