### PR TITLE
2558 Relatert innhold i læringstier linker til ny fane

### DIFF
--- a/packages/designmanual/stories/article/RelatedArticleListExample.jsx
+++ b/packages/designmanual/stories/article/RelatedArticleListExample.jsx
@@ -68,6 +68,7 @@ export const RelatedArticleExternal = ({ t }) => (
       modifier="external-learning-resources"
       introduction="Bioteknologinemnda er et frittstående, rådgivende organ som er oppnevnt av Regjeringen og hjemlet (begrunnet) i Genteknologiloven og Bioteknologiloven."
       linkInfo="Nettside hos bion.no"
+      target={'_blank'}
       to="#"
     />
     <RelatedArticle
@@ -76,6 +77,7 @@ export const RelatedArticleExternal = ({ t }) => (
       modifier="external-learning-resources"
       introduction="https://www.url.no/visuelt/vin…"
       linkInfo="Nettside hos helsedirektoratet.no"
+      target={'_blank'}
       to="#"
     />
   </RelatedArticleList>

--- a/packages/designmanual/stories/article/RelatedArticleListExample.jsx
+++ b/packages/designmanual/stories/article/RelatedArticleListExample.jsx
@@ -68,7 +68,7 @@ export const RelatedArticleExternal = ({ t }) => (
       modifier="external-learning-resources"
       introduction="Bioteknologinemnda er et frittstående, rådgivende organ som er oppnevnt av Regjeringen og hjemlet (begrunnet) i Genteknologiloven og Bioteknologiloven."
       linkInfo="Nettside hos bion.no"
-      target={'_blank'}
+      target="_blank"
       to="#"
     />
     <RelatedArticle
@@ -77,7 +77,7 @@ export const RelatedArticleExternal = ({ t }) => (
       modifier="external-learning-resources"
       introduction="https://www.url.no/visuelt/vin…"
       linkInfo="Nettside hos helsedirektoratet.no"
-      target={'_blank'}
+      target="_blank"
       to="#"
     />
   </RelatedArticleList>

--- a/packages/ndla-ui/src/RelatedArticleList/RelatedArticleList.jsx
+++ b/packages/ndla-ui/src/RelatedArticleList/RelatedArticleList.jsx
@@ -20,7 +20,7 @@ export const RelatedArticle = ({ title, introduction, icon, modifier, to, linkIn
           <SafeLink
             to={to}
             {...classes('link')}
-            target={(linkInfo || inOembed) ? '_blank' : null}
+            target={linkInfo || inOembed ? '_blank' : null}
             rel={linkInfo ? 'noopener noreferrer' : null}>
             {title}
           </SafeLink>

--- a/packages/ndla-ui/src/RelatedArticleList/RelatedArticleList.jsx
+++ b/packages/ndla-ui/src/RelatedArticleList/RelatedArticleList.jsx
@@ -10,7 +10,7 @@ const classes = new BEMHelper({
   prefix: 'c-',
 });
 
-export const RelatedArticle = ({ title, introduction, icon, modifier, to, linkInfo, inOembed }) => {
+export const RelatedArticle = ({ title, introduction, icon, modifier, to, linkInfo, target }) => {
   const iconWithClass = cloneElement(icon, { className: 'c-icon--medium' });
   return (
     <article {...classes('item', modifier)}>
@@ -20,7 +20,7 @@ export const RelatedArticle = ({ title, introduction, icon, modifier, to, linkIn
           <SafeLink
             to={to}
             {...classes('link')}
-            target={linkInfo || inOembed ? '_blank' : null}
+            target={target}
             rel={linkInfo ? 'noopener noreferrer' : null}>
             {title}
           </SafeLink>
@@ -39,10 +39,12 @@ RelatedArticle.propTypes = {
   introduction: PropTypes.string.isRequired,
   to: PropTypes.string.isRequired,
   linkInfo: PropTypes.string,
+  target: PropTypes.string,
 };
 
 RelatedArticle.defaultProps = {
   linkInfo: null,
+  target: null,
 };
 
 const RelatedArticleList = ({ messages, children, articleCount, dangerouslySetInnerHTML }) => {

--- a/packages/ndla-ui/src/RelatedArticleList/RelatedArticleList.jsx
+++ b/packages/ndla-ui/src/RelatedArticleList/RelatedArticleList.jsx
@@ -10,7 +10,15 @@ const classes = new BEMHelper({
   prefix: 'c-',
 });
 
-export const RelatedArticle = ({ title, introduction, icon, modifier, to, linkInfo, target }) => {
+export const RelatedArticle = ({
+  title,
+  introduction,
+  icon,
+  modifier,
+  to,
+  linkInfo = '',
+  target = '',
+}) => {
   const iconWithClass = cloneElement(icon, { className: 'c-icon--medium' });
   return (
     <article {...classes('item', modifier)}>
@@ -40,11 +48,6 @@ RelatedArticle.propTypes = {
   to: PropTypes.string.isRequired,
   linkInfo: PropTypes.string,
   target: PropTypes.string,
-};
-
-RelatedArticle.defaultProps = {
-  linkInfo: null,
-  target: null,
 };
 
 const RelatedArticleList = ({ messages, children, articleCount, dangerouslySetInnerHTML }) => {

--- a/packages/ndla-ui/src/RelatedArticleList/RelatedArticleList.jsx
+++ b/packages/ndla-ui/src/RelatedArticleList/RelatedArticleList.jsx
@@ -10,7 +10,7 @@ const classes = new BEMHelper({
   prefix: 'c-',
 });
 
-export const RelatedArticle = ({ title, introduction, icon, modifier, to, linkInfo }) => {
+export const RelatedArticle = ({ title, introduction, icon, modifier, to, linkInfo, inOembed }) => {
   const iconWithClass = cloneElement(icon, { className: 'c-icon--medium' });
   return (
     <article {...classes('item', modifier)}>
@@ -20,7 +20,7 @@ export const RelatedArticle = ({ title, introduction, icon, modifier, to, linkIn
           <SafeLink
             to={to}
             {...classes('link')}
-            target={linkInfo ? '_blank' : null}
+            target={(linkInfo || inOembed) ? '_blank' : null}
             rel={linkInfo ? 'noopener noreferrer' : null}>
             {title}
           </SafeLink>


### PR DESCRIPTION
For NDLANO/Issues#2558

Lagt til en prop `inOembed` som setter `target=_blank` hvis lista over relaterte artikler blir vist i en oembed som f.eks. i en læringssti.