### PR TITLE
Fix dart-sass error

### DIFF
--- a/packages/core/scss/global/tools/tools.functions.scss
+++ b/packages/core/scss/global/tools/tools.functions.scss
@@ -19,11 +19,8 @@
 }
 
 @mixin chinese() {
-  &[lang='zh'],
   [lang='zh'],
-  &[lang='zh-Hans'],
   [lang='zh-Hans'],
-  &[lang='zh-Hant'],
   [lang='zh-Hant'],
   .u-large-body-text {
     @content;


### PR DESCRIPTION
Får en error på dette når jeg migrerer til dart-sass. 

>   &[lang='zh'],
 ^
      Top-level selectors may not contain the parent selector "&".

Jeg forstår ikke helt syntaksen her, men prøvde å bare fjerne det den klagde på som uansett så ut til å være overflødig. Har klikket meg litt gjennom kinesisk fagene og alt ser fortsatt likt ut så vidt jeg kan se. Er det noen her som forstår denne koden eller vet hvorfor det er dobbelt opp?