### PR TITLE
Added i18next

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,5 +101,10 @@
     "style-loader": "^0.23.1",
     "ts-jest": "^26.5.4",
     "typescript": "^4.1.3"
+  },
+  "dependencies": {
+    "i18next": "^20.3.1",
+    "i18next-browser-languagedetector": "^6.1.1",
+    "react-i18next": "^11.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -102,9 +102,5 @@
     "ts-jest": "^26.5.4",
     "typescript": "^4.1.3"
   },
-  "dependencies": {
-    "i18next": "^20.3.1",
-    "i18next-browser-languagedetector": "^6.1.1",
-    "react-i18next": "^11.11.0"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -101,6 +101,5 @@
     "style-loader": "^0.23.1",
     "ts-jest": "^26.5.4",
     "typescript": "^4.1.3"
-  },
-  "dependencies": {}
+  }
 }

--- a/packages/ndla-forms/src/DropdownMenu.js
+++ b/packages/ndla-forms/src/DropdownMenu.js
@@ -9,11 +9,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { injectT } from '@ndla/i18n';
 import { colors, fonts, spacing, shadows, misc, animations } from '@ndla/core';
 import Pager from '@ndla/pager';
 import DropdownMenuItem from './DropdownMenuItem';
 import { getFieldValue, checkIfItemIsSelected } from './dropdownHelper';
+import { useTranslation } from 'react-i18next';
 
 const StyledDropDownContainer = styled.div`
   font-family: ${fonts.sans};
@@ -62,7 +62,6 @@ const DropdownMenu = ({
   loading,
   getItemProps,
   getMenuProps,
-  t,
   maxRender,
   multiSelect,
   onCreate,
@@ -79,6 +78,7 @@ const DropdownMenu = ({
   if (!isOpen) {
     return null;
   }
+  const {t} = useTranslation()
   return (
     <StyledDropDownContainer
       positionAbsolute={positionAbsolute}
@@ -160,4 +160,4 @@ DropdownMenu.defaultProps = {
   disableSelected: false,
 };
 
-export default injectT(DropdownMenu);
+export default DropdownMenu;

--- a/packages/ndla-forms/src/DropdownMenu.js
+++ b/packages/ndla-forms/src/DropdownMenu.js
@@ -9,11 +9,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import { useTranslation } from 'react-i18next';
 import { colors, fonts, spacing, shadows, misc, animations } from '@ndla/core';
 import Pager from '@ndla/pager';
 import DropdownMenuItem from './DropdownMenuItem';
 import { getFieldValue, checkIfItemIsSelected } from './dropdownHelper';
-import { useTranslation } from 'react-i18next';
 
 const StyledDropDownContainer = styled.div`
   font-family: ${fonts.sans};
