### PR TITLE
ResourceGroup supports one list of resources.

### DIFF
--- a/packages/designmanual/stories/collated-components.jsx
+++ b/packages/designmanual/stories/collated-components.jsx
@@ -420,35 +420,6 @@ storiesOf('Sammensatte moduler', module)
       </LayoutItem>
     </PageContainer>
   ))
-  .add('Læringsressurser', () => (
-    <div>
-      <StoryIntro title="Læringsressurser">
-        <p>Læringsressurser deles opp i læringsstier, fagstoff og oppgaver og aktiviteter.</p>
-        <p>
-          Ved å klikke på «Tilleggsstoff» vil brukeren få vist også innhold som er tilleggsstoff.
-          Det er ellers skjult. Tilleggsstoffet er merket med T-ikonet, samt med en noe dusere
-          farge. Sjekkboksen skal være markert når tilleggsstoff er aktivt.
-        </p>
-        <p>Emneoverskriften viser hvilke emne man står i.</p>
-      </StoryIntro>
-      <LayoutItem layout="center">
-        <Resources showTopicHeading />
-      </LayoutItem>
-    </div>
-  ))
-  .add('Læringsressurser tom', () => (
-    <div>
-      <StoryIntro title="Læringsressurser - tom liste">
-        <p>
-          Når en ressursgruppe er tom for innhold, vises en tekst som forklarer dette for brukeren
-          og tilbyr en handlingsdriver som lar deg utforske tilleggsstoff om det er tilgjengelig.
-        </p>
-      </StoryIntro>
-      <LayoutItem layout="center">
-        <Resources onlyAdditional />
-      </LayoutItem>
-    </div>
-  ))
   .add('Paginering', () => (
     <Center>
       <Pager page={3} lastPage={10} query={{ query: 'Medier' }} pathname="#" />
@@ -515,11 +486,11 @@ storiesOf('Sammensatte moduler', module)
       </Footer>
     </Center>
   ))
