### PR TITLE
Update core-js version and imports in polyfill package

### DIFF
--- a/packages/polyfill/package.json
+++ b/packages/polyfill/package.json
@@ -19,7 +19,8 @@
   ],
   "dependencies": {
     "details-polyfill": "^1.1.0",
-    "react-app-polyfill": "^0.2.1"
+    "react-app-polyfill": "^0.2.1",
+    "core-js": "^3.10.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/polyfill/src/index.js
+++ b/packages/polyfill/src/index.js
@@ -11,16 +11,16 @@
 import 'react-app-polyfill/ie11';
 
 // addition polyfill for language features used in ndla frontends
-import 'core-js/fn/array/find';
-import 'core-js/fn/array/flat-map';
-import 'core-js/fn/array/find-index';
-import 'core-js/fn/array/fill';
-import 'core-js/fn/array/includes';
-import 'core-js/fn/string/starts-with';
-import 'core-js/fn/string/ends-with';
-import 'core-js/fn/string/includes';
-import 'core-js/fn/number/is-integer';
-import 'core-js/fn/number/is-nan';
+import 'core-js/features/array/find';
+import 'core-js/features/array/flat-map';
+import 'core-js/features/array/find-index';
+import 'core-js/features/array/fill';
+import 'core-js/features/array/includes';
+import 'core-js/features/string/starts-with';
+import 'core-js/features/string/ends-with';
+import 'core-js/features/string/includes';
+import 'core-js/features/number/is-integer';
+import 'core-js/features/number/is-nan';
 
 // polyfill for <details></details> and <summary></summary> html elements used in articles.
 import 'details-polyfill';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7352,6 +7352,11 @@ core-js@^3.0.4:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
+core-js@^3.10.2:
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.10.2.tgz#17cb038ce084522a717d873b63f2b3ee532e2cd5"
+  integrity sha512-W+2oVYeNghuBr3yTzZFQ5rfmjZtYB/Ubg87R5YOmlGrIb+Uw9f7qjUbhsj+/EkXhcV7eOD3jiM4+sgraX3FZUw==
+
 core-js@^3.6.5:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.9.1.tgz#cec8de593db8eb2a85ffb0dbdeb312cb6e5460ae"


### PR DESCRIPTION
Litt vanskelig å teste, men når vi drar inn core-js 3.x transitivt (feks ved apollo-cli) så tryner det i ndla-frontend
Så denne er kjekk for nye versjoner av core-js.