### PR TITLE
2410 inline visning av pdf i artikkel

### DIFF
--- a/packages/designmanual/stories/produksjonssystem/FileListEditorExample.jsx
+++ b/packages/designmanual/stories/produksjonssystem/FileListEditorExample.jsx
@@ -18,44 +18,42 @@ class StructureExample extends Component {
           path: 'http://www.exampleurl1.com',
           title: 'Filename',
           type: 'pdf',
-          renderInline: true,
+          'render-inline': 'true',
         },
         {
           path: 'http://www.exampleurl2.com',
           title: 'Filename 2',
           type: 'pdf',
-          renderInline: false,
         },
         {
           path: 'http://www.exampleurl3.com',
           title: 'Filename 3',
           type: 'pdf',
-          renderInline: false,
+          'render-inline': 'false',
         },
         {
           path: 'http://www.exampleurl4.com',
           title: 'Filename 4',
           type: 'txt',
-          renderInline: false,
+          'render-inline': 'false',
         },
         {
           path: 'http://www.exampleurl5.com',
           title: 'Filename 5',
           type: 'txt',
-          renderInline: false,
         },
         {
           path: 'http://www.exampleurl6.com',
           title: 'Filename 6',
           type: 'txt',
-          renderInline: false,
+          'render-inline': 'false',
         },
       ],
     };
     this.onUpdateFileName = this.onUpdateFileName.bind(this);
     this.onMovedFile = this.onMovedFile.bind(this);
     this.onDeleteFile = this.onDeleteFile.bind(this);
-    this.toggleInlineRender = this.toggleInlineRender.bind(this);
+    this.onToggleRenderInline = this.onToggleRenderInline.bind(this);
   }
 
   onMovedFile(from, to) {
@@ -85,25 +83,29 @@ class StructureExample extends Component {
     }));
   }
 
-  toggleInlineRender(index) {
+  onToggleRenderInline(index) {
     this.setState(prevState => ({
-      addedFiles: prevState.addedFiles.map((file, i) =>
-        i === index ? { ...file, renderInline: !file.renderInline } : file,
-      ),
+      addedFiles: prevState.addedFiles.map((file, i) => {
+        return i === index
+          ? {
+              ...file,
+              'render-inline': (!(file['render-inline'] === 'true')).toString(),
+            }
+          : file;
+      }),
     }));
   }
 
   render() {
     const { addedFiles } = this.state;
-
     return (
       <FileListEditor
         files={addedFiles}
         onEditFileName={this.onUpdateFileName}
         onMovedFile={this.onMovedFile}
         onDeleteFile={this.onDeleteFile}
-        showCheckboxes={true}
-        toggleCheckbox={this.toggleInlineRender}
+        onToggleRenderInline={this.onToggleRenderInline}
+        showRenderInlineCheckbox={true}
         messages={{
           placeholder: 'Oppgi et filnavn',
           changeName: 'Endre navn',

--- a/packages/designmanual/stories/produksjonssystem/FileListEditorExample.jsx
+++ b/packages/designmanual/stories/produksjonssystem/FileListEditorExample.jsx
@@ -98,6 +98,7 @@ class StructureExample extends Component {
 
   render() {
     const { addedFiles } = this.state;
+    const { withCheckboxes } = this.props;
     return (
       <FileListEditor
         files={addedFiles}
@@ -105,7 +106,7 @@ class StructureExample extends Component {
         onMovedFile={this.onMovedFile}
         onDeleteFile={this.onDeleteFile}
         onToggleRenderInline={this.onToggleRenderInline}
-        showRenderInlineCheckbox={true}
+        showRenderInlineCheckbox={withCheckboxes}
         messages={{
           placeholder: 'Oppgi et filnavn',
           changeName: 'Endre navn',

--- a/packages/designmanual/stories/produksjonssystem/FileListEditorExample.jsx
+++ b/packages/designmanual/stories/produksjonssystem/FileListEditorExample.jsx
@@ -134,8 +134,8 @@ class StructureExample extends Component {
           missingFileTooltip:
             'Ser ikke ut til å eksistere på serveren. Den kan ha blitt slettet fra en annen artikkel.',
           missingTitle: '[Mangler filnavn]',
-          renderInlineLabel: 'Vis PDF',
-          renderInlineTooltip: 'Forhåndsvis PDF i artikkel',
+          checkboxLabel: 'Vis PDF',
+          checkboxTooltip: 'Forhåndsvis PDF i artikkel',
         }}
       />
     );

--- a/packages/designmanual/stories/produksjonssystem/FileListEditorExample.jsx
+++ b/packages/designmanual/stories/produksjonssystem/FileListEditorExample.jsx
@@ -42,24 +42,24 @@ class StructureExample extends Component {
           path: 'http://www.exampleurl1.com',
           title: 'Filename',
           type: 'pdf',
-          'render-inline': 'true',
+          display: 'block',
         },
         {
           path: 'http://www.exampleurl2.com',
           title: 'Filename 2',
           type: 'pdf',
+          display: 'inline',
         },
         {
           path: 'http://www.exampleurl3.com',
           title: 'Filename 3',
           type: 'pdf',
-          'render-inline': 'false',
+          display: 'block',
         },
         {
           path: 'http://www.exampleurl4.com',
           title: 'Filename 4',
           type: 'txt',
-          'render-inline': 'false',
         },
         {
           path: 'http://www.exampleurl5.com',
@@ -70,7 +70,6 @@ class StructureExample extends Component {
           path: 'http://www.exampleurl6.com',
           title: 'Filename 6',
           type: 'txt',
-          'render-inline': 'false',
         },
       ],
     };
@@ -109,7 +108,7 @@ class StructureExample extends Component {
         return i === index
           ? {
               ...file,
-              'render-inline': (!(file['render-inline'] === 'true')).toString(),
+              display: file.display === 'block' ? 'inline' : 'block',
             }
           : file;
       }),

--- a/packages/designmanual/stories/produksjonssystem/FileListEditorExample.jsx
+++ b/packages/designmanual/stories/produksjonssystem/FileListEditorExample.jsx
@@ -9,6 +9,30 @@
 import React, { Component } from 'react';
 import { FileListEditor } from '@ndla/editor';
 
+export function arrMove(array, fromIndex, toIndex) {
+  const item = array[fromIndex];
+  const length = array.length;
+  const diff = fromIndex - toIndex;
+
+  if (diff > 0) {
+    return [
+      ...array.slice(0, toIndex),
+      item,
+      ...array.slice(toIndex, fromIndex),
+      ...array.slice(fromIndex + 1, length),
+    ];
+  } else if (diff < 0) {
+    const targetIndex = toIndex + 1;
+    return [
+      ...array.slice(0, fromIndex),
+      ...array.slice(fromIndex + 1, targetIndex),
+      item,
+      ...array.slice(targetIndex, length),
+    ];
+  }
+  return array;
+}
+
 class StructureExample extends Component {
   constructor(props) {
     super(props);
@@ -57,12 +81,8 @@ class StructureExample extends Component {
   }
 
   onMovedFile(from, to) {
-    this.setState(({ addedFiles }) => ({
-      addedFiles: addedFiles.map((file, i) => {
-        if (i === from) return addedFiles[to];
-        if (i === to) return addedFiles[from];
-        return file;
-      }),
+    this.setState(prevState => ({
+      addedFiles: arrMove(prevState.addedFiles, from, to),
     }));
   }
 

--- a/packages/designmanual/stories/produksjonssystem/FileListEditorExample.jsx
+++ b/packages/designmanual/stories/produksjonssystem/FileListEditorExample.jsx
@@ -18,37 +18,44 @@ class StructureExample extends Component {
           path: 'http://www.exampleurl1.com',
           title: 'Filename',
           type: 'pdf',
+          renderInline: true,
         },
         {
           path: 'http://www.exampleurl2.com',
           title: 'Filename 2',
           type: 'pdf',
+          renderInline: false,
         },
         {
           path: 'http://www.exampleurl3.com',
           title: 'Filename 3',
           type: 'pdf',
+          renderInline: false,
         },
         {
           path: 'http://www.exampleurl4.com',
           title: 'Filename 4',
-          type: 'pdf',
+          type: 'txt',
+          renderInline: false,
         },
         {
           path: 'http://www.exampleurl5.com',
           title: 'Filename 5',
-          type: 'pdf',
+          type: 'txt',
+          renderInline: false,
         },
         {
           path: 'http://www.exampleurl6.com',
           title: 'Filename 6',
-          type: 'pdf',
+          type: 'txt',
+          renderInline: false,
         },
       ],
     };
     this.onUpdateFileName = this.onUpdateFileName.bind(this);
     this.onMovedFile = this.onMovedFile.bind(this);
     this.onDeleteFile = this.onDeleteFile.bind(this);
+    this.toggleInlineRender = this.toggleInlineRender.bind(this);
   }
 
   onMovedFile(from, to) {
@@ -78,6 +85,14 @@ class StructureExample extends Component {
     }));
   }
 
+  toggleInlineRender(index) {
+    this.setState(prevState => ({
+      addedFiles: prevState.addedFiles.map((file, i) =>
+        i === index ? { ...file, renderInline: !file.renderInline } : file,
+      ),
+    }));
+  }
+
   render() {
     const { addedFiles } = this.state;
 
@@ -87,6 +102,8 @@ class StructureExample extends Component {
         onEditFileName={this.onUpdateFileName}
         onMovedFile={this.onMovedFile}
         onDeleteFile={this.onDeleteFile}
+        showCheckboxes={true}
+        toggleCheckbox={this.toggleInlineRender}
         messages={{
           placeholder: 'Oppgi et filnavn',
           changeName: 'Endre navn',
@@ -95,6 +112,8 @@ class StructureExample extends Component {
           missingFileTooltip:
             'Ser ikke ut til å eksistere på serveren. Den kan ha blitt slettet fra en annen artikkel.',
           missingTitle: '[Mangler filnavn]',
+          renderInlineLabel: 'Vis PDF',
+          renderInlineTooltip: 'Forhåndsvis PDF i artikkel',
         }}
       />
     );

--- a/packages/designmanual/stories/produksjonssystem/FileListEditorExample.jsx
+++ b/packages/designmanual/stories/produksjonssystem/FileListEditorExample.jsx
@@ -134,8 +134,8 @@ class StructureExample extends Component {
           missingFileTooltip:
             'Ser ikke ut til å eksistere på serveren. Den kan ha blitt slettet fra en annen artikkel.',
           missingTitle: '[Mangler filnavn]',
-          checkboxLabel: 'Vis PDF',
-          checkboxTooltip: 'Forhåndsvis PDF i artikkel',
+          checkboxLabel: 'Vis ekspandert',
+          checkboxTooltip: 'Vis PDF ekspandert i artikkel',
         }}
       />
     );

--- a/packages/designmanual/stories/produksjonssystem/FileListEditorExample.jsx
+++ b/packages/designmanual/stories/produksjonssystem/FileListEditorExample.jsx
@@ -135,7 +135,7 @@ class StructureExample extends Component {
             'Ser ikke ut til å eksistere på serveren. Den kan ha blitt slettet fra en annen artikkel.',
           missingTitle: '[Mangler filnavn]',
           checkboxLabel: 'Vis ekspandert',
-          checkboxTooltip: 'Vis PDF ekspandert i artikkel',
+          checkboxTooltip: 'Vis ekspandert PDF i artikkel',
         }}
       />
     );

--- a/packages/designmanual/stories/produksjonssystem/index.js
+++ b/packages/designmanual/stories/produksjonssystem/index.js
@@ -187,6 +187,10 @@ storiesOf('Produksjonssystem', module)
       <StoryBody>
         <FileListEditorExample />
       </StoryBody>
+      <StoryBody>
+        <h1>Med markering av pdf-filer:</h1>
+        <FileListEditorExample withCheckboxes />
+      </StoryBody>
     </div>
   ))
   .add('How-to', () => (

--- a/packages/ndla-editor/src/FileListEditor.js
+++ b/packages/ndla-editor/src/FileListEditor.js
@@ -283,7 +283,7 @@ class FileListEditor extends Component {
                 <Tooltip tooltip={messages.renderInlineTooltip}>
                   <CheckboxItem
                     label="Vis PDF"
-                    checked={file['render-inline'] === 'true'}
+                    checked={file.display === 'block'}
                     value=""
                     id={index}
                     onChange={i => onToggleRenderInline(i)}

--- a/packages/ndla-editor/src/FileListEditor.js
+++ b/packages/ndla-editor/src/FileListEditor.js
@@ -280,9 +280,9 @@ class FileListEditor extends Component {
                 onBlur={this.exitEditFileName}
               />
               {showRenderInlineCheckbox && file.type === 'pdf' && (
-                <Tooltip tooltip={messages.renderInlineTooltip}>
+                <Tooltip tooltip={messages.checkboxTooltip}>
                   <CheckboxItem
-                    label="Vis PDF"
+                    label={messages.checkboxLabel}
                     checked={file.display === 'block'}
                     value=""
                     id={index}

--- a/packages/ndla-editor/src/FileListEditor.js
+++ b/packages/ndla-editor/src/FileListEditor.js
@@ -91,6 +91,12 @@ const fadeOutAnimation = css`
   ${animations.fadeOut()}
 `;
 
+const StyledInputCheckbox = styled.input`
+  appearance: checkbox !important;
+  margin-right: ${spacing.small};
+  width: auto;
+`;
+
 class FileListEditor extends Component {
   constructor(props) {
     super(props);
@@ -232,6 +238,8 @@ class FileListEditor extends Component {
       usePortal,
       messages,
       missingFilePaths,
+      showCheckboxes,
+      toggleCheckbox,
     } = this.props;
     const { editFileIndex, draggingIndex, deleteIndex } = this.state;
 
@@ -273,6 +281,16 @@ class FileListEditor extends Component {
                 }}
                 onBlur={this.exitEditFileName}
               />
+              {showCheckboxes && file.type === 'pdf' && (
+                <Tooltip tooltip={messages.renderInlineTooltip}>
+                  <StyledInputCheckbox
+                    type="checkbox"
+                    checked={file.renderInline}
+                    onChange={() => toggleCheckbox(index)}
+                  />
+                  {messages.renderInlineLabel}
+                </Tooltip>
+              )}
               <div>
                 <Tooltip tooltip={messages.changeName}>
                   <ButtonIcons
@@ -332,9 +350,11 @@ FileListEditor.propTypes = {
   ),
   missingFilePaths: PropTypes.arrayOf(PropTypes.string),
   sortable: PropTypes.bool,
+  showCheckboxes: PropTypes.bool,
   onEditFileName: PropTypes.func.isRequired,
   onDeleteFile: PropTypes.func.isRequired,
   onMovedFile: PropTypes.func.isRequired,
+  toggleCheckbox: PropTypes.func,
   usePortal: PropTypes.bool,
 };
 

--- a/packages/ndla-editor/src/FileListEditor.js
+++ b/packages/ndla-editor/src/FileListEditor.js
@@ -14,6 +14,7 @@ import Tooltip from '@ndla/tooltip';
 import { DragHorizontal, DeleteForever } from '@ndla/icons/editor';
 import { Pencil } from '@ndla/icons/action';
 import { spacing, fonts, colors, shadows, animations } from '@ndla/core';
+import { CheckboxItem } from '@ndla/forms';
 import FileNameInput from './FileNameInput';
 
 const FILE_HEIGHT = 69;
@@ -89,12 +90,6 @@ const ButtonIcons = styled.button`
 
 const fadeOutAnimation = css`
   ${animations.fadeOut()}
-`;
-
-const StyledInputCheckbox = styled.input`
-  appearance: checkbox !important;
-  margin-right: ${spacing.small};
-  width: auto;
 `;
 
 class FileListEditor extends Component {
@@ -238,8 +233,8 @@ class FileListEditor extends Component {
       usePortal,
       messages,
       missingFilePaths,
-      showCheckboxes,
-      toggleCheckbox,
+      showRenderInlineCheckbox,
+      onToggleRenderInline,
     } = this.props;
     const { editFileIndex, draggingIndex, deleteIndex } = this.state;
 
@@ -281,14 +276,15 @@ class FileListEditor extends Component {
                 }}
                 onBlur={this.exitEditFileName}
               />
-              {showCheckboxes && file.type === 'pdf' && (
+              {showRenderInlineCheckbox && file.type === 'pdf' && (
                 <Tooltip tooltip={messages.renderInlineTooltip}>
-                  <StyledInputCheckbox
-                    type="checkbox"
-                    checked={file.renderInline}
-                    onChange={() => toggleCheckbox(index)}
+                  <CheckboxItem
+                    label="Vis PDF"
+                    checked={file['render-inline'] === 'true'}
+                    value=""
+                    id={index}
+                    onChange={i => onToggleRenderInline(i)}
                   />
-                  {messages.renderInlineLabel}
                 </Tooltip>
               )}
               <div>
@@ -350,11 +346,11 @@ FileListEditor.propTypes = {
   ),
   missingFilePaths: PropTypes.arrayOf(PropTypes.string),
   sortable: PropTypes.bool,
-  showCheckboxes: PropTypes.bool,
+  showRenderInlineCheckbox: PropTypes.bool,
   onEditFileName: PropTypes.func.isRequired,
   onDeleteFile: PropTypes.func.isRequired,
   onMovedFile: PropTypes.func.isRequired,
-  toggleCheckbox: PropTypes.func,
+  onToggleRenderInline: PropTypes.func,
   usePortal: PropTypes.bool,
 };
 

--- a/packages/ndla-editor/src/FileListEditor.js
+++ b/packages/ndla-editor/src/FileListEditor.js
@@ -38,6 +38,9 @@ const fileCss = css`
     align-items: center;
     padding: 0 ${spacing.small} 0 calc(${spacing.small} + ${spacing.xsmall});
     &:first-of-type {
+      flex-basis: 0;
+      flex-shrink: 1;
+      min-width: 0;
       flex-grow: 1;
     }
     svg {
@@ -90,6 +93,12 @@ const ButtonIcons = styled.button`
 
 const fadeOutAnimation = css`
   ${animations.fadeOut()}
+`;
+
+const checkboxStyle = css`
+  label > span {
+    white-space: nowrap;
+  }
 `;
 
 class FileListEditor extends Component {
@@ -280,7 +289,7 @@ class FileListEditor extends Component {
                 onBlur={this.exitEditFileName}
               />
               {showRenderInlineCheckbox && file.type === 'pdf' && (
-                <Tooltip tooltip={messages.checkboxTooltip}>
+                <Tooltip css={checkboxStyle} tooltip={messages.checkboxTooltip}>
                   <CheckboxItem
                     label={messages.checkboxLabel}
                     checked={file.display === 'block'}

--- a/packages/ndla-editor/src/FileListEditor.js
+++ b/packages/ndla-editor/src/FileListEditor.js
@@ -185,7 +185,10 @@ class FileListEditor extends Component {
     window.removeEventListener('mousemove', this.onDragging);
     window.removeEventListener('mouseup', this.onDragEnd);
 
-    this.props.onMovedFile(this.initialPosition, this.state.draggingIndex);
+    if (this.state.draggingIndex !== -1) {
+      this.props.onMovedFile(this.initialPosition, this.state.draggingIndex);
+    }
+
     this.setState({
       draggingIndex: -1,
     });

--- a/packages/ndla-editor/src/FileListEditor.js
+++ b/packages/ndla-editor/src/FileListEditor.js
@@ -36,12 +36,16 @@ const fileCss = css`
   > div {
     display: flex;
     align-items: center;
-    padding: 0 ${spacing.small} 0 calc(${spacing.small} + ${spacing.xsmall});
+    padding: 0 ${spacing.small} 0 ${spacing.small};
     &:first-of-type {
       flex-basis: 0;
       flex-shrink: 1;
       min-width: 0;
       flex-grow: 1;
+      padding-left: calc(${spacing.small} + ${spacing.xsmall});
+    }
+    &:last-of-type {
+      padding-left: ${spacing.xsmall};
     }
     svg {
       width: 18px;

--- a/packages/ndla-editor/src/FileNameInput.js
+++ b/packages/ndla-editor/src/FileNameInput.js
@@ -69,11 +69,18 @@ const getButtonComponent = (file, isMissing, messages) => {
     );
   } else {
     return (
-      <LinkButton type="button" onClick={() => window.open(file.url)}>
-        {file.title === '' ? messages.missingTitle : file.title}
-        {` `}
-        <span>({file.type})</span>
-      </LinkButton>
+      <div
+        css={css`
+          max-width: 100%;
+        `}>
+        <Tooltip tooltip={`${file.title} (${file.type.toUpperCase()})`}>
+          <LinkButton type="button" onClick={() => window.open(file.url)}>
+            {file.title === '' ? messages.missingTitle : file.title}
+            {` `}
+            <span>({file.type})</span>
+          </LinkButton>
+        </Tooltip>
+      </div>
     );
   }
 };
@@ -94,7 +101,9 @@ const FileNameInput = ({
     );
   return (
     <div>
-      <Download />
+      <div>
+        <Download />
+      </div>
       {getButtonComponent(file, isMissing, messages)}
     </div>
   );
@@ -120,6 +129,11 @@ const LinkButton = styled.button`
   box-shadow: inset 0 -1px;
   border: 0;
   background: none;
+  max-width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  text-align: left;
+  white-space: nowrap;
   cursor: pointer;
   transform: translateY(-2px);
   span {

--- a/packages/ndla-forms/package.json
+++ b/packages/ndla-forms/package.json
@@ -19,7 +19,6 @@
   ],
   "dependencies": {
     "@ndla/core": "^0.6.32",
-    "@ndla/forms": "^0.3.163",
     "@ndla/icons": "^0.6.26",
     "@ndla/ui": "^0.30.8"
   },

--- a/packages/ndla-forms/package.json
+++ b/packages/ndla-forms/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "@ndla/core": "^0.6.32",
+    "@ndla/forms": "^0.3.163",
     "@ndla/icons": "^0.6.26",
     "@ndla/ui": "^0.30.8"
   },

--- a/packages/ndla-forms/src/CheckboxItem.js
+++ b/packages/ndla-forms/src/CheckboxItem.js
@@ -10,6 +10,7 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { colors, fonts, spacing, utils } from '@ndla/core';
+import { uuid } from '@ndla/util';
 
 const CheckboxInput = styled.input`
   position: absolute;
@@ -103,24 +104,27 @@ const CheckboxLabel = styled.label`
   }
 `;
 
-const CheckboxItem = ({ label, checked, value, id, onChange, disabled }) => (
-  <Fragment>
-    <CheckboxInput
-      disabled={disabled}
-      aria-checked={checked}
-      checked={checked}
-      type="checkbox"
-      value={value}
-      id={id}
-      name={id}
-      onChange={() => onChange(id)}
-    />
-    <CheckboxLabel htmlFor={id} hasLabel={label !== ''}>
-      <span />
-      <span>{label}</span>
-    </CheckboxLabel>
-  </Fragment>
-);
+const CheckboxItem = ({ label, checked, value, id, onChange, disabled }) => {
+  const uniqueID = uuid();
+  return (
+    <Fragment>
+      <CheckboxInput
+        disabled={disabled}
+        aria-checked={checked}
+        checked={checked}
+        type="checkbox"
+        value={value}
+        id={uniqueID}
+        name={id}
+        onChange={() => onChange(id)}
+      />
+      <CheckboxLabel htmlFor={uniqueID} hasLabel={label !== ''}>
+        <span />
+        <span>{label}</span>
+      </CheckboxLabel>
+    </Fragment>
+  );
+};
 
 CheckboxItem.propTypes = {
   disabled: PropTypes.bool,


### PR DESCRIPTION
Tilhører NDLANO/Issues#2410

Ting som er oppdatert:
1. CheckboxItem bruker nå ikke innsendt ID som referanse mellom label og CheckboxInput. Det genereres heller en unik id med uuid(). Dette forhindrer at to CheckboxItem bruker samme ID som kan føre til at når man trykker på en checkbox er det en annen  checkbox med samme ID som blir markert.
2. FileListEditor har nå støtte for checkboxes for markering av pdf. Det skal kun dukke opp checkbox på PDF når checkboxes er aktivert.
3. FileListEditorExample er oppdatert med et eksempel som viser bruk med checkboxes.

How to test:
1. https://frontend-packages-pr-751.ndla.sh/?path=/story/produksjonssystem--filelisteditor
2. Test at gammel funksjonalitet fungerer.
3. Test at man kan markere checkboxes.
4. Prøv å framprovosere feil i sortering, krasj eller duplisering av elementer ved veldig mange flyttinger på rad.