### PR TITLE
Øke størrelsen på navigeringspilene i læringssti-sticky på mobil

### DIFF
--- a/packages/ndla-ui/src/LearningPaths/LearningPathSticky.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathSticky.tsx
@@ -62,6 +62,7 @@ const SafeLinkCSS = css`
   ${mq.range({ until: breakpoints.tablet })} {
     height: ${FOOTER_HEIGHT_MOBILE};
     width: ${FOOTER_HEIGHT_MOBILE};
+    min-width: ${FOOTER_HEIGHT_MOBILE};
   }
   padding: 0 ${spacing.normal} 0 ${spacing.normal};
   ${mq.range({ until: breakpoints.tablet })} {

--- a/packages/ndla-ui/src/LearningPaths/LearningPathSticky.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathSticky.tsx
@@ -17,6 +17,7 @@ import SafeLink from '@ndla/safelink';
 
 const FOOTER_HEIGHT = '78px';
 const FOOTER_HEIGHT_MOBILE = spacing.large;
+const SAFELINK_SIZE_MOBILE = spacing.large;
 
 const StyledFooter = styled.nav`
   display: flex;
@@ -60,9 +61,9 @@ const SafeLinkCSS = css`
   color: ${colors.brand.primary};
   height: ${FOOTER_HEIGHT};
   ${mq.range({ until: breakpoints.tablet })} {
-    height: ${FOOTER_HEIGHT_MOBILE};
-    width: ${FOOTER_HEIGHT_MOBILE};
-    min-width: ${FOOTER_HEIGHT_MOBILE};
+    height: ${SAFELINK_SIZE_MOBILE};
+    width: ${SAFELINK_SIZE_MOBILE};
+    min-width: ${SAFELINK_SIZE_MOBILE};
   }
   padding: 0 ${spacing.normal} 0 ${spacing.normal};
   ${mq.range({ until: breakpoints.tablet })} {


### PR DESCRIPTION
For NDLANO/ndla-frontend#618

Bredden på størrelsen ble presset ned fordi "vis læringssti"-knappen ble plassert i stickyen og komprimerte plassen. La til `min-width` for å sikre at pilene har den samme kvadratiske wrapperen på alle flater.

På mobil: https://frontend-packages-pr-764.ndla.sh/?path=/story/sidevisninger--l%C3%A6ringssti 