### PR TITLE
Fix word-break in safari search-result

### DIFF
--- a/packages/ndla-ui/src/SearchTypeResult/SearchItem.tsx
+++ b/packages/ndla-ui/src/SearchTypeResult/SearchItem.tsx
@@ -129,6 +129,7 @@ const ItemText = styled.p`
   font-size: 15px;
   line-height: 20px;
   margin-bottom: ${spacing.small};
+  word-break: break-word;
   overflow-wrap: anywhere;
 `;
 const BreadcrumbPath = styled.div`


### PR DESCRIPTION
https://trello.com/c/f5xexBKQ/1010-visuelt-element-p%C3%A5-ndla-film-er-breiare-enn-andre-innholdstypar-f%C3%B8rer-til-feil-p%C3%A5-s%C3%B8keside