### PR TITLE
initialiserer i18n i ndla/ui

### DIFF
--- a/packages/ndla-ui/src/i18n/i18n.ts
+++ b/packages/ndla-ui/src/i18n/i18n.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import i18n from 'i18next';
+import { initReactI18next, I18nextProvider, withTranslation, useTranslation } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+import messagesEN from '../locale/messages-en';
+import messagesNN from '../locale/messages-nn';
+import messagesNB from '../locale/messages-nb';
+
+const DETECTION_OPTIONS = {
+  order: ['path', 'localStorage', 'htmlTag'],
+  caches: ['localStorage'],
+  lookupLocalStorage: 'i18nextLng',
+};
+
+i18n
+  .use(initReactI18next)
+  .use(LanguageDetector)
+  .init({
+    detection: DETECTION_OPTIONS,
+    fallbackLng: 'nb',
+    supportedLngs: ['nb', 'nn', 'en'],
+    resources: {
+      en: {
+        translation: messagesEN,
+      },
+      nn: {
+        translation: messagesNN,
+      },
+      nb: {
+        translation: messagesNB,
+      },
+    },
+  });
+
+export { i18n, useTranslation, I18nextProvider, withTranslation };

--- a/packages/ndla-ui/src/i18n/index.ts
+++ b/packages/ndla-ui/src/i18n/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export { useTranslation, withTranslation, i18n, I18nextProvider } from './i18n';

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -100,3 +100,4 @@ export { default as Topic } from './Topic';
 export { default as Breadcrumb, BreadcrumbBlock } from './Breadcrumb';
 
 export type { BreadcrumbItemProps } from './Breadcrumblist/Breadcrumblist';
+export { useTranslation, withTranslation, i18n, I18nextProvider } from './i18n';


### PR DESCRIPTION
Sidan komponentar i frontend packages ikkje klarar å dele i18n instans med listing-frontend går eg for løysinga med å oppdatere språk med refresh av sida. Alle i18n instansar vil då sjekke URLen etter språkkode og få riktig språk deretter.

Initialisering av i18next skjer i @ndla/ui. Denne blir delt av ui komponentar. I tillegg vil kvar frontend legge til ekstra oversetting i sin eigendefinerte i18n.ts fil.