### PR TITLE
Add position relative to factbox content

### DIFF
--- a/packages/ndla-ui/src/FactBox/component.factbox.scss
+++ b/packages/ndla-ui/src/FactBox/component.factbox.scss
@@ -11,6 +11,7 @@ $padding-bottom: 17px;
   padding-bottom: $padding-bottom;
 
   &__content {
+    position: relative;
     color: $brand-grey-dark;
     padding: $spacing $spacing $spacing--large;
     border: 1px solid $brand-grey--light;


### PR DESCRIPTION
Gjør at knappene til faktaboks blir plassert inne i boksen, slik som det gjøres for de andre boksene. Se: https://editorial-frontend-pr-936.ndla.sh/subject-matter/learning-resource/59228/edit/nb

Har ikke fått test pga yarn link problemer, men er relativt sikker på at det skal fungere