### PR TITLE
nye oppdateringer til læringssti footer

### DIFF
--- a/packages/designmanual/stories/pages/LearningPathExample.jsx
+++ b/packages/designmanual/stories/pages/LearningPathExample.jsx
@@ -20,6 +20,7 @@ import {
   LearningPathStickySibling,
   LearningPathMobileStepInfo,
   LearningPathMobileHeader,
+  LearningPathStickyPlaceholder,
 } from '@ndla/ui';
 import { getCookie, setCookie } from '@ndla/util';
 import { animations, shadows } from '@ndla/core';
@@ -292,13 +293,13 @@ const LearningPathExample = ({ invertedStyle, t }) => {
               title={learningsteps[currentLearningStepNumber - 1].title.title}
             />
           ) : (
-            <div />
+            <LearningPathStickyPlaceholder />
           )}
           <LearningPathMobileStepInfo
             total={learningsteps.length}
             current={currentLearningStepNumber + 1}
           />
-          {currentLearningStepNumber < learningsteps.length - 1 && (
+          {currentLearningStepNumber < learningsteps.length - 1 ? (
             <LearningPathStickySibling
               arrow="right"
               toLearningPathUrl={toLearningPathUrl}
@@ -306,6 +307,8 @@ const LearningPathExample = ({ invertedStyle, t }) => {
               stepId={learningsteps[currentLearningStepNumber + 1].id}
               title={learningsteps[currentLearningStepNumber + 1].title.title}
             />
+          ) : (
+            <LearningPathStickyPlaceholder />
           )}
         </LearningPathSticky>
       </LearningPathWrapper>

--- a/packages/designmanual/stories/pages/LearningPathExample.jsx
+++ b/packages/designmanual/stories/pages/LearningPathExample.jsx
@@ -9,7 +9,6 @@
 import React, { useReducer, useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
-import { LearningPath } from '@ndla/icons/contentType';
 import { injectT } from '@ndla/i18n';
 import {
   LearningPathWrapper,
@@ -20,13 +19,13 @@ import {
   LearningPathSticky,
   LearningPathStickySibling,
   LearningPathMobileStepInfo,
-  showLearningPathButtonToggleCss,
+  LearningPathMobileHeader,
 } from '@ndla/ui';
 import { getCookie, setCookie } from '@ndla/util';
 import { animations, shadows } from '@ndla/core';
 import Button from '@ndla/button';
 import { Cross } from '@ndla/icons/action';
-
+import { useWindowSize } from '@ndla/hooks';
 import Resources from '../molecules/resources';
 import ArticleLoader from '../article/ArticleLoader';
 import Breadcrumb from '../molecules/breadcrumbs';
@@ -198,6 +197,9 @@ const LearningPathExample = ({ invertedStyle, t }) => {
     fetchLearningSteps({ learningPathId });
   }, [learningPathId]);
 
+  const { innerWidth } = useWindowSize(100);
+  const mobileView = innerWidth < 601;
+
   if (!learningStepsData || currentLearningStepNumber === undefined) {
     return null;
   }
@@ -227,11 +229,20 @@ const LearningPathExample = ({ invertedStyle, t }) => {
   const fetchedCookies = getCookie(cookieKey, document.cookie);
   const useCookies = fetchedCookies ? JSON.parse(fetchedCookies) : {};
   const isLastStep = currentLearningStepNumber === learningsteps.length - 1;
-  const showLearningPathButton = (
-    <Button css={showLearningPathButtonToggleCss}>
-      <LearningPath />
-      <span>{t('learningPath.openMenuTooltip')}</span>
-    </Button>
+  const learningPathMenu = (
+    <LearningPathMenu
+      invertedStyle={invertedStyle}
+      learningsteps={mappedLearningsteps}
+      duration={duration}
+      lastUpdated={lastUpdatedString}
+      copyright={copyright}
+      learningPathId={3}
+      toLearningPathUrl={toLearningPathUrl}
+      currentIndex={currentLearningStepNumber}
+      name={learningStepsData.title.title}
+      cookies={useCookies}
+      learningPathURL="https://stier.ndla.no"
+    />
   );
   return (
     <>
@@ -242,20 +253,7 @@ const LearningPathExample = ({ invertedStyle, t }) => {
           </section>
         </div>
         <LearningPathContent>
-          <LearningPathMenu
-            invertedStyle={invertedStyle}
-            learningsteps={mappedLearningsteps}
-            duration={duration}
-            lastUpdated={lastUpdatedString}
-            copyright={copyright}
-            learningPathId={3}
-            toLearningPathUrl={toLearningPathUrl}
-            currentIndex={currentLearningStepNumber}
-            name={learningStepsData.title.title}
-            cookies={useCookies}
-            learningPathURL="https://stier.ndla.no"
-            showLearningPathButton={showLearningPathButton}
-          />
+          {mobileView ? <LearningPathMobileHeader /> : learningPathMenu}
           {currentLearningStep && (
             <div>
               {currentLearningStep.showTitle && (
@@ -284,7 +282,7 @@ const LearningPathExample = ({ invertedStyle, t }) => {
           )}
         </LearningPathContent>
         <LearningPathSticky>
-          {showLearningPathButton}
+          {mobileView && learningPathMenu}
           {currentLearningStepNumber > 0 ? (
             <LearningPathStickySibling
               arrow="left"

--- a/packages/ndla-ui/src/LearningPaths/LearningPathMenu.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathMenu.tsx
@@ -29,12 +29,12 @@ type StyledMenuProps = {
 
 const StyledMenu = styled.div<StyledMenuProps>`
   width: 100%;
-  flex-shrink: 0;
-  transition: all 200ms ease;
-  margin-bottom: ${spacing.large};
   ${mq.range({ from: breakpoints.tablet })} {
+    flex-shrink: 0;
+    transition: all 200ms ease;
     max-width: ${SIDE_NAV_WIDTH};
     width: ${SIDE_NAV_WIDTH};
+    margin-bottom: ${spacing.large};
   }
   ${mq.range({ from: breakpoints.tablet, until: breakpoints.desktop })} {
     min-width: ${SIDE_NAV_WIDTH};
@@ -120,17 +120,13 @@ const LearningPathMenu: React.FunctionComponent<Props & tType> = ({
   invertedStyle,
   cookies,
   t,
-  showLearningPathButton,
 }) => {
   const [isOpen, toggleOpenState] = useState(false);
   const { innerWidth } = useWindowSize(100);
 
   return (
     <StyledMenu isOpen={isOpen}>
-      <LearningPathMenuModalWrapper
-        innerWidth={innerWidth}
-        closeLabel={t('modal.closeModal')}
-        activateButton={showLearningPathButton}>
+      <LearningPathMenuModalWrapper innerWidth={innerWidth}>
         <>
           <div
             css={css`

--- a/packages/ndla-ui/src/LearningPaths/LearningPathMenuModalWrapper.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathMenuModalWrapper.tsx
@@ -7,61 +7,63 @@
  */
 
 import React from 'react';
-import styled from '@emotion/styled';
 import { injectT, tType } from '@ndla/i18n';
-import { colors, spacing, fonts } from '@ndla/core';
+import { spacing, mq, breakpoints } from '@ndla/core';
 // @ts-ignore
 import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
+import { css } from '@emotion/core';
 // @ts-ignore
-import { LearningPathBadge } from '../index-javascript';
+import Button from '@ndla/button';
+// @ts-ignore
+import { LearningPath } from '@ndla/icons/contentType';
 
-const StyledWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  margin: 0 -${spacing.normal} ${spacing.medium};
-  background: ${colors.brand.lighter};
-  padding: ${spacing.small} ${spacing.normal};
-`;
-
-const StyledMiniHeader = styled.span`
-  padding-left: ${spacing.xsmall};
-  ${fonts.sizes(16, 1.1)};
+const buttonToggleCss = css`
+  ${mq.range({ from: breakpoints.tablet })} {
+    display: none;
+  }
+  margin-right: auto;
+  margin-left: ${spacing.normal};
+  z-index: 100;
+  svg {
+    width: 20px;
+    height: 20px;
+    margin-right: ${spacing.xsmall};
+    transform: translateY(-2px);
+  }
 `;
 
 type ModalWrapperProps = {
   innerWidth: number;
-  closeLabel: string;
-  activateButton: Object;
   children: JSX.Element;
 };
 
 const ModalWrapperComponent: React.FunctionComponent<ModalWrapperProps &
-  tType> = ({ innerWidth, closeLabel, children, t, activateButton }) => {
+  tType> = ({ innerWidth, children, t }) => {
   if (innerWidth < 601) {
     return (
-      <StyledWrapper>
-        <Modal
-          backgroundColor="grey"
-          animation="slide-up"
-          animationDuration={200}
-          size="fullscreen"
-          activateButton={activateButton}>
-          {(onClose: Function) => (
-            <>
-              <ModalHeader>
-                <ModalCloseButton title={closeLabel} onClick={onClose} />
-              </ModalHeader>
-              <ModalBody>{children}</ModalBody>
-            </>
-          )}
-        </Modal>
-        <div>
-          <LearningPathBadge size="xx-small" background />
-          <StyledMiniHeader>
-            {t('learningPath.youAreInALearningPath')}
-          </StyledMiniHeader>
-        </div>
-      </StyledWrapper>
+      <Modal
+        backgroundColor="grey"
+        animation="slide-up"
+        animationDuration={200}
+        size="fullscreen"
+        activateButton={
+          <Button css={buttonToggleCss}>
+            <LearningPath />
+            <span>{t('learningPath.openMenuTooltip')}</span>
+          </Button>
+        }>
+        {(onClose: Function) => (
+          <>
+            <ModalHeader>
+              <ModalCloseButton
+                title={t('modal.closeModal')}
+                onClick={onClose}
+              />
+            </ModalHeader>
+            <ModalBody>{children}</ModalBody>
+          </>
+        )}
+      </Modal>
     );
   }
   return children;

--- a/packages/ndla-ui/src/LearningPaths/LearningPathMobileHeader.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathMobileHeader.tsx
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import styled from '@emotion/styled';
 import { colors, fonts, spacing } from '@ndla/core';
 import React from 'react';

--- a/packages/ndla-ui/src/LearningPaths/LearningPathMobileHeader.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathMobileHeader.tsx
@@ -1,0 +1,30 @@
+import styled from '@emotion/styled';
+import { colors, fonts, spacing } from '@ndla/core';
+import React from 'react';
+import { injectT, tType } from '@ndla/i18n';
+// @ts-ignore
+import { LearningPathBadge } from '../index-javascript';
+
+const StyledWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  margin: 0 -${spacing.normal} ${spacing.medium};
+  background: ${colors.brand.lighter};
+  padding: ${spacing.small} ${spacing.normal};
+`;
+
+const StyledMiniHeader = styled.span`
+  padding-left: ${spacing.xsmall};
+  ${fonts.sizes(16, 1.1)};
+`;
+
+const LearningPathMobileHeader: React.FunctionComponent<tType> = ({ t }) => (
+  <StyledWrapper>
+    <LearningPathBadge size="xx-small" background />
+    <StyledMiniHeader>
+      {t('learningPath.youAreInALearningPath')}
+    </StyledMiniHeader>
+  </StyledWrapper>
+);
+
+export default injectT(LearningPathMobileHeader);

--- a/packages/ndla-ui/src/LearningPaths/LearningPathMobileStepInfo.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathMobileStepInfo.tsx
@@ -13,6 +13,7 @@ import { injectT, tType } from '@ndla/i18n';
 
 const StyledInfo = styled.div`
   ${typography.smallHeading}
+  white-space: nowrap;
   ${mq.range({ from: breakpoints.tablet })} {
     display: none;
   }

--- a/packages/ndla-ui/src/LearningPaths/LearningPathSticky.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathSticky.tsx
@@ -137,5 +137,5 @@ export const LearningPathStickySibling: React.FunctionComponent<PropsSiblings> =
 );
 
 export const LearningPathStickyPlaceholder: React.FunctionComponent = () => (
-    <div css={SafeLinkCSS} />
-)
+  <div css={SafeLinkCSS} />
+);

--- a/packages/ndla-ui/src/LearningPaths/LearningPathSticky.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathSticky.tsx
@@ -25,6 +25,7 @@ const StyledFooter = styled.nav`
   ${mq.range({ until: breakpoints.tablet })} {
     --safe-area-inset-bottom: env(safe-area-inset-bottom);
     height: calc(${FOOTER_HEIGHT_MOBILE} + var(--safe-area-inset-bottom));
+    min-height: var(-webkit-fill-available);
     position: fixed;
     z-index: 2;
     bottom: 0;
@@ -134,3 +135,7 @@ export const LearningPathStickySibling: React.FunctionComponent<PropsSiblings> =
     {arrow === 'right' && <Forward className="c-icon--medium" />}
   </SafeLink>
 );
+
+export const LearningPathStickyPlaceholder: React.FunctionComponent = () => (
+    <div css={SafeLinkCSS} />
+)

--- a/packages/ndla-ui/src/LearningPaths/LearningPathSticky.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathSticky.tsx
@@ -23,7 +23,8 @@ const StyledFooter = styled.nav`
   height: ${FOOTER_HEIGHT};
   width: 100%;
   ${mq.range({ until: breakpoints.tablet })} {
-    height: ${FOOTER_HEIGHT_MOBILE};
+    --safe-area-inset-bottom: env(safe-area-inset-bottom);
+    height: calc(${FOOTER_HEIGHT_MOBILE} + var(--safe-area-inset-bottom));
     position: fixed;
     z-index: 2;
     bottom: 0;
@@ -133,19 +134,3 @@ export const LearningPathStickySibling: React.FunctionComponent<PropsSiblings> =
     {arrow === 'right' && <Forward className="c-icon--medium" />}
   </SafeLink>
 );
-
-export const showLearningPathButtonToggleCss = css`
-  ${mq.range({ from: breakpoints.tablet })} {
-    display: none;
-  }
-  position: fixed;
-  z-index: 100;
-  bottom: ${spacing.xsmall};
-  left: ${spacing.normal};
-  svg {
-    width: 20px;
-    height: 20px;
-    margin-right: ${spacing.xsmall};
-    transform: translateY(-2px);
-  }
-`;

--- a/packages/ndla-ui/src/LearningPaths/index.ts
+++ b/packages/ndla-ui/src/LearningPaths/index.ts
@@ -22,5 +22,6 @@ export { LearningPathInformation } from './LearningPathInformation';
 export {
   LearningPathSticky,
   LearningPathStickySibling,
+  LearningPathStickyPlaceholder,
 } from './LearningPathSticky';
 export { LearningPathMobileHeader };

--- a/packages/ndla-ui/src/LearningPaths/index.ts
+++ b/packages/ndla-ui/src/LearningPaths/index.ts
@@ -9,6 +9,7 @@
 import LearningPathMenu from './LearningPathMenu';
 import LearningPathLastStepNavigation from './LearningPathLastStepNavigation';
 import LearningPathMobileStepInfo from './LearningPathMobileStepInfo';
+import LearningPathMobileHeader from './LearningPathMobileHeader';
 
 export { LearningPathWrapper } from './LearningPathWrapper';
 export { LearningPathContent } from './LearningPathContent';
@@ -21,5 +22,5 @@ export { LearningPathInformation } from './LearningPathInformation';
 export {
   LearningPathSticky,
   LearningPathStickySibling,
-  showLearningPathButtonToggleCss,
 } from './LearningPathSticky';
+export { LearningPathMobileHeader };

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -40,6 +40,7 @@ export {
   LearningPathSticky,
   LearningPathInformation,
   LearningPathStickySibling,
+  LearningPathStickyPlaceholder,
   LearningPathLastStepNavigation,
   LearningPathMobileStepInfo,
   LearningPathMobileHeader,

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -40,9 +40,9 @@ export {
   LearningPathSticky,
   LearningPathInformation,
   LearningPathStickySibling,
-  showLearningPathButtonToggleCss,
   LearningPathLastStepNavigation,
   LearningPathMobileStepInfo,
+  LearningPathMobileHeader,
 } from './LearningPaths';
 
 export { default as SearchResultSleeve } from './Search/SearchResultSleeve';


### PR DESCRIPTION
For NDLANO/ndla-frontend#618

- Endret slik at høyden på footeren følger safe-area også, sånn at ikke pilene skal legge seg rart
- De endringene jeg hadde gjort for å få knappen som aktiverer læringsstimodalen til å plassere seg riktig funket ikke, så jeg måtte omstrukturere litt for å få den til å bli en del av footeren på riktig måte.

Testes i designmanualen: https://frontend-packages-pr-749.ndla.sh/?path=/story/sidevisninger--l%C3%A6ringssti

Igjen må det inn i now-deployment på ndla-frontend for å være sikker på at pilene og knappen legger seg riktig, men jeg lagde lokale wrappers med samme css som her som jeg testet direkte i pr-en i ndla-frontend, og der kan man se at footeren oppfører seg riktig (https://ndla-frontend-pr-618.ndla.sh/nn/subject:19/topic:1:186579/topic:1:187897/resource:1:151647/5578?filters=urn:filter:8bbcfdcb-2edc-4fc0-b8a4-f342514b9f20)