-  .add('Bilde karusell', () => (
+  .add('Bildekarusell', () => (
     <div>
-      <StoryIntro title="Bilde karusell">
+      <StoryIntro title="Bildekarusell">
         <p>
-          Bilde karusell består av 2 komponenter. En Wrapper komponent for automatisk utregning av
+          Bildekarusell består av 2 komponenter. En Wrapper komponent for automatisk utregning av
           størrelser, og selve bildekarusellen.
         </p>
       </StoryIntro>
@@ -528,9 +499,9 @@ storiesOf('Sammensatte moduler', module)
       </StoryBody>
     </div>
   ))
-  .add('Tilleggsstoff', () => (
+  .add('Læringsressurser', () => (
     <div>
-      <StoryIntro title="Tilleggsstoff">
+      <StoryIntro title="Læringsressurser/launchpad">
         <p>
           Når ressurser listes opp, vises i utgangspunktet kun kjernestoff. Om
           tilleggsstoff-filteret aktiveres, vil ressursopplistingen utvides med tilleggsstoff.
@@ -544,6 +515,19 @@ storiesOf('Sammensatte moduler', module)
       </StoryIntro>
       <StoryBody>
         <Resources />
+      </StoryBody>
+    </div>
+  ))
+  .add('Ugrupperte læringsressurser', () => (
+    <div>
+      <StoryIntro title="Ugrupperte ressurser">
+        <p>
+          Brukere av ed kan spesifisere at ressurser skal vises ugruppert. Da vises alle ressurser i
+          ei liste.
+        </p>
+      </StoryIntro>
+      <StoryBody>
+        <Resources showUngrouped />
       </StoryBody>
     </div>
   ))

--- a/packages/designmanual/stories/molecules/resources.jsx
+++ b/packages/designmanual/stories/molecules/resources.jsx
@@ -35,7 +35,7 @@ const resourceGroup1 = {
   id: 'type-learning-path',
   title: 'Læringsstier',
   contentType: contentTypes.LEARNING_PATH,
-  resources: learningPathResources.map(r => ({...r, type: ''})),
+  resources: learningPathResources.map(r => ({ ...r, type: '' })),
   noContentLabel: 'Det er ikke noe kjernestoff for læringsstier.',
 };
 
@@ -43,7 +43,7 @@ const resourceGroup2 = {
   id: 'subject-material',
   title: 'Fagstoff',
   contentType: contentTypes.SUBJECT_MATERIAL,
-  resources: articleResources.map(r => ({...r, type: ''})),
+  resources: articleResources.map(r => ({ ...r, type: '' })),
   noContentLabel: 'Det er ikke noe kjernestoff for fagstoff.',
 };
 
@@ -51,7 +51,7 @@ const resourceGroup3 = {
   id: 'tasks-and-activities',
   title: 'Oppgaver og aktiviteter',
   contentType: contentTypes.TASKS_AND_ACTIVITIES,
-  resources: exerciseResources.map(r => ({...r, type: ''})),
+  resources: exerciseResources.map(r => ({ ...r, type: '' })),
   noContentLabel: 'Det er ikke noe kjernestoff for oppgaver og aktiviteter.',
 };
 
@@ -59,7 +59,7 @@ const resourceGroup4 = {
   id: 'assessment-resources',
   title: 'Vurderingsressurser',
   contentType: contentTypes.ASSESSMENT_RESOURCES,
-  resources: assessmentResources.map(r => ({...r, type: ''})),
+  resources: assessmentResources.map(r => ({ ...r, type: '' })),
   noContentLabel: 'Det er ikke noe kjernestoff for læringsstier.',
 };
 
@@ -67,7 +67,7 @@ const resourceGroup5 = {
   id: 'source-material-resources',
   title: 'Kildemateriale',
   contentType: contentTypes.SOURCE_MATERIAL,
-  resources: sourceMaterialResources.map(r => ({...r, type: ''})),
+  resources: sourceMaterialResources.map(r => ({ ...r, type: '' })),
   noContentLabel: 'Det er ikke noe kjernestoff for kildemateriale.',
 };
 
@@ -75,7 +75,7 @@ const resourceGroup6 = {
   id: 'external-learning-resources',
   title: 'Eksterne læringsressurser',
   contentType: contentTypes.EXTERNAL_LEARNING_RESOURCES,
-  resources: externalLearningResources.map(r => ({...r, type: ''})),
+  resources: externalLearningResources.map(r => ({ ...r, type: '' })),
   noContentLabel: 'Det er ikke noe kjernestoff for eksterne læringssressurser.',
 };
 

--- a/packages/designmanual/stories/molecules/resources.jsx
+++ b/packages/designmanual/stories/molecules/resources.jsx
@@ -88,6 +88,16 @@ const resourceGroups = [
   resourceGroup6,
 ];
 
+const flattenResources = resourceGroups.flatMap(group =>
+  group.resources.map(r => {
+    return {
+      ...r,
+      type: group.title,
+      contentType: group.contentType,
+    };
+  }),
+);
+
 class Resources extends Component {
   constructor(props) {
     super(props);
@@ -129,15 +139,8 @@ class Resources extends Component {
     }
 
     const allResources = showUngrouped
-      ? resourceGroups.flatMap(group => {
-          const resources = group.resources.map(r => {
-            return {
-              ...r,
-              type: group.title,
-              contentType: group.contentType,
-            };
-          });
-          return resources;
+      ? flattenResources.map((r, index) => {
+          return { ...r, extraBottomMargin: (index + 1) % 4 === 0 };
         })
       : [];
 
@@ -167,12 +170,11 @@ class Resources extends Component {
         }>
         {showUngrouped && (
           <ResourceGroup
-            key="all-resources"
-            title="Ressuser"
             resources={allResources}
             showAdditionalResources={showAdditionalResources}
             toggleAdditionalResources={this.toggleAdditionalResources}
             resourceToLinkProps={toLink}
+            unGrouped
           />
         )}
         {!showUngrouped &&

--- a/packages/designmanual/stories/molecules/resources.jsx
+++ b/packages/designmanual/stories/molecules/resources.jsx
@@ -35,7 +35,7 @@ const resourceGroup1 = {
   id: 'type-learning-path',
   title: 'Læringsstier',
   contentType: contentTypes.LEARNING_PATH,
-  resources: learningPathResources,
+  resources: learningPathResources.map(r => ({...r, type: ''})),
   noContentLabel: 'Det er ikke noe kjernestoff for læringsstier.',
 };
 
@@ -43,7 +43,7 @@ const resourceGroup2 = {
   id: 'subject-material',
   title: 'Fagstoff',
   contentType: contentTypes.SUBJECT_MATERIAL,
-  resources: articleResources,
+  resources: articleResources.map(r => ({...r, type: ''})),
   noContentLabel: 'Det er ikke noe kjernestoff for fagstoff.',
 };
 
@@ -51,7 +51,7 @@ const resourceGroup3 = {
   id: 'tasks-and-activities',
   title: 'Oppgaver og aktiviteter',
   contentType: contentTypes.TASKS_AND_ACTIVITIES,
-  resources: exerciseResources,
+  resources: exerciseResources.map(r => ({...r, type: ''})),
   noContentLabel: 'Det er ikke noe kjernestoff for oppgaver og aktiviteter.',
 };
 
@@ -59,7 +59,7 @@ const resourceGroup4 = {
   id: 'assessment-resources',
   title: 'Vurderingsressurser',
   contentType: contentTypes.ASSESSMENT_RESOURCES,
-  resources: assessmentResources,
+  resources: assessmentResources.map(r => ({...r, type: ''})),
   noContentLabel: 'Det er ikke noe kjernestoff for læringsstier.',
 };
 
@@ -67,7 +67,7 @@ const resourceGroup5 = {
   id: 'source-material-resources',
   title: 'Kildemateriale',
   contentType: contentTypes.SOURCE_MATERIAL,
-  resources: sourceMaterialResources,
+  resources: sourceMaterialResources.map(r => ({...r, type: ''})),
   noContentLabel: 'Det er ikke noe kjernestoff for kildemateriale.',
 };
 
@@ -75,7 +75,7 @@ const resourceGroup6 = {
   id: 'external-learning-resources',
   title: 'Eksterne læringsressurser',
   contentType: contentTypes.EXTERNAL_LEARNING_RESOURCES,
-  resources: externalLearningResources,
+  resources: externalLearningResources.map(r => ({...r, type: ''})),
   noContentLabel: 'Det er ikke noe kjernestoff for eksterne læringssressurser.',
 };
 
@@ -112,7 +112,7 @@ class Resources extends Component {
   }
 
   render() {
-    const { title, showActiveResource } = this.props;
+    const { title, showActiveResource, showUngrouped } = this.props;
     const { showAdditionalResources, showAdditionalDialog } = this.state;
     const hasAdditionalResources = resourceGroups.some(group =>
       group.resources.some(resource => resource.additional),
@@ -127,6 +127,19 @@ class Resources extends Component {
         });
       });
     }
+
+    const allResources = showUngrouped
+      ? resourceGroups.flatMap(group => {
+          const resources = group.resources.map(r => {
+            return {
+              ...r,
+              type: group.title,
+              contentType: group.contentType,
+            };
+          });
+          return resources;
+        })
+      : [];
 
     return (
       <ResourcesWrapper
@@ -152,25 +165,29 @@ class Resources extends Component {
             showAdditionalDialog={showAdditionalDialog}
           />
         }>
-        {resourceGroups.map(group => (
+        {showUngrouped && (
           <ResourceGroup
-            key={group.id}
-            title={group.title}
-            resources={group.resources}
+            key="all-resources"
+            title="Ressuser"
+            resources={allResources}
             showAdditionalResources={showAdditionalResources}
             toggleAdditionalResources={this.toggleAdditionalResources}
-            contentType={group.contentType}
-            icon={<ContentTypeBadge type={group.contentType} />}
-            messages={{
-              noContentBoxLabel: group.noContentLabel,
-              noContentBoxButtonText: 'Tilleggsstoff',
-              toggleFilterLabel: 'Tilleggsressurser',
-              coreTooltip: 'Kjernestoff er fagstoff som er på pensum',
-              additionalTooltip: 'Tilleggsstoff er ikke på pensum',
-            }}
             resourceToLinkProps={toLink}
           />
-        ))}
+        )}
+        {!showUngrouped &&
+          resourceGroups.map(group => (
+            <ResourceGroup
+              key={group.id}
+              title={group.title}
+              resources={group.resources}
+              showAdditionalResources={showAdditionalResources}
+              toggleAdditionalResources={this.toggleAdditionalResources}
+              contentType={group.contentType}
+              icon={<ContentTypeBadge type={group.contentType} />}
+              resourceToLinkProps={toLink}
+            />
+          ))}
       </ResourcesWrapper>
     );
   }
@@ -179,11 +196,13 @@ class Resources extends Component {
 Resources.propTypes = {
   title: PropTypes.string,
   showActiveResource: PropTypes.bool,
+  showUngrouped: PropTypes.bool,
 };
 
 Resources.defaultProps = {
   title: 'Havbunnsløsninger',
   showActiveResource: true,
+  showUngrouped: false,
 };
 
 export default Resources;

--- a/packages/designmanual/stories/organisms/CarouselExample.jsx
+++ b/packages/designmanual/stories/organisms/CarouselExample.jsx
@@ -125,7 +125,7 @@ const CarouselExample = () => (
         type: 'Number',
         default: 'Required',
         description:
-          'Total utregnet lengde på hele bilde karusellen. (Tips: <CarouselAutosize /> hjelper deg å finne denne)',
+          'Total utregnet lengde på hele bildekarusellen. (Tips: <CarouselAutosize /> hjelper deg å finne denne)',
       },
       {
         name: 'distanceBetweenItems',

--- a/packages/ndla-ui/src/ContentTypeBadge/component.content-type-badge.scss
+++ b/packages/ndla-ui/src/ContentTypeBadge/component.content-type-badge.scss
@@ -4,8 +4,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  border-radius: 100%;
   &--border {
-    border-radius: 100%;
+
     border: 2px solid $black;
   }
 
@@ -14,6 +15,12 @@
 
     svg {
       color: $subject-material-dark !important;
+    }
+    &.c-content-type-badge--small {
+      svg {
+        width: 22px;
+        height: 22px;
+      }
     }
 
     &.c-content-type-badge--background {

--- a/packages/ndla-ui/src/ResourceGroup/ResourceGroup.jsx
+++ b/packages/ndla-ui/src/ResourceGroup/ResourceGroup.jsx
@@ -22,8 +22,8 @@ const ResourceGroup = ({
   title,
   icon,
   resources,
-  toggleAdditionalResources,
   showAdditionalResources,
+  toggleAdditionalResources,
   resourceToLinkProps,
   contentType,
   invertedStyle,
@@ -47,18 +47,17 @@ const ResourceGroup = ({
 
 ResourceGroup.propTypes = {
   title: PropTypes.string.isRequired,
-  icon: PropTypes.node.isRequired,
-  contentType: ContentTypeShape.isRequired,
+  icon: PropTypes.node,
+  contentType: ContentTypeShape,
   resources: PropTypes.arrayOf(ResourceShape).isRequired,
+  showAdditionalResources: PropTypes.bool,
   toggleAdditionalResources: PropTypes.func.isRequired,
   resourceToLinkProps: PropTypes.func.isRequired,
   hideResourceToggleFilter: PropTypes.bool,
-  empty: PropTypes.bool,
-  showAdditionalResources: PropTypes.bool,
+  invertedStyle: PropTypes.bool,
 };
 
 ResourceGroup.defaultProps = {
-  hideResourceToggleFilter: false,
   showAdditionalResources: false,
 };
 

--- a/packages/ndla-ui/src/ResourceGroup/ResourceGroup.jsx
+++ b/packages/ndla-ui/src/ResourceGroup/ResourceGroup.jsx
@@ -27,11 +27,19 @@ const ResourceGroup = ({
   resourceToLinkProps,
   contentType,
   invertedStyle,
+  unGrouped,
 }) => (
-  <section {...classes('', [contentType, showAdditionalResources ? 'showall' : ''])}>
-    <header {...classes('header', { invertedStyle })}>
-      <ResourcesTitle>{title}</ResourcesTitle>
-    </header>
+  <section
+    {...classes('', [
+      contentType,
+      showAdditionalResources ? 'showall' : '',
+      unGrouped ? 'un-grouped' : '',
+    ])}>
+    {title && (
+      <header {...classes('header', { invertedStyle })}>
+        <ResourcesTitle>{title}</ResourcesTitle>
+      </header>
+    )}
     {resources.length > 0 ? (
       <ResourceList
         title={title}
@@ -55,6 +63,7 @@ ResourceGroup.propTypes = {
   resourceToLinkProps: PropTypes.func.isRequired,
   hideResourceToggleFilter: PropTypes.bool,
   invertedStyle: PropTypes.bool,
+  unGrouped: PropTypes.bool,
 };
 
 ResourceGroup.defaultProps = {

--- a/packages/ndla-ui/src/ResourceGroup/ResourceList.jsx
+++ b/packages/ndla-ui/src/ResourceGroup/ResourceList.jsx
@@ -14,6 +14,7 @@ import Tooltip from '@ndla/tooltip';
 import { Additional, Core } from '@ndla/icons/common';
 import SafeLink from '@ndla/safelink';
 import NoContentBox from '../NoContentBox';
+import ContentTypeBadge from '../ContentTypeBadge';
 import { ResourceShape } from '../shapes';
 
 const classes = new BEMHelper({
@@ -59,6 +60,9 @@ const Resource = ({
   contentTypeDescription,
 }) => {
   const hidden = resource.additional ? !showAdditionalResources : false;
+  if (icon === undefined) {
+    icon = <ContentTypeBadge type={resource.contentType} />;
+  }
 
   return (
     <li
@@ -77,10 +81,10 @@ const Resource = ({
           {...resourceToLinkProps(resource)}>
           {resource.name}
         </ResourceLink>
-        <span id={id} hidden>
-          {contentTypeDescription}
-        </span>
-        <div>
+        <div {...classes('item__icon')}>
+          <span id={id} hidden={resource.type === undefined} {...classes('item__type')}>
+            {resource.type}
+          </span>
           {resource.additional && (
             <Tooltip tooltip={contentTypeDescription} align="left">
               <Additional className="c-icon--20 u-margin-left-tiny c-topic-resource__list__additional-icons" />
@@ -99,12 +103,11 @@ const Resource = ({
 
 Resource.propTypes = {
   showAdditionalResources: PropTypes.bool,
-  icon: PropTypes.node.isRequired,
   resource: ResourceShape.isRequired,
   resourceToLinkProps: PropTypes.func.isRequired,
   id: PropTypes.string.isRequired,
   contentTypeDescription: PropTypes.string.isRequired,
-  currentPage: PropTypes.bool,
+  icon: PropTypes.node,
 };
 
 injectT(Resource);
@@ -160,6 +163,7 @@ ResourceList.propTypes = {
   onClick: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
   t: PropTypes.func.isRequired,
+  icon: PropTypes.node,
 };
 
 export default injectT(ResourceList);

--- a/packages/ndla-ui/src/ResourceGroup/ResourceList.jsx
+++ b/packages/ndla-ui/src/ResourceGroup/ResourceList.jsx
@@ -61,16 +61,21 @@ const Resource = ({
 }) => {
   const hidden = resource.additional ? !showAdditionalResources : false;
   if (icon === undefined) {
-    icon = <ContentTypeBadge type={resource.contentType} />;
+    icon = <ContentTypeBadge type={resource.contentType} background border={false} />;
   }
 
   return (
     <li
-      {...classes('item', {
-        hidden,
-        additional: resource.additional,
-        active: resource.active,
-      })}>
+      {...classes(
+        'item',
+        {
+          hidden,
+          additional: resource.additional,
+          active: resource.active,
+          spacer: resource.extraBottomMargin,
+        },
+        resource.contentType,
+      )}>
       <div {...classes('body o-flag__body')}>
         <ResourceLink
           component={resource.active ? 'div' : SafeLink}

--- a/packages/ndla-ui/src/ResourceGroup/component.resource-group.scss
+++ b/packages/ndla-ui/src/ResourceGroup/component.resource-group.scss
@@ -173,4 +173,33 @@
       border: 1px dashed rgba($source-material-dark, 0.4);
     }
   }
+  &--un-grouped {
+    li {
+      border: 1px solid #D1D6DB;
+      border-radius: 5px;
+      background: none;
+      margin-bottom: $spacing--small / 2;
+      * {
+        transition: all 0.2s;
+      }
+      &.c-topic-resource__item--spacer {
+        margin-bottom: $spacing--medium;
+      }
+      a:hover .c-topic-resource__icon .c-content-type-badge  {
+        width: 38px;
+        height: 38px;
+
+        svg {
+          width: 20px;
+          height: 20px;
+        }
+        &.c-content-type-badge--subject-material, &.c-content-type-badge--learning-path, &.c-content-type-badge--source-material, &.c-content-type-badge--external-learning-resources {
+          svg {
+            width: 26px;
+            height: 26px;
+          }
+        }
+      }
+    }
+  }
 }

--- a/packages/ndla-ui/src/ResourceGroup/component.topic-resource.scss
+++ b/packages/ndla-ui/src/ResourceGroup/component.topic-resource.scss
@@ -53,6 +53,14 @@
         }
       }
     }
+    &__icon {
+      display: flex;
+    }
+    &__type {
+      align-self: center;
+      right: 30px;
+      @include font-size(16px, 18px);
+    }
   }
 
   &__link {

--- a/packages/ndla-ui/src/ResourceGroup/component.topic-resource.scss
+++ b/packages/ndla-ui/src/ResourceGroup/component.topic-resource.scss
@@ -41,6 +41,24 @@
           font-weight: $font-weight-normal;
         }
       }
+      &.subject-material:before {
+        background-color: $subject-material-dark;
+      }
+      &.tasks-and-activities:before {
+        background-color: $tasks-and-activities-dark;
+      }
+      &.assessment-resources:before {
+        background-color: $assessment-resource-dark;
+      }
+      &.learning-path:before {
+        background-color: $learning-path-dark;
+      }
+      &.external-learning-resources:before {
+        background-color: $external-learning-resource-dark;
+      }
+      &.source-material:before {
+        background-color: $source-material-dark;
+      }
       &:before {
         @include mq(tablet) {
           content: '';
@@ -50,16 +68,21 @@
           height: $spacing--small;
           border-radius: 100%;
           transform: translate(-($spacing + $spacing--small), $spacing + 1);
+
+
         }
       }
     }
     &__icon {
       display: flex;
+      align-items: center;
     }
     &__type {
-      align-self: center;
-      right: 30px;
-      @include font-size(16px, 18px);
+      font-family: $font;
+      @include font-size(14px, 18px);
+      font-weight: $font-weight-semibold;
+      color: $text-light-color;
+      text-align: right;
     }
   }
 
@@ -105,7 +128,9 @@
   &__icon {
     display: flex;
     text-align: center;
-    width: auto;
+    justify-content: center;
+    width: 42px;
+    box-sizing: content-box;
     padding-right: $spacing--small;
     @include mq(tablet) {
       padding-right: $spacing;

--- a/packages/ndla-ui/src/ResourcesWrapper/component.resources.scss
+++ b/packages/ndla-ui/src/ResourcesWrapper/component.resources.scss
@@ -83,8 +83,7 @@
     flex-flow: wrap;
     align-items: center;
     margin-top: $spacing--large;
-    border-bottom: 2px solid $brand-color--lighter;
-    padding-bottom: $spacing--small / 2;
+    padding-bottom: $spacing--small;
     width: 100%;
     flex-direction: row;
     justify-content: space-between;

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -279,6 +279,7 @@ const messages = {
     activateAdditionalResources: 'Show additional content',
     toggleFilterLabel: 'Show additional content',
     label: 'Learning content',
+    allResources: 'Content',
     shortcutButtonText: 'Learning material',
     tooltipCoreTopic: 'Core content is a subject that is on the curriculum',
     tooltipAdditionalTopic: 'Additional content is a subject that is not on the curriculum',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -281,6 +281,7 @@ const messages = {
     activateAdditionalResources: 'Tilleggsstoff',
     toggleFilterLabel: 'Tilleggsressurser',
     label: 'Læringsressurser',
+    allResources: 'Ressurser',
     shortcutButtonText: 'Lærestoff',
     tooltipCoreTopic: 'Kjernestoff',
     tooltipAdditionalTopic: 'Tilleggsstoff',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -282,6 +282,7 @@ const messages = {
     toggleFilterLabel: 'Tilleggsressursar',
     activateAdditionalResources: 'Tilleggsressursar',
     label: 'Læringsressursar',
+    allResources: 'Ressursar',
     shortcutButtonText: 'Lærestoff',
     tooltipCoreTopic: 'Kjernestoff',
     tooltipAdditionalTopic: 'Tilleggsstoff',

--- a/packages/ndla-ui/src/shapes.js
+++ b/packages/ndla-ui/src/shapes.js
@@ -65,6 +65,8 @@ export const ResourceShape = PropTypes.shape({
   name: PropTypes.string.isRequired,
   contentUri: PropTypes.string,
   primary: PropTypes.bool,
+  contentType: PropTypes.string,
+  type: PropTypes.string,
 });
 
 export const ShortcutShape = PropTypes.shape({

--- a/packages/ndla-ui/src/types.ts
+++ b/packages/ndla-ui/src/types.ts
@@ -23,10 +23,17 @@ type ResourceTypes = {
 };
 
 export type Resource = {
-  path: string;
+  id: string;
   name: string;
+  contentUri: string;
+  path: string;
+  primary?: boolean;
+  rank?: number;
   subject?: string;
   resourceTypes?: Array<ResourceTypes>;
+  contentType?: string;
+  active?: boolean;
+  additional?: boolean;
 };
 
 export interface Contributor {
@@ -73,13 +80,7 @@ export type SearchResult = {
 export interface ContentTypeResultType {
   title: string;
   contentType?: string;
-  resources: Array<{
-    path: string;
-    name: string;
-    subject?: string;
-    additional?: boolean;
-    resourceTypes?: Array<ResourceTypes>;
-  }>;
+  resources: Array<Resource>;
 }
 
 export type subjectProp = {


### PR DESCRIPTION
Har endra ResourceGroup litt slik at den skal kunne vise ei liste med ressurser uavhengig av ressurstype. Eg har fått til at ikonet har korrekt farge, og at navnet på gruppa vises som ekstrainfo, men skulle gjerne hatt det penere. Men der skulle eg gjerne hatt hjelp av en designer. Har du mulighet til å justere på utseendet, @beery ?
Sjekk sida http://localhost:6006/?path=/story/sammensatte-moduler--ugrupperte-l%C3%A6ringsressurser for slik det ser ut i dag.

Sletter også unødvendige eksempelsider.