@@ -75,10 +75,11 @@ const DropdownMenu = ({
   page,
   highlightedIndex,
 }) => {
+  const { t } = useTranslation();
   if (!isOpen) {
     return null;
   }
-  const {t} = useTranslation()
+
   return (
     <StyledDropDownContainer
       positionAbsolute={positionAbsolute}

--- a/packages/ndla-forms/src/DropdownMenuItem.js
+++ b/packages/ndla-forms/src/DropdownMenuItem.js
@@ -9,11 +9,11 @@
 import React from 'react';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
+import { useTranslation } from 'react-i18next';
 import { colors, fonts, spacing } from '@ndla/core';
 import { Check } from '@ndla/icons/editor';
 import { Information } from '@ndla/icons/common';
 import { DropdownMenuImage } from './DropdownMenuImage';
-import { useTranslation } from 'react-i18next';
 
 const StyledDescription = styled.span`
   ${fonts.sizes(14, 1.1)};
@@ -136,7 +136,7 @@ const InfoPart = ({ isSelected, disabledText, t }) => {
 };
 
 function DropdownMenuItem({ disableSelected, item, isSelected, highlighted, ...rest }) {
-  const {t} = useTranslation()
+  const { t } = useTranslation();
   return (
     <StyledItemButton
       key={item.id}

--- a/packages/ndla-forms/src/DropdownMenuItem.js
+++ b/packages/ndla-forms/src/DropdownMenuItem.js
@@ -8,12 +8,12 @@
 
 import React from 'react';
 import { css } from '@emotion/core';
-import { injectT } from '@ndla/i18n';
 import styled from '@emotion/styled';
 import { colors, fonts, spacing } from '@ndla/core';
 import { Check } from '@ndla/icons/editor';
 import { Information } from '@ndla/icons/common';
 import { DropdownMenuImage } from './DropdownMenuImage';
+import { useTranslation } from 'react-i18next';
 
 const StyledDescription = styled.span`
   ${fonts.sizes(14, 1.1)};
@@ -135,7 +135,8 @@ const InfoPart = ({ isSelected, disabledText, t }) => {
   return null;
 };
 
-function DropdownMenuItem({ disableSelected, item, isSelected, t, highlighted, ...rest }) {
+function DropdownMenuItem({ disableSelected, item, isSelected, highlighted, ...rest }) {
+  const {t} = useTranslation()
   return (
     <StyledItemButton
       key={item.id}
@@ -154,4 +155,4 @@ function DropdownMenuItem({ disableSelected, item, isSelected, t, highlighted, .
   );
 }
 
-export default injectT(DropdownMenuItem);
+export default DropdownMenuItem;

--- a/packages/ndla-i18n/package.json
+++ b/packages/ndla-i18n/package.json
@@ -34,7 +34,10 @@
     "hoist-non-react-statics": "^3.3.0",
     "intl-format-cache": "^4.3.1",
     "intl-messageformat": "5.4.3",
-    "invariant": "^2.2.3"
+    "invariant": "^2.2.3",
+    "i18next": "^20.3.1",
+    "i18next-browser-languagedetector": "^6.1.1",
+    "react-i18next": "^11.11.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ndla-i18n/src/i18n.ts
+++ b/packages/ndla-i18n/src/i18n.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+const DETECTION_OPTIONS = {
+  order: ['localStorage', 'path', 'htmlTag'],
+  caches: ['localStorage'],
+  lookupLocalStorage: 'i18nextLng',
+};
+
+const lng = ['nn', 'nb', 'en'];
+
+export const isValidLocale = (locale: string) => lng.find(l => l === locale) !== undefined;
+
+i18n.on('languageChanged', function(lng) {
+  if (typeof document != 'undefined') {
+    document.documentElement.lang = lng;
+  }
+  if (typeof window != 'undefined') {
+    const paths = window.location.pathname.split('/');
+    const basename = isValidLocale(paths[1]) ? `${paths[1]}` : '';
+    if (!(basename === '' && lng === 'nb')) {
+      const { search } = window.location;
+      window.history.replaceState({}, 'NDLA', `/${lng}/${search}`);
+    }
+  }
+});
+
+i18n
+  .use(initReactI18next)
+  .use(LanguageDetector)
+  .init({
+    detection: DETECTION_OPTIONS,
+    fallbackLng: 'nb',
+    resources: {},
+  });
+
+export default i18n;

--- a/packages/ndla-i18n/src/i18n.ts
+++ b/packages/ndla-i18n/src/i18n.ts
@@ -10,28 +10,10 @@ import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
 const DETECTION_OPTIONS = {
-  order: ['localStorage', 'path', 'htmlTag'],
+  order: ['path', 'localStorage', 'htmlTag'],
   caches: ['localStorage'],
   lookupLocalStorage: 'i18nextLng',
 };
-
-const lng = ['nn', 'nb', 'en'];
-
-export const isValidLocale = (locale: string) => lng.find(l => l === locale) !== undefined;
-
-i18n.on('languageChanged', function(lng) {
-  if (typeof document != 'undefined') {
-    document.documentElement.lang = lng;
-  }
-  if (typeof window != 'undefined') {
-    const paths = window.location.pathname.split('/');
-    const basename = isValidLocale(paths[1]) ? `${paths[1]}` : '';
-    if (!(basename === '' && lng === 'nb')) {
-      const { search } = window.location;
-      window.history.replaceState({}, 'NDLA', `/${lng}/${search}`);
-    }
-  }
-});
 
 i18n
   .use(initReactI18next)

--- a/packages/ndla-i18n/src/index.ts
+++ b/packages/ndla-i18n/src/index.ts
@@ -7,8 +7,10 @@
  */
 
 import IntlProvider from './IntlProvider';
-
+// @ts-ignore
 export { default as injectT } from './injectT';
+// @ts-ignore
+export { default as i18n } from './i18n';
 // @ts-ignore
 export { default as tType } from './t';
 export { default as formatMessage } from './formatMessage';
@@ -16,4 +18,6 @@ export { default as Trans } from './Trans';
 export { formatNestedMessages } from './formatNestedMessages';
 
 export { IntlProvider };
+// @ts-ignore
+
 export default IntlProvider;

--- a/packages/ndla-i18n/src/index.ts
+++ b/packages/ndla-i18n/src/index.ts
@@ -7,17 +7,12 @@
  */
 
 import IntlProvider from './IntlProvider';
-// @ts-ignore
 export { default as injectT } from './injectT';
-// @ts-ignore
 export { default as i18n } from './i18n';
 // @ts-ignore
 export { default as tType } from './t';
 export { default as formatMessage } from './formatMessage';
 export { default as Trans } from './Trans';
 export { formatNestedMessages } from './formatNestedMessages';
-
 export { IntlProvider };
-// @ts-ignore
-
 export default IntlProvider;

--- a/packages/ndla-listview/src/ListView.js
+++ b/packages/ndla-listview/src/ListView.js
@@ -199,107 +199,108 @@ const ListView = ({
     return text;
   },
 }) => {
-  const {t} = useTranslation()
+  const { t } = useTranslation();
 
-return (
-  <ListViewWrapper>
-    {filters ? (
-      <div {...filterClasses('wrapper-multiple-filters')}>
-        {filters.map(filter => (
-          <FilterListPhone
-            preid="list-view"
-            key={filter.key}
-            label={filter.label}
-            options={filter.options}
-            isGroupedOptions={filter.isGroupedOptions}
-            alignedGroup
-            showActiveFiltersOnSmallScreen
-            values={filter.filterValues}
-            messages={{
-              useFilter: t(`listview.filters.${filter.key}.useFilter`),
-              openFilter: t(`listview.filters.${filter.key}.openFilter`),
-              closeFilter: t(`listview.filters.${filter.key}.closeFilter`),
-            }}
-            onChange={values => {
-              filter.onChange(filter.key, values);
-            }}
-          />
-        ))}
-      </div>
-    ) : null}
-    <div className={'sorting'}>
-      {!disableSearch && (
-        <div className={'sorting-wrapper'}>
-          <div className={'search'}>
-            <div {...searchFieldClasses()}>
-              <div {...searchFieldClasses('input-wrapper', 'with-icon', 'search-input-wrapper')}>
-                <input
-                  css={inputStyle}
-                  type="search"
-                  placeholder={t(`listview.search.placeholder`)}
-                  value={searchValue}
-                  onChange={onChangedSearchValue}
-                />
+  return (
+    <ListViewWrapper>
+      {filters ? (
+        <div {...filterClasses('wrapper-multiple-filters')}>
+          {filters.map(filter => (
+            <FilterListPhone
+              preid="list-view"
+              key={filter.key}
+              label={filter.label}
+              options={filter.options}
+              isGroupedOptions={filter.isGroupedOptions}
+              alignedGroup
+              showActiveFiltersOnSmallScreen
+              values={filter.filterValues}
+              messages={{
+                useFilter: t(`listview.filters.${filter.key}.useFilter`),
+                openFilter: t(`listview.filters.${filter.key}.openFilter`),
+                closeFilter: t(`listview.filters.${filter.key}.closeFilter`),
+              }}
+              onChange={values => {
+                filter.onChange(filter.key, values);
+              }}
+            />
+          ))}
+        </div>
+      ) : null}
+      <div className={'sorting'}>
+        {!disableSearch && (
+          <div className={'sorting-wrapper'}>
+            <div className={'search'}>
+              <div {...searchFieldClasses()}>
+                <div {...searchFieldClasses('input-wrapper', 'with-icon', 'search-input-wrapper')}>
+                  <input
+                    css={inputStyle}
+                    type="search"
+                    placeholder={t(`listview.search.placeholder`)}
+                    value={searchValue}
+                    onChange={onChangedSearchValue}
+                  />
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      )}
-      {!disableViewOption && (
-        <div className={'list-style'}>
-          <button
-            type="button"
-            className={`style-button ${viewStyle === 'list' && 'active'}`}
-            onClick={() => onChangedViewStyle({ viewStyle: 'list' })}>
-            <ListIcon />
-          </button>
-          <button
-            type="button"
-            className={`style-button ${viewStyle === 'grid' && 'active'}`}
-            onClick={() => onChangedViewStyle({ viewStyle: 'grid' })}>
-            <GridIcon />
-          </button>
-        </div>
-      )}
+        )}
+        {!disableViewOption && (
+          <div className={'list-style'}>
+            <button
+              type="button"
+              className={`style-button ${viewStyle === 'list' && 'active'}`}
+              onClick={() => onChangedViewStyle({ viewStyle: 'list' })}>
+              <ListIcon />
+            </button>
+            <button
+              type="button"
+              className={`style-button ${viewStyle === 'grid' && 'active'}`}
+              onClick={() => onChangedViewStyle({ viewStyle: 'grid' })}>
+              <GridIcon />
+            </button>
+          </div>
+        )}
 
-      {selectedLetterCallback ? (
-        <ul className={'alphabet'}>
-          {Object.keys(alphabet).map(letter => (
-            <li key={`letter-${letter}`} className={'letter'}>
-              <button
-                type="button"
-                className={`letter-button ${selectedLetter === letter && 'active'} ${!alphabet[
-                  letter
-                ] && 'disabled'}`}
-                onClick={() =>
-                  selectedLetter === letter
-                    ? selectedLetterCallback('')
-                    : selectedLetterCallback(letter)
-                }>
-                {letter}
-              </button>
-            </li>
-          ))}
-        </ul>
-      ) : null}
-    </div>
-    <CountWrapper>{t('listview.hits', { count: totalCount })}</CountWrapper>
-    <div className={'content-wrapper'}>
-      <div className={`content ${viewStyle}`}>
-        {items.map(item => (
-          <ListItem
-            item={item}
-            key={item.id}
-            clickCallback={() => onSelectItem(item)}
-            viewStyle={viewStyle}
-            renderMarkdown={renderMarkdown}
-          />
-        ))}
+        {selectedLetterCallback ? (
+          <ul className={'alphabet'}>
+            {Object.keys(alphabet).map(letter => (
+              <li key={`letter-${letter}`} className={'letter'}>
+                <button
+                  type="button"
+                  className={`letter-button ${selectedLetter === letter && 'active'} ${!alphabet[
+                    letter
+                  ] && 'disabled'}`}
+                  onClick={() =>
+                    selectedLetter === letter
+                      ? selectedLetterCallback('')
+                      : selectedLetterCallback(letter)
+                  }>
+                  {letter}
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : null}
       </div>
-    </div>
-    {selectedItem}
-  </ListViewWrapper>
-)};
+      <CountWrapper>{t('listview.hits', { count: totalCount })}</CountWrapper>
+      <div className={'content-wrapper'}>
+        <div className={`content ${viewStyle}`}>
+          {items.map(item => (
+            <ListItem
+              item={item}
+              key={item.id}
+              clickCallback={() => onSelectItem(item)}
+              viewStyle={viewStyle}
+              renderMarkdown={renderMarkdown}
+            />
+          ))}
+        </div>
+      </div>
+      {selectedItem}
+    </ListViewWrapper>
+  );
+};
 
 const optionsShape = PropTypes.shape({
   title: PropTypes.string.isRequired,

--- a/packages/ndla-listview/src/ListView.js
+++ b/packages/ndla-listview/src/ListView.js
@@ -4,10 +4,9 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import BEMHelper from 'react-bem-helper';
 import { spacing, fonts, colors, misc, breakpoints, mq } from '@ndla/core';
-import { injectT } from '@ndla/i18n';
 import { FilterListPhone } from '@ndla/ui';
 import { List as ListIcon, Grid as GridIcon } from '@ndla/icons/action';
-
+import { useTranslation } from 'react-i18next';
 import ListItem from './ListItem';
 
 const ListViewWrapper = styled.div`
@@ -199,8 +198,10 @@ const ListView = ({
   renderMarkdown = text => {
     return text;
   },
-  t,
-}) => (
+}) => {
+  const {t} = useTranslation()
+
+return (
   <ListViewWrapper>
     {filters ? (
       <div {...filterClasses('wrapper-multiple-filters')}>
@@ -298,7 +299,7 @@ const ListView = ({
     </div>
     {selectedItem}
   </ListViewWrapper>
-);
+)};
 
 const optionsShape = PropTypes.shape({
   title: PropTypes.string.isRequired,
@@ -344,7 +345,6 @@ ListView.propTypes = {
   selectedItem: PropTypes.node,
   renderMarkdown: PropTypes.func.isRequired,
   totalCount: PropTypes.number.isRequired,
-  t: PropTypes.func.isRequired,
 };
 
 ListView.defaultProps = {
@@ -352,4 +352,4 @@ ListView.defaultProps = {
   selectedLetter: '',
 };
 
-export default injectT(ListView);
+export default ListView;

--- a/packages/ndla-notion/src/NotionHeader.js
+++ b/packages/ndla-notion/src/NotionHeader.js
@@ -9,8 +9,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { injectT } from '@ndla/i18n';
 import { spacing, colors, fonts, misc } from '@ndla/core';
+import { useTranslation } from 'react-i18next';
 
 const NotionHeaderWrapper = styled.div`
   margin: ${spacing.normal} ${spacing.normal} ${spacing.small};
@@ -56,7 +56,9 @@ export const NotionHeaderWithoutExitButton = ({ title, subTitle }) => (
   <NotionHeaderWrapper>{notionTitle(title, subTitle)}</NotionHeaderWrapper>
 );
 
-const NotionHeader = injectT(({ title, subTitle, onClose, t }) => (
+const NotionHeader = ({ title, subTitle, onClose }) => {
+  const {t} = useTranslation()
+  return(
   <NotionHeaderWrapper>
     {notionTitle(title, subTitle)}
     {onClose ? (
@@ -69,7 +71,7 @@ const NotionHeader = injectT(({ title, subTitle, onClose, t }) => (
       </button>
     )}
   </NotionHeaderWrapper>
-));
+)};
 
 NotionHeader.propTypes = {
   title: PropTypes.string.isRequired,

--- a/packages/ndla-notion/src/NotionHeader.js
+++ b/packages/ndla-notion/src/NotionHeader.js
@@ -57,21 +57,22 @@ export const NotionHeaderWithoutExitButton = ({ title, subTitle }) => (
 );
 
 const NotionHeader = ({ title, subTitle, onClose }) => {
-  const {t} = useTranslation()
-  return(
-  <NotionHeaderWrapper>
-    {notionTitle(title, subTitle)}
-    {onClose ? (
-      <button type="button" onClick={onClose}>
-        {t('notions.closeNotion')}
-      </button>
-    ) : (
-      <button type="button" data-notion-close>
-        {t('notions.closeNotion')}
-      </button>
-    )}
-  </NotionHeaderWrapper>
-)};
+  const { t } = useTranslation();
+  return (
+    <NotionHeaderWrapper>
+      {notionTitle(title, subTitle)}
+      {onClose ? (
+        <button type="button" onClick={onClose}>
+          {t('notions.closeNotion')}
+        </button>
+      ) : (
+        <button type="button" data-notion-close>
+          {t('notions.closeNotion')}
+        </button>
+      )}
+    </NotionHeaderWrapper>
+  );
+};
 
 NotionHeader.propTypes = {
   title: PropTypes.string.isRequired,

--- a/packages/ndla-ui/src/Footer/Footer.tsx
+++ b/packages/ndla-ui/src/Footer/Footer.tsx
@@ -9,7 +9,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { colors, spacing, fonts, mq, breakpoints } from '@ndla/core';
-import { injectT, tType } from '@ndla/i18n';
 // @ts-ignore
 import { FooterHeaderIcon } from '@ndla/icons/common';
 // @ts-ignore
@@ -17,6 +16,7 @@ import { OneColumn } from '../Layout';
 import FooterLinks from './FooterLinks';
 import FooterPrivacy from './FooterPrivacy';
 import { Locale } from '../types';
+import { useTranslation } from 'react-i18next';
 
 const StyledBackground = styled.div`
   display: block;
@@ -125,13 +125,14 @@ type Props = {
   languageSelector?: React.ReactNode;
 };
 
-const Footer: React.FunctionComponent<Props & tType> = ({
+const Footer: React.FunctionComponent<Props> = ({
   lang,
   children,
-  t,
   links,
   languageSelector,
 }) => {
+  const {t} = useTranslation()
+
   const mainContent = (
     <>
       {children}
@@ -168,4 +169,4 @@ const Footer: React.FunctionComponent<Props & tType> = ({
   );
 };
 
-export default injectT(Footer);
+export default Footer;

--- a/packages/ndla-ui/src/Footer/Footer.tsx
+++ b/packages/ndla-ui/src/Footer/Footer.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import styled from '@emotion/styled';
+import { useTranslation } from 'react-i18next';
 import { colors, spacing, fonts, mq, breakpoints } from '@ndla/core';
 // @ts-ignore
 import { FooterHeaderIcon } from '@ndla/icons/common';
@@ -16,7 +17,6 @@ import { OneColumn } from '../Layout';
 import FooterLinks from './FooterLinks';
 import FooterPrivacy from './FooterPrivacy';
 import { Locale } from '../types';
-import { useTranslation } from 'react-i18next';
 
 const StyledBackground = styled.div`
   display: block;
@@ -125,13 +125,8 @@ type Props = {
   languageSelector?: React.ReactNode;
 };
 
-const Footer: React.FunctionComponent<Props> = ({
-  lang,
-  children,
-  links,
-  languageSelector,
-}) => {
-  const {t} = useTranslation()
+const Footer: React.FunctionComponent<Props> = ({ lang, children, links, languageSelector }) => {
+  const { t } = useTranslation();
 
   const mainContent = (
     <>

--- a/packages/ndla-ui/src/LanguageSelector/LanguageSelector.tsx
+++ b/packages/ndla-ui/src/LanguageSelector/LanguageSelector.tsx
@@ -130,13 +130,6 @@ const styledInvertedOutlineLargeScreensOnly = css`
 `;
 
 type Props = {
-  options: {
-    [key: string]: {
-      name: string;
-      url: string;
-    };
-  };
-  currentLanguage: string;
   inverted?: boolean;
   invertedOutlineLargeScreensOnly?: boolean;
   outline?: boolean;
@@ -145,19 +138,16 @@ type Props = {
 };
 
 const LanguageSelector: React.FunctionComponent<Props> = ({
-  options,
-  currentLanguage,
   outline,
   center,
   inverted,
   invertedOutlineLargeScreensOnly,
   alwaysVisible,
 }) => {
-  currentLanguage = localStorage.getItem('i18nextLng') as string;
-  const [infoLocale, setInfoLocale] = useState(currentLanguage);
+  const { t, i18n } = useTranslation();
+  const [infoLocale, setInfoLocale] = useState(i18n.language);
   const [isOpen, setIsOpen] = useState(false);
-  const { t } = useTranslation();
-
+  
   return (
     <StyledWrapper alwaysVisible={alwaysVisible}>
       <Button

--- a/packages/ndla-ui/src/LanguageSelector/LanguageSelector.tsx
+++ b/packages/ndla-ui/src/LanguageSelector/LanguageSelector.tsx
@@ -10,7 +10,7 @@ import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import FocusTrapReact from 'focus-trap-react';
-import { injectT, tType } from '@ndla/i18n';
+import { useTranslation } from 'react-i18next';
 // @ts-ignore
 import Button, { appearances } from '@ndla/button';
 import { spacing, misc, colors, mq, breakpoints, animations, fonts } from '@ndla/core';
@@ -144,7 +144,7 @@ type Props = {
   alwaysVisible?: boolean;
 };
 
-const LanguageSelector: React.FunctionComponent<Props & tType> = ({
+const LanguageSelector: React.FunctionComponent<Props> = ({
   options,
   currentLanguage,
   outline,
@@ -152,10 +152,12 @@ const LanguageSelector: React.FunctionComponent<Props & tType> = ({
   inverted,
   invertedOutlineLargeScreensOnly,
   alwaysVisible,
-  t,
 }) => {
+  currentLanguage = localStorage.getItem('i18nextLng') as string;
   const [infoLocale, setInfoLocale] = useState(currentLanguage);
   const [isOpen, setIsOpen] = useState(false);
+  const { t } = useTranslation();
+
   return (
     <StyledWrapper alwaysVisible={alwaysVisible}>
       <Button
@@ -188,12 +190,7 @@ const LanguageSelector: React.FunctionComponent<Props & tType> = ({
               }}>
               {t('masthead.menu.close')}
             </Button>
-            <LanguageSelectorContent
-              options={options}
-              currentLanguage={currentLanguage}
-              setInfoLocale={setInfoLocale}
-              infoLocale={infoLocale}
-            />
+            <LanguageSelectorContent setInfoLocale={setInfoLocale} infoLocale={infoLocale} />
           </StyledModal>
         </FocusTrapReact>
       )}
@@ -201,4 +198,4 @@ const LanguageSelector: React.FunctionComponent<Props & tType> = ({
   );
 };
 
-export default injectT(LanguageSelector);
+export default LanguageSelector;

--- a/packages/ndla-ui/src/LanguageSelector/LanguageSelector.tsx
+++ b/packages/ndla-ui/src/LanguageSelector/LanguageSelector.tsx
@@ -147,7 +147,7 @@ const LanguageSelector: React.FunctionComponent<Props> = ({
   const { t, i18n } = useTranslation();
   const [infoLocale, setInfoLocale] = useState(i18n.language);
   const [isOpen, setIsOpen] = useState(false);
-  
+
   return (
     <StyledWrapper alwaysVisible={alwaysVisible}>
       <Button

--- a/packages/ndla-ui/src/LanguageSelector/LanguageSelectorContent.tsx
+++ b/packages/ndla-ui/src/LanguageSelector/LanguageSelectorContent.tsx
@@ -5,29 +5,43 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import React from 'react';
+import { css } from '@emotion/core';
 import { useTranslation } from 'react-i18next';
 
 type Props = {
   setInfoLocale(arg: string): void;
   infoLocale: string;
 };
+const languageButton = css`
+  background: transparent;
+  color: #184673;
+  width: 100%;
+  padding: 13px 65px;
+  justify-content: center;
+  border: none;
+`;
 
-const LanguageSelectorContent: React.FunctionComponent<Props> = ({ setInfoLocale, infoLocale }) => {
+const LanguageSelectorContent = ({ setInfoLocale, infoLocale }:Props) => {
   const { t, i18n } = useTranslation();
-  const lngs = ['nn', 'nb'];
-
+  const languages = i18n.options.supportedLngs as string[]
+  
+  //CIMODE is used for testing to consistently return the translation key instead of the variant value
+  let i = languages.indexOf("cimode")
+  if(i > -1) {
+    console.log(i)
+    languages.splice(i)
+  }
   return (
     <nav>
       <ul>
-        {lngs.map(key => (
+        {languages.map(key => (
           <li key={key}>
             {key === i18n.language ? (
               <span>{t(`languages.${key}`)}</span>
             ) : (
               // eslint-disable-next-line
-              <a
+              <button css={languageButton}
                 onMouseOver={() => {
                   setInfoLocale(key);
                 }}
@@ -40,7 +54,7 @@ const LanguageSelectorContent: React.FunctionComponent<Props> = ({ setInfoLocale
                 }}
                 aria-label={t(`changeLanguage.${key}`)}>
                 {t(`languages.${key}`)}
-              </a>
+              </button>
             )}
           </li>
         ))}

--- a/packages/ndla-ui/src/LanguageSelector/LanguageSelectorContent.tsx
+++ b/packages/ndla-ui/src/LanguageSelector/LanguageSelectorContent.tsx
@@ -7,50 +7,46 @@
  */
 
 import React from 'react';
-import { injectT, tType } from '@ndla/i18n';
+import { useTranslation } from 'react-i18next';
 
 type Props = {
-  options: {
-    [key: string]: {
-      name: string;
-      url: string;
-    };
-  };
-  currentLanguage: string;
   setInfoLocale(arg: string): void;
   infoLocale: string;
 };
 
-const LanguageSelectorContent: React.FunctionComponent<Props & tType> = ({
-  options,
-  currentLanguage,
-  setInfoLocale,
-  infoLocale,
-  t,
-}) => (
-  <nav>
-    <ul>
-      {Object.keys(options).map(key => (
-        <li key={key}>
-          {key === currentLanguage ? (
-            <span>{options[key].name}</span>
-          ) : (
-            <a
-              href={options[key].url}
-              onMouseOver={() => {
-                setInfoLocale(key);
-              }}
-              onMouseOut={() => {
-                setInfoLocale(currentLanguage);
-              }}
-              aria-label={t(`changeLanguage.${key}`)}>
-              {options[key].name}
-            </a>
-          )}
-        </li>
-      ))}
-    </ul>
-    <p>{t(`currentLanguageText.${infoLocale}`)}</p>
-  </nav>
-);
-export default injectT(LanguageSelectorContent);
+const LanguageSelectorContent: React.FunctionComponent<Props> = ({ setInfoLocale, infoLocale }) => {
+  const { t, i18n } = useTranslation();
+  const lngs = ['nn', 'nb'];
+
+  return (
+    <nav>
+      <ul>
+        {lngs.map(key => (
+          <li key={key}>
+            {key === i18n.language ? (
+              <span>{t(`languages.${key}`)}</span>
+            ) : (
+              // eslint-disable-next-line
+              <a
+                onMouseOver={() => {
+                  setInfoLocale(key);
+                }}
+                onMouseOut={() => {
+                  setInfoLocale(i18n.language);
+                }}
+                onClick={() => {
+                  i18n.changeLanguage(key);
+                  setInfoLocale(key);
+                }}
+                aria-label={t(`changeLanguage.${key}`)}>
+                {t(`languages.${key}`)}
+              </a>
+            )}
+          </li>
+        ))}
+      </ul>
+      <p>{t(`currentLanguageText.${infoLocale}`)}</p>
+    </nav>
+  );
+};
+export default LanguageSelectorContent;

--- a/packages/ndla-ui/src/LanguageSelector/LanguageSelectorContent.tsx
+++ b/packages/ndla-ui/src/LanguageSelector/LanguageSelectorContent.tsx
@@ -22,15 +22,14 @@ const languageButton = css`
   border: none;
 `;
 
-const LanguageSelectorContent = ({ setInfoLocale, infoLocale }:Props) => {
+const LanguageSelectorContent = ({ setInfoLocale, infoLocale }: Props) => {
   const { t, i18n } = useTranslation();
-  const languages = i18n.options.supportedLngs as string[]
-  
+  const languages = i18n.options.supportedLngs as string[];
+
   //CIMODE is used for testing to consistently return the translation key instead of the variant value
-  let i = languages.indexOf("cimode")
-  if(i > -1) {
-    console.log(i)
-    languages.splice(i)
+  let i = languages.indexOf('cimode');
+  if (i > -1) {
+    languages.splice(i);
   }
   return (
     <nav>
@@ -41,7 +40,8 @@ const LanguageSelectorContent = ({ setInfoLocale, infoLocale }:Props) => {
               <span>{t(`languages.${key}`)}</span>
             ) : (
               // eslint-disable-next-line
-              <button css={languageButton}
+              <button
+                css={languageButton}
                 onMouseOver={() => {
                   setInfoLocale(key);
                 }}

--- a/packages/ndla-ui/src/LanguageSelector/LanguageSelectorContent.tsx
+++ b/packages/ndla-ui/src/LanguageSelector/LanguageSelectorContent.tsx
@@ -39,7 +39,6 @@ const LanguageSelectorContent = ({ setInfoLocale, infoLocale }: Props) => {
             {key === i18n.language ? (
               <span>{t(`languages.${key}`)}</span>
             ) : (
-              // eslint-disable-next-line
               <button
                 css={languageButton}
                 onMouseOver={() => {

--- a/packages/ndla-ui/src/Search/ActiveFilters.jsx
+++ b/packages/ndla-ui/src/Search/ActiveFilters.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import css from '@emotion/css';
+import { useTranslation } from 'react-i18next';
 import { spacing, mq, breakpoints } from '@ndla/core';
 import Tooltip from '@ndla/tooltip';
 import ActiveFilterContent, { StyledActiveFilterTitle } from './ActiveFilterContent';
-import { useTranslation } from 'react-i18next';
 
 const StyledActiveFilters = styled('ul')`
   margin: 0;
@@ -73,8 +73,8 @@ const StyledActiveFilterWrapper = styled('li')`
 const getFilterLength = filters =>
   filters.filter(filter => filter.filterName === 'filter_subjects' && filter.title).length;
 
-const ActiveFilters = ({ filters, onFilterRemove, showOnSmallScreen}) => {
-const {t} = useTranslation();
+const ActiveFilters = ({ filters, onFilterRemove, showOnSmallScreen }) => {
+  const { t } = useTranslation();
   if (filters && filters.length > 0) {
     const filterLength = getFilterLength(filters);
 

--- a/packages/ndla-ui/src/Search/ActiveFilters.jsx
+++ b/packages/ndla-ui/src/Search/ActiveFilters.jsx
@@ -4,8 +4,8 @@ import styled from '@emotion/styled';
 import css from '@emotion/css';
 import { spacing, mq, breakpoints } from '@ndla/core';
 import Tooltip from '@ndla/tooltip';
-import { injectT } from '@ndla/i18n';
 import ActiveFilterContent, { StyledActiveFilterTitle } from './ActiveFilterContent';
+import { useTranslation } from 'react-i18next';
 
 const StyledActiveFilters = styled('ul')`
   margin: 0;
@@ -73,7 +73,8 @@ const StyledActiveFilterWrapper = styled('li')`
 const getFilterLength = filters =>
   filters.filter(filter => filter.filterName === 'filter_subjects' && filter.title).length;
 
-const ActiveFilters = ({ filters, onFilterRemove, showOnSmallScreen, t }) => {
+const ActiveFilters = ({ filters, onFilterRemove, showOnSmallScreen}) => {
+const {t} = useTranslation();
   if (filters && filters.length > 0) {
     const filterLength = getFilterLength(filters);
 
@@ -132,4 +133,4 @@ ActiveFilters.propTypes = {
   onFilterRemove: PropTypes.func.isRequired,
 };
 
-export default injectT(ActiveFilters);
+export default ActiveFilters;

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -549,7 +549,7 @@ const messages = {
     relatedLinks: {
       label: 'Related articles',
     },
-    hits: '{count} hits',
+    hits: '{{count}} hits',
   },
   notions: {
     closeNotion: 'Close',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -548,7 +548,7 @@ const messages = {
     relatedLinks: {
       label: 'Tilknyttede artikler',
     },
-    hits: '{count} treff',
+    hits: '{{count}} treff',
   },
   notions: {
     closeNotion: 'Lukk',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -549,7 +549,7 @@ const messages = {
     relatedLinks: {
       label: 'Tilknytta artiklar',
     },
-    hits: '{count} treff',
+    hits: '{{count}} treff',
   },
   notions: {
     closeNotion: 'Lukk',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1924,6 +1924,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.14.5":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
@@ -10247,6 +10254,13 @@ html-minifier-terser@^5.0.1:
     relateurl "^0.2.7"
     terser "^4.6.3"
 
+html-parse-stringify@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2"
+  integrity sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==
+  dependencies:
+    void-elements "3.1.0"
+
 html-react-parser@^0.10.3:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-0.10.5.tgz#d05e3efd8ffaff692007b99b5b7d54f05a6c5f37"
@@ -10352,6 +10366,20 @@ humanize-ms@^1.2.1:
   integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
   dependencies:
     ms "^2.0.0"
+
+i18next-browser-languagedetector@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.1.1.tgz#fc4c6606bb3f7afc331737cf7c41e50919d55542"
+  integrity sha512-hckgbBdCpJPhkGUANe6tsvD52k9R7GuYskG0EaIw89pZz3owUvUEwXHqM5pX1Pn93jz+O65Y09ikwJrMkqtq2Q==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+
+i18next@^20.3.1:
+  version "20.3.1"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-20.3.1.tgz#b51dd281a2eec8087753edf1727e160dac8a5554"
+  integrity sha512-WTY07KreR5z2LBSzAIKs05zpR5tgUT98C4fD96e7Risbc/HZePwF6AEnb9VkjdeSeRn9PDqQBay7ZkphuXt0Xw==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
@@ -14827,6 +14855,14 @@ react-helmet@^5.2.0:
     react-fast-compare "^2.0.2"
     react-side-effect "^1.1.0"
 
+react-i18next@^11.11.0:
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.11.0.tgz#2f7c6cb4f81f94d1728a02d60e4bb5216709f942"
+  integrity sha512-p1jHmoyJgDFQmyubUEjrx6kCsr1izW/C8i9pOiJy+9lJqLYwNA8sElVplm0VAnop3kH68edT0/g3wB3UvAcRCQ==
+  dependencies:
+    "@babel/runtime" "^7.14.5"
+    html-parse-stringify "^3.0.1"
+
 react-inspector@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.0.tgz#45a325e15f33e595be5356ca2d3ceffb7d6b8c3a"
@@ -17758,6 +17794,11 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+void-elements@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
+  integrity sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1924,7 +1924,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.12.0", "@babel/runtime@^7.14.5":
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.14.5", "@babel/runtime@^7.14.6":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
   integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
@@ -10368,16 +10368,16 @@ humanize-ms@^1.2.1:
     ms "^2.0.0"
 
 i18next-browser-languagedetector@^6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.1.1.tgz#fc4c6606bb3f7afc331737cf7c41e50919d55542"
-  integrity sha512-hckgbBdCpJPhkGUANe6tsvD52k9R7GuYskG0EaIw89pZz3owUvUEwXHqM5pX1Pn93jz+O65Y09ikwJrMkqtq2Q==
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.1.2.tgz#68565a28b929cbc98ab6a56826ef2faf0e927ff8"
+  integrity sha512-YDzIGHhMRvr7M+c8B3EQUKyiMBhfqox4o1qkFvt4QXuu5V2cxf74+NCr+VEkUuU0y+RwcupA238eeolW1Yn80g==
   dependencies:
-    "@babel/runtime" "^7.5.5"
+    "@babel/runtime" "^7.14.6"
 
 i18next@^20.3.1:
-  version "20.3.1"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-20.3.1.tgz#b51dd281a2eec8087753edf1727e160dac8a5554"
-  integrity sha512-WTY07KreR5z2LBSzAIKs05zpR5tgUT98C4fD96e7Risbc/HZePwF6AEnb9VkjdeSeRn9PDqQBay7ZkphuXt0Xw==
+  version "20.3.2"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-20.3.2.tgz#5195e76b9e0848a1c198001bf6c7fc72995a55f1"
+  integrity sha512-e8CML2R9Ng2sSQOM80wb/PrM2j8mDm84o/T4Amzn9ArVyNX5/ENWxxAXkRpZdTQNDaxKImF93Wep4mAoozFrKw==
   dependencies:
     "@babel/runtime" "^7.12.0"
 


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2605

Added an i18next instance in the ndla-i18n package. This is exported for use in the other frontends. This way all components can share i18n instance. The instance needs to be exported and used in a provider wrapped around `<App>` to work. 

The language is saved in the path, localStorage and in the HTML language tag. Earlier it has also been saved in window.initialstate in a locale variable. Since I am not sure if that variable is needed, I have not implemented that now. Does anyone know if the variable is used?

You have to locally link to i18n, ui, notion, listview and form to listing-frontend to test.

