### PR TITLE
Enter click on FrontPageSearch routes to search page.

### DIFF
--- a/packages/ndla-ui/src/Search/IsPathToHighlight.ts
+++ b/packages/ndla-ui/src/Search/IsPathToHighlight.ts
@@ -3,5 +3,5 @@ export const isPathToHighlight = (
   href: string | false | null,
 ): boolean => {
   const regexForPath = new RegExp(`^(/.*)?${path}$`);
-  return regexForPath.test(href || '');
+  return regexForPath.test(href || '') || path === href;
 };

--- a/packages/ndla-ui/src/Search/SearchResultSleeve.tsx
+++ b/packages/ndla-ui/src/Search/SearchResultSleeve.tsx
@@ -278,7 +278,10 @@ const SearchResultSleeve: React.FC<Props & tType> = ({
       } else if (e.code === 'Enter') {
         e.stopPropagation();
         e.preventDefault();
-        if (keyboardPathNavigation === GO_TO_SEARCHPAGE) {
+        if (
+          keyboardPathNavigation === GO_TO_SEARCHPAGE ||
+          keyboardPathNavigation === undefined
+        ) {
           const anchorTag =
             searchAllRef &&
             searchAllRef.current &&


### PR DESCRIPTION
Relatert til NDLANO/Issues#2450

Denne PRen fikser to ting:
1. Når du har gjort et søk på ndla.no, men enda ikke markert et resultat med piltaster så vil enter-klikk ta deg til søkesiden. Dette tilsvarer trykk på "se alle treff på søk" som er øverste resultat.
2. Oppdaget en bug. Ved søk på feks "tr" på test.ndla.no så ble ikke alle resultater fremhevet ved trykk nedover med piltaster. Dette gjaldt hvertfall resultater under kategorien "Fag". Skal fungere nå. (Kan ikke bruke path rett i regex når path inneholder ? og /. Dette er tegn som må escapes som "\\?" eller "\\/" for at det skal fungere)

Oppsett:
1. repo: frontend-packages på branch `2450-search-onpress-enter-goto-search`
2. `cd /packages/ndla-ui/`
3. `yarn link`
4. repo: ndla-frontend på branch `master`
5. `yarn link "@ndla/ui"`'
6. Start opp ndla-frontend

Hvordan teste:
- Skriv en tilfeldig string i søkefeltet. Trykk deretter enter og du skal tas til søkesiden med strengen du skrev inn.
- Skriv en tilfeldig string i søkefeltet. Naviger med piltastene og se at resultater av typen "Fag" blir fremhevet.