### PR TITLE
fixes prop type warnings in SearchResult and Tooltip

### DIFF
--- a/packages/ndla-ui/src/Search/SearchResult.jsx
+++ b/packages/ndla-ui/src/Search/SearchResult.jsx
@@ -126,7 +126,7 @@ SearchResult.defaultProps = {
 const searchResultItemClasses = BEMHelper('c-search-result-item');
 
 const searchResultItemShape = PropTypes.shape({
-  id: PropTypes.number.isRequired,
+  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   title: PropTypes.string.isRequired,
   url: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   breadcrumb: PropTypes.arrayOf(PropTypes.string),

--- a/packages/tooltip/src/Tooltip.jsx
+++ b/packages/tooltip/src/Tooltip.jsx
@@ -183,7 +183,7 @@ class Tooltip extends Component {
 
 Tooltip.propTypes = {
   children: PropTypes.node.isRequired,
-  tooltip: PropTypes.string.isRequired,
+  tooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   delay: PropTypes.number,
   disabled: PropTypes.bool,
   align: PropTypes.oneOf(['left', 'right', 'top', 'bottom']),


### PR DESCRIPTION
Fixes some prop-type warning introduces in https://github.com/NDLANO/ndla-frontend/pull/670. 

![image](https://user-images.githubusercontent.com/10486712/115040910-3a197600-9ed2-11eb-8234-1f1a39364bb5.png)
 
 Usually the prop sent to SearchResult is of type `Resource`, in this PR the prop is of type `Topic`, hence the warnings.