### PR TITLE
2571 Bruke apa for kopiering av referanse

### DIFF
--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -433,10 +433,10 @@ const messages = {
     embed: 'Embed',
     embedCopied: 'Copied embed code!',
     copyText: {
-      internet: 'Internet',
+      internet: '[Internet]. ',
       noTitle: 'No title',
-      downloadedFrom: 'Downloaded from',
-      readDate: 'Read',
+      downloadedFrom: 'Downloaded from: ',
+      readDate: 'Read: ',
     },
     hasCopiedTitle: 'Copied!',
     download: 'Download',

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -432,6 +432,12 @@ const messages = {
     copyTitle: 'Copy reference',
     embed: 'Embed',
     embedCopied: 'Copied embed code!',
+    copyText: {
+      internet: 'Internet',
+      noTitle: 'No title',
+      downloadedFrom: 'Downloaded from',
+      readDate: 'Read',
+    },
     hasCopiedTitle: 'Copied!',
     download: 'Download',
     creditType: {

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -358,6 +358,12 @@ const messages = {
     hasCopiedTitle: 'Kopiert!',
     embed: 'Bygg inn',
     embedCopied: 'Kopierte innbyggingskode!',
+    copyText: {
+      internet: 'Internett',
+      noTitle: 'Uten tittel',
+      downloadedFrom: 'Hentet fra',
+      readDate: 'Lest',
+    },
     download: 'Last ned',
     tabs: {
       text: 'Tekst',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -359,10 +359,10 @@ const messages = {
     embed: 'Bygg inn',
     embedCopied: 'Kopierte innbyggingskode!',
     copyText: {
-      internet: 'Internett',
+      internet: '[Internett]. ',
       noTitle: 'Uten tittel',
-      downloadedFrom: 'Hentet fra',
-      readDate: 'Lest',
+      downloadedFrom: 'Hentet fra: ',
+      readDate: 'Lest: ',
     },
     download: 'Last ned',
     tabs: {

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -360,10 +360,10 @@ const messages = {
     embed: 'Bygg inn',
     embedCopied: 'Kopierte innbyggingskode!',
     copyText: {
-      internet: 'Internett',
+      internet: '[Internett]. ',
       noTitle: 'Utan tittel',
-      downloadedFrom: 'Henta frå',
-      readDate: 'Lese',
+      downloadedFrom: 'Henta frå: ',
+      readDate: 'Lese: ',
     },
     download: 'Last ned',
     tabs: {

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -359,6 +359,12 @@ const messages = {
     hasCopiedTitle: 'Kopiert!',
     embed: 'Bygg inn',
     embedCopied: 'Kopierte innbyggingskode!',
+    copyText: {
+      internet: 'Internett',
+      noTitle: 'Utan tittel',
+      downloadedFrom: 'Henta frå',
+      readDate: 'Lese',
+    },
     download: 'Last ned',
     tabs: {
       text: 'Tekst',


### PR DESCRIPTION
For NDLANO/article-converter#235

Lagt til noen oversettelsesfraser for kopiering av apa referansefraser. Greit å vente med denne til strukturen på kopieringsstrengen er godkjent.