### PR TITLE
Adding constants for subject categories.

### DIFF
--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -45,7 +45,7 @@ const messages = {
     notSupported:
       'It did not work to auto-insert the content. You can copy the source code and add it to your content.',
   },
-  subjectCagegories: {
+  subjectCategories: {
     [subjectCategories.ARCHIVE_SUBJECTS]: 'LK06-subjects',
     [subjectCategories.BETA_SUBJECTS]: 'Beta subjects',
     [subjectCategories.COMMON_SUBJECTS]: 'Common core subjects',

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -9,7 +9,7 @@
 import { contributorTypes } from '@ndla/licenses';
 import constants from '../model';
 
-export const { contentTypes } = constants;
+export const { contentTypes, subjectCategories } = constants;
 
 const titleTemplate = ' - NDLA';
 
@@ -44,6 +44,13 @@ const messages = {
     embed: 'Embed',
     notSupported:
       'It did not work to auto-insert the content. You can copy the source code and add it to your content.',
+  },
+  subjectCagegories: {
+    [subjectCategories.ARCHIVE_SUBJECTS]: 'LK06-subjects',
+    [subjectCategories.BETA_SUBJECTS]: 'Beta subjects',
+    [subjectCategories.COMMON_SUBJECTS]: 'Common core subjects',
+    [subjectCategories.PROGRAMME_SUBJECTS]: 'Programme subjects SF',
+    [subjectCategories.SPECIALIZED_SUBJECTS]: 'Programme subjects YF',
   },
   searchPage: {
     noHits: 'Your search - {query} - did not match any articles. ',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -9,7 +9,7 @@
 import { contributorTypes } from '@ndla/licenses';
 import constants from '../model';
 
-export const { contentTypes } = constants;
+export const { contentTypes, subjectCategories } = constants;
 
 const titleTemplate = ' - NDLA';
 
@@ -44,6 +44,13 @@ const messages = {
     embed: 'Sett inn',
     notSupported:
       'Det fungerte ikke å sette inn innholdet automatisk. Kopier kildekoden under for å sette inn på din side.',
+  },
+  subjectCagegories: {
+    [subjectCategories.ARCHIVE_SUBJECTS]: 'LK06-fag',
+    [subjectCategories.BETA_SUBJECTS]: 'Betafag',
+    [subjectCategories.COMMON_SUBJECTS]: 'Fellesfag',
+    [subjectCategories.PROGRAMME_SUBJECTS]: 'Programfag SF',
+    [subjectCategories.SPECIALIZED_SUBJECTS]: 'Yrkesfag',
   },
   searchPage: {
     noHits: 'Ingen artikler samsvarte med søket ditt på: {query}',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -45,7 +45,7 @@ const messages = {
     notSupported:
       'Det fungerte ikke å sette inn innholdet automatisk. Kopier kildekoden under for å sette inn på din side.',
   },
-  subjectCagegories: {
+  subjectCategories: {
     [subjectCategories.ARCHIVE_SUBJECTS]: 'LK06-fag',
     [subjectCategories.BETA_SUBJECTS]: 'Betafag',
     [subjectCategories.COMMON_SUBJECTS]: 'Fellesfag',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -9,7 +9,7 @@
 import { contributorTypes } from '@ndla/licenses';
 import constants from '../model';
 
-export const { contentTypes } = constants;
+export const { contentTypes, subjectCategories } = constants;
 
 const titleTemplate = ' - NDLA';
 
@@ -44,6 +44,13 @@ const messages = {
     embed: 'Sett inn',
     notSupported:
       'Det fungerte ikkje å setje inn innhaldet automatisk. Kopier kjeldekoden under for å setje han inn på sida di.',
+  },
+  subjectCagegories: {
+    [subjectCategories.ARCHIVE_SUBJECTS]: 'LK06-fag',
+    [subjectCategories.BETA_SUBJECTS]: 'Betafag',
+    [subjectCategories.COMMON_SUBJECTS]: 'Fellesfag',
+    [subjectCategories.PROGRAMME_SUBJECTS]: 'Programfag SF',
+    [subjectCategories.SPECIALIZED_SUBJECTS]: 'Yrkesfag',
   },
   searchPage: {
     noHits: 'Ingen artiklar samsvarte med søket ditt på: {query}',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -45,7 +45,7 @@ const messages = {
     notSupported:
       'Det fungerte ikkje å setje inn innhaldet automatisk. Kopier kjeldekoden under for å setje han inn på sida di.',
   },
-  subjectCagegories: {
+  subjectCategories: {
     [subjectCategories.ARCHIVE_SUBJECTS]: 'LK06-fag',
     [subjectCategories.BETA_SUBJECTS]: 'Betafag',
     [subjectCategories.COMMON_SUBJECTS]: 'Fellesfag',

--- a/packages/ndla-ui/src/model/SubjectCategories.ts
+++ b/packages/ndla-ui/src/model/SubjectCategories.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export const COMMON_SUBJECTS = 'common';
+export const PROGRAMME_SUBJECTS = 'programme';
+export const SPECIALIZED_SUBJECTS = 'specialised';
+export const BETA_SUBJECTS = 'beta';
+export const ARCHIVE_SUBJECTS = 'archive';

--- a/packages/ndla-ui/src/model/SubjectCategories.ts
+++ b/packages/ndla-ui/src/model/SubjectCategories.ts
@@ -8,6 +8,6 @@
 
 export const COMMON_SUBJECTS = 'common';
 export const PROGRAMME_SUBJECTS = 'programme';
-export const SPECIALIZED_SUBJECTS = 'specialised';
+export const SPECIALIZED_SUBJECTS = 'specialized';
 export const BETA_SUBJECTS = 'beta';
 export const ARCHIVE_SUBJECTS = 'archive';

--- a/packages/ndla-ui/src/model/index.ts
+++ b/packages/ndla-ui/src/model/index.ts
@@ -7,9 +7,11 @@
  */
 
 import * as contentTypes from './ContentType';
+import * as subjectCategories from './SubjectCategories';
 
 const model = {
   contentTypes,
+  subjectCategories,
 };
 
 export default model;


### PR DESCRIPTION
NDLANO/Issues#2671

Første steg i å bruke taksonomi for å hente fag er å kunne kategorisere dei. Denne PR legger til kategoriene som brukes på ndla.no i dag. Disse skal brukes i ed for å kategorisere fag, og i ndla.no for å vise gruppert.