### PR TITLE
Initialiserer i18n med kall frå frontend

### DIFF
--- a/packages/ndla-i18n/src/i18n.ts
+++ b/packages/ndla-i18n/src/i18n.ts
@@ -15,13 +15,19 @@ const DETECTION_OPTIONS = {
   caches: ['localStorage'],
   lookupLocalStorage: 'i18nextLng',
 };
-i18n
-  .use(initReactI18next)
-  .use(LanguageDetector)
-  .init({
-    detection: DETECTION_OPTIONS,
-    fallbackLng: 'nb',
-    supportedLngs: ['nb'],
-    resources: {},
-  });
-export { i18n, useTranslation, I18nextProvider, withTranslation };
+
+const initializeI18n = (languages: string[], translation: any) => {
+  i18n
+    .use(initReactI18next)
+    .use(LanguageDetector)
+    .init({
+      detection: DETECTION_OPTIONS,
+      fallbackLng: 'nb',
+      supportedLngs: languages,
+      resources: translation,
+    });
+
+  return i18n;
+};
+
+export { initializeI18n, useTranslation, I18nextProvider, withTranslation };

--- a/packages/ndla-i18n/src/i18n.ts
+++ b/packages/ndla-i18n/src/i18n.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import i18n from 'i18next';
+import i18n, { Resource as TranslationResource } from 'i18next';
 import { initReactI18next, I18nextProvider, withTranslation, useTranslation } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
@@ -16,7 +16,7 @@ const DETECTION_OPTIONS = {
   lookupLocalStorage: 'i18nextLng',
 };
 
-const initializeI18n = (languages: string[], translation: any) => {
+const initializeI18n = (languages: string[], translation: TranslationResource) => {
   i18n
     .use(initReactI18next)
     .use(LanguageDetector)

--- a/packages/ndla-i18n/src/index.ts
+++ b/packages/ndla-i18n/src/index.ts
@@ -14,6 +14,6 @@ export { default as tType } from './t';
 export { default as formatMessage } from './formatMessage';
 export { default as Trans } from './Trans';
 export { formatNestedMessages } from './formatNestedMessages';
-export { useTranslation, withTranslation, i18n, I18nextProvider } from './i18n';
+export { useTranslation, withTranslation, initializeI18n, I18nextProvider } from './i18n';
 export { IntlProvider };
 export default IntlProvider;


### PR DESCRIPTION
Gjer eit forsøk til på å dele instans mellom `@ndla/i18n` og listing-frontend. Denne gongen ved å initialisere i18n med eit kall frå frontend.

Sender inn språk og oversettingsfiler i frontend og sender i18n instansen deretter i ein provider. 

