### PR TITLE
Adding set of reset-classes to reset counter for ordered list

### DIFF
--- a/packages/core/scss/global/objects/objects.lists.scss
+++ b/packages/core/scss/global/objects/objects.lists.scss
@@ -27,7 +27,7 @@ ol {
 // For resetting starting-point for ordered lists. 50 is a random large number.
 @for $i from 1 through 50 {
   .ol-reset-#{$i} {
-    counter-reset: item $i-1;
+    counter-reset: item $i - 1;
   }
 }
 

--- a/packages/core/scss/global/objects/objects.lists.scss
+++ b/packages/core/scss/global/objects/objects.lists.scss
@@ -24,7 +24,14 @@ ol {
   counter-reset: item;
 }
 
-.ol-list--roman>li {
+// For resetting starting-point for ordered lists. 50 is a random large number.
+@for $i from 1 through 50 {
+  .ol-reset-#{$i} {
+    counter-reset: item $i-1;
+  }
+}
+
+.ol-list--roman > li {
   &:before {
     content: counter(item, lower-latin);
     counter-increment: item;

--- a/packages/designmanual/stories/basic-styles.jsx
+++ b/packages/designmanual/stories/basic-styles.jsx
@@ -1720,8 +1720,27 @@ storiesOf('Grunnstiler', module)
             </ol>
           </li>
         </ol>
+        <h2 className="u-heading">Nummererte lister som starter på 3</h2>
+        <ol className="ol-reset-3">
+          <li>Listepunkt</li>
+          <li>Listepunkt</li>
+          <li>
+            Underliste:
+            <ol className="ol-list--roman">
+              <li>Underlistepunkt</li>
+              <li>Underlistepunkt</li>
+              <li>Underlistepunkt</li>
+            </ol>
+          </li>
+        </ol>
         <h2 className="u-heading">Alfabetiserte lister</h2>
         <ol className="ol-list--roman">
+          <li>Listepunkt</li>
+          <li>Listepunkt</li>
+          <li>Listepunkt</li>
+        </ol>
+        <h2 className="u-heading">Alfabetiserte lister som starter på b</h2>
+        <ol className="ol-list--roman ol-reset-2">
           <li>Listepunkt</li>
           <li>Listepunkt</li>
           <li>Listepunkt</li>


### PR DESCRIPTION
NDLANO/Issues#2233

Lager en class som resetter counter for ol-lister. 

Både ed og article-converter må oppdateres til å støtte dette slik at ved kode `<ol start="2">` så må klassen .ol-reset-2 settes på ol-taggen. Det vil resette telleren for liste-elementer til å begynne på start-1 slik at første element viser 2.

Genererer 1-50 for å ha en del å gå på sjølv om det sikkert er sjelden at lister blir så lange. 

Om det finnes bedre måter å gjøre dette på, kom gjerne med forslag. Fant ingen andre gode måter å sette inn en verdi i counter-reset regelen.