### PR TITLE
2499 frontpage search suggestion

### DIFF
--- a/packages/designmanual/stories/pages/FrontpageExample.jsx
+++ b/packages/designmanual/stories/pages/FrontpageExample.jsx
@@ -244,6 +244,8 @@ class FrontpageExample extends Component {
               menuButton: t('welcomePage.heading.messages.menuButton'),
             }}
             languageOptions={dummyLanguageOptions}
+            suggestion={searchFieldValue.length > 2 && 'et-liknende-ord'}
+            suggestionUrl={'search?query=et-liknende-ord'}
           />
         </FrontpageHeader>
         <main>

--- a/packages/ndla-ui/src/Frontpage/FrontpageSearch.tsx
+++ b/packages/ndla-ui/src/Frontpage/FrontpageSearch.tsx
@@ -62,6 +62,7 @@ type Props = {
   loading: boolean;
   t(arg: string, obj?: { [key: string]: string | boolean | number }): string;
   history: History;
+  suggestion: string;
 };
 
 const FrontpageSearch: React.FunctionComponent<Props> = ({
@@ -79,6 +80,7 @@ const FrontpageSearch: React.FunctionComponent<Props> = ({
   loading,
   t,
   history,
+  suggestion,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const searchFieldRef = useRef<HTMLDivElement>(null);

--- a/packages/ndla-ui/src/Frontpage/FrontpageSearch.tsx
+++ b/packages/ndla-ui/src/Frontpage/FrontpageSearch.tsx
@@ -63,6 +63,7 @@ type Props = {
   t(arg: string, obj?: { [key: string]: string | boolean | number }): string;
   history: History;
   suggestion: string;
+  suggestionUrl: string;
 };
 
 const FrontpageSearch: React.FunctionComponent<Props> = ({
@@ -81,6 +82,7 @@ const FrontpageSearch: React.FunctionComponent<Props> = ({
   t,
   history,
   suggestion,
+  suggestionUrl,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const searchFieldRef = useRef<HTMLDivElement>(null);
@@ -197,6 +199,8 @@ const FrontpageSearch: React.FunctionComponent<Props> = ({
               resourceToLinkProps={resourceToLinkProps}
               infoText={t('welcomePage.searchDisclaimer')}
               history={history}
+              suggestion={suggestion}
+              suggestionUrl={suggestionUrl}
             />
           )}
         </SearchFieldForm>

--- a/packages/ndla-ui/src/Search/SearchResultSleeve.tsx
+++ b/packages/ndla-ui/src/Search/SearchResultSleeve.tsx
@@ -27,6 +27,7 @@ import { highlightStyle } from './ContentTypeResultStyles';
 import { ContentTypeResultType, Resource } from '../types';
 
 const GO_TO_SEARCHPAGE = 'GO_TO_SEARCHPAGE';
+const GO_TO_SUGGESTION = 'GO_TO_SUGGESTION';
 
 const StyledNoHits = styled.div`
   ${fonts.sizes(16, 1.1)};
@@ -57,10 +58,15 @@ const StyledAside = styled.aside`
   }
 `;
 
-const StyledSearchAll = styled(SafeLink)`
+const SearchLinkContainer = styled.div`
+  margin: calc(${spacing.normal} - ${spacing.xsmall}) 0;
+`;
+
+const StyledSearchLink = styled(SafeLink)`
+  width: 100%;
   box-shadow: none;
   border: 0;
-  margin: ${spacing.normal} -${spacing.small};
+  margin: ${spacing.xsmall} -${spacing.small};
   background: transparent;
   display: inline-flex;
   flex-grow: 1;
@@ -74,7 +80,6 @@ const StyledSearchAll = styled(SafeLink)`
   }
   &:focus {
     ${highlightStyle}
-    width: 100%;
   }
   &:hover {
     strong {
@@ -194,6 +199,7 @@ const findPathForKeyboardNavigation = (
     : [];
   const resultsContainingPaths: Array<string | HTMLElement> = ([
     GO_TO_SEARCHPAGE,
+    GO_TO_SUGGESTION,
   ] as Array<HTMLElement | string>).concat(...selectables);
 
   // Nothing selected, goto either first or last depending on direction
@@ -230,6 +236,8 @@ type Props = {
   loading: boolean;
   frontpage?: boolean;
   history: History;
+  suggestion: string;
+  suggestionUrl: string;
 };
 
 const SearchResultSleeve: React.FC<Props & tType> = ({
@@ -244,9 +252,12 @@ const SearchResultSleeve: React.FC<Props & tType> = ({
   frontpage,
   t,
   history,
+  suggestion,
+  suggestionUrl,
 }) => {
   const contentRef = useRef<HTMLDivElement>(null);
   const searchAllRef = useRef<HTMLDivElement>(null);
+  const searchSuggestionRef = useRef<HTMLDivElement>(null);
   const [keyboardPathNavigation, setKeyNavigation] = useState<
     HTMLElement | string | null
   >('');
@@ -278,7 +289,15 @@ const SearchResultSleeve: React.FC<Props & tType> = ({
       } else if (e.code === 'Enter') {
         e.stopPropagation();
         e.preventDefault();
-        if (
+        if (keyboardPathNavigation === GO_TO_SUGGESTION) {
+          const anchorTag =
+            searchSuggestionRef &&
+            searchSuggestionRef.current &&
+            searchSuggestionRef.current.closest('a');
+          if (anchorTag) {
+            anchorTag.click();
+          }
+        } else if (
           keyboardPathNavigation === GO_TO_SEARCHPAGE ||
           keyboardPathNavigation === undefined
         ) {
@@ -343,13 +362,30 @@ const SearchResultSleeve: React.FC<Props & tType> = ({
           </StyledAside>
         )}
         <div>
-          <StyledSearchAll
-            css={keyboardPathNavigation === GO_TO_SEARCHPAGE && highlightStyle}
-            to={allResultUrl}>
-            <SearchIcon className="c-icon--22" />
-            <strong ref={searchAllRef}>{searchString}</strong>
-            <small>{t('welcomePage.searchAllInfo')}</small>
-          </StyledSearchAll>
+          <SearchLinkContainer>
+            <StyledSearchLink
+              css={
+                keyboardPathNavigation === GO_TO_SEARCHPAGE && highlightStyle
+              }
+              to={allResultUrl}>
+              <SearchIcon className="c-icon--22" />
+              <strong ref={searchAllRef}>{searchString}</strong>
+              <small>{t('welcomePage.searchAllInfo')}</small>
+            </StyledSearchLink>
+            {suggestion && (
+              <StyledSearchLink
+                css={
+                  keyboardPathNavigation === GO_TO_SUGGESTION && highlightStyle
+                }
+                to={suggestionUrl}>
+                <SearchIcon className="c-icon--22" />
+                <small>
+                  {t('searchPage.resultType.searchPhraseSuggestion')}
+                </small>
+                <strong ref={searchSuggestionRef}>{suggestion}</strong>
+              </StyledSearchLink>
+            )}
+          </SearchLinkContainer>
           {result.map((contentTypeResult: ContentTypeResultType) => (
             <ContentTypeResult
               ignoreContentTypeBadge={ignoreContentTypeBadge}

--- a/packages/ndla-ui/src/Search/SearchResultSleeve.tsx
+++ b/packages/ndla-ui/src/Search/SearchResultSleeve.tsx
@@ -59,14 +59,13 @@ const StyledAside = styled.aside`
 `;
 
 const SearchLinkContainer = styled.div`
-  margin: calc(${spacing.normal} - ${spacing.xsmall}) 0;
+  margin: ${spacing.normal} -${spacing.small};
 `;
 
 const StyledSearchLink = styled(SafeLink)`
   width: 100%;
   box-shadow: none;
   border: 0;
-  margin: ${spacing.xsmall} -${spacing.small};
   background: transparent;
   display: inline-flex;
   flex-grow: 1;


### PR DESCRIPTION
Relatert til NDLANO/Issues#2499

Utvider FrontPageSearch til å støtte forslag til annet søkeord. Dette er en string `suggestion` som er ordet som skal foreslås og en string `suggestionUrl` som er søket som skal redirectes til.

Hvordan teste:
1. http://frontend-packages-pr-774.ndla.sh/?path=/story/fag-og-emnesider--1-forside
2. Skriv inn et søk på minst tre tegn. Det skal dukke opp resultater og et statisk forslag til annet søkeord.
3. Sjekk at klikk med piltaster fungerer med det nye feltet med foreslått søkeord.
4. Sjekk at det nye feltet har en lenke. (Det fungerer kun å trykke på disse lenkene med ctrl+venstre museknapp i eksempelet).