### PR TITLE
Fix overlapping filters in dropdownmenu for listing

### DIFF
--- a/packages/ndla-forms/src/DropdownMenu.js
+++ b/packages/ndla-forms/src/DropdownMenu.js
@@ -21,7 +21,7 @@ const StyledDropDownContainer = styled.div`
   border-radius: ${misc.borderRadius};
   box-shadow: ${shadows.levitate1};
   transition: height 100ms ease;
-  ${props => props.positionAbsolute && 'position: absolute; z-index: 1;'}
+  ${props => props.positionAbsolute && 'position: absolute; z-index: 99;'}
   width: 100%;
 `;
 


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2639

Fungerte å sette z-index til 3, men valgte å sette verdien til 99. Dette er fordi jeg ikke forestiller meg scenarioer hvor man ikke ønsker at dropdownmenyen er fremst. 

Screenshot av fiks i listing:

![image](https://user-images.githubusercontent.com/54741055/124563850-b91eaa80-de40-11eb-9d61-abaa0252aa63.png)
