### PR TITLE
fixed overly wide div in RadioButtonGroup

### DIFF
--- a/packages/ndla-ui/src/RadioButtonGroup/component.radio-button-group.scss
+++ b/packages/ndla-ui/src/RadioButtonGroup/component.radio-button-group.scss
@@ -42,7 +42,7 @@
   &__input {
     opacity: 0;
     position: absolute;
-    display:none;
+    display: none;
     &:hover, &:focus {
       + .c-radio-button-group__label {
         @include restore-outline();

--- a/packages/ndla-ui/src/RadioButtonGroup/component.radio-button-group.scss
+++ b/packages/ndla-ui/src/RadioButtonGroup/component.radio-button-group.scss
@@ -42,6 +42,7 @@
   &__input {
     opacity: 0;
     position: absolute;
+    display:none;
     &:hover, &:focus {
       + .c-radio-button-group__label {
         @include restore-outline();


### PR DESCRIPTION
Fixes wide invisible div:

![image](https://user-images.githubusercontent.com/10486712/107124686-ac078a80-68a5-11eb-955b-f31a943a0bfb.png)
