### PR TITLE
Show ungrouped resources in topic menu

### DIFF
--- a/packages/designmanual/dummydata/mockTopics.js
+++ b/packages/designmanual/dummydata/mockTopics.js
@@ -191,6 +191,11 @@ export const topicMenu = [
         name: 'Idéutvikling',
         contentUri: null,
         contentTypeResults: contentTypeResultsMenu,
+        metadata: {
+          customFields: {
+            'topic-resources': 'ungrouped',
+          },
+        },
       },
       {
         id: 'urn:topic:169397',

--- a/packages/ndla-ui/src/Search/ContentTypeResult.tsx
+++ b/packages/ndla-ui/src/Search/ContentTypeResult.tsx
@@ -55,6 +55,7 @@ type Props = {
   keyboardPathNavigation: HTMLElement | string | null;
   inMenu?: boolean;
   animateList?: number;
+  unGrouped?: boolean;
 };
 
 const ContentTypeResult: React.FC<Props & tType> = ({
@@ -68,6 +69,7 @@ const ContentTypeResult: React.FC<Props & tType> = ({
   keyboardPathNavigation,
   inMenu,
   animateList,
+  unGrouped,
   t,
 }) => {
   const [showAll, toggleShowAll] = useState(false);
@@ -91,18 +93,21 @@ const ContentTypeResult: React.FC<Props & tType> = ({
       });
     }
   }, [showAll]);
+
   return (
     <StyledWrapper>
-      <StyledHeader>
-        {!ignoreContentTypeBadge && contentTypeResult.contentType && (
-          <ContentTypeBadge type={contentTypeResult.contentType} size="x-small" background outline />
-        )}
-        <h1>
-          {contentTypeResult.title} <small>({results.length})</small>
-        </h1>
-      </StyledHeader>
+      {!unGrouped && (
+        <StyledHeader>
+          {!ignoreContentTypeBadge && contentTypeResult.contentType && (
+            <ContentTypeBadge type={contentTypeResult.contentType} size="x-small" background outline />
+          )}
+          <h1>
+            {contentTypeResult.title} <small>({results.length})</small>
+          </h1>
+        </StyledHeader>
+      )}
       {resources.length > 0 ? (
-        <StyledList inMenu={inMenu} animateList={animateList}>
+        <StyledList inMenu={inMenu} animateList={animateList} unGrouped={unGrouped}>
           {resources.map((resource) => {
             const { path, name, resourceTypes, subject, additional } = resource;
 
@@ -137,6 +142,9 @@ const ContentTypeResult: React.FC<Props & tType> = ({
                       onNavigate();
                     }
                   }}>
+                  {unGrouped && !ignoreContentTypeBadge && (
+                    <ContentTypeBadge type={resource.contentType} size="x-small" background outline />
+                  )}
                   {linkContent}
                   {renderAdditionalIcon(t('resource.additionalTooltip'), additional)}
                 </SafeLink>

--- a/packages/ndla-ui/src/Search/ContentTypeResultStyles.tsx
+++ b/packages/ndla-ui/src/Search/ContentTypeResultStyles.tsx
@@ -22,6 +22,7 @@ export const noWidthhighlightStyle = css`
 type inMenuProps = {
   inMenu?: boolean;
   animateList?: number;
+  unGrouped?: boolean;
 };
 
 export const StyledNoHit = styled.p<inMenuProps>`
@@ -98,6 +99,9 @@ export const StyledList = styled.ul<inMenuProps>`
   li {
     margin: 0 -${spacing.small};
     a {
+      > div {
+        margin-right: ${spacing.small};
+      }
       color: ${colors.brand.primary};
       box-shadow: none;
       display: inline-flex;
@@ -118,7 +122,7 @@ export const StyledList = styled.ul<inMenuProps>`
         props.inMenu
           ? css`
               ${mq.range({ from: breakpoints.desktop })} {
-                margin-left: ${spacingUnit * 1.5}px;
+                margin-left: ${!props.unGrouped && spacingUnit * 1.5}px;
               }
               strong {
                 text-decoration: underline;

--- a/packages/ndla-ui/src/TopicMenu/SubtopicLinkList.jsx
+++ b/packages/ndla-ui/src/TopicMenu/SubtopicLinkList.jsx
@@ -142,6 +142,7 @@ class SubtopicLinkList extends Component {
       resourceToLinkProps,
       lastOpen,
       t,
+      isUngrouped,
     } = this.props;
 
     const { showAdditionalResources, animateUL } = this.state;
@@ -202,20 +203,42 @@ class SubtopicLinkList extends Component {
                 />
               )}
             </HeaderWrapper>
-            {topic.contentTypeResults.map((result) => (
+            {isUngrouped && (
               <ContentTypeResult
                 animateUL={animateUL}
                 resourceToLinkProps={resourceToLinkProps}
                 onNavigate={closeMenu}
-                key={result.title}
-                contentTypeResult={result}
-                messages={{
-                  noHit: t(`masthead.menu.contentTypeResultsNoHit.${result.contentType}`),
+                contentTypeResult={{
+                  resources: topic.contentTypeResults.flatMap((grouped) =>
+                    grouped.resources.map((res) => ({
+                      ...res,
+                      contentType: grouped.contentType,
+                    })),
+                  ),
                 }}
+                messages={{
+                  noHit: t(`masthead.menu.contentTypeResultsNoHit.unGrouped`),
+                }}
+                unGrouped={isUngrouped}
                 showAdditionalResources={showAdditionalResources}
                 inMenu
               />
-            ))}
+            )}
+            {!isUngrouped &&
+              topic.contentTypeResults.map((result) => (
+                <ContentTypeResult
+                  animateUL={animateUL}
+                  resourceToLinkProps={resourceToLinkProps}
+                  onNavigate={closeMenu}
+                  key={result.title}
+                  contentTypeResult={result}
+                  messages={{
+                    noHit: t(`masthead.menu.contentTypeResultsNoHit.${result.contentType}`),
+                  }}
+                  showAdditionalResources={showAdditionalResources}
+                  inMenu
+                />
+              ))}
             {someResourcesAreAdditional && (
               <Switch
                 id="showSomeAdditionalId"
@@ -246,6 +269,7 @@ SubtopicLinkList.propTypes = {
   defaultCount: PropTypes.number,
   t: PropTypes.func.isRequired,
   lastOpen: PropTypes.bool,
+  isUngrouped: PropTypes.bool,
 };
 
 export default injectT(SubtopicLinkList);

--- a/packages/ndla-ui/src/TopicMenu/TopicMenu.jsx
+++ b/packages/ndla-ui/src/TopicMenu/TopicMenu.jsx
@@ -304,31 +304,38 @@ export const TopicMenu = ({
                 lastOpen={!hasExpandedSubtopics}
               />
             )}
-            {currentlyExpandedSubTopics.map((subTopic, index) => (
-              <SubtopicLinkList
-                key={subTopic.id}
-                classes={classes}
-                className={classes('section', ['sub-topic', 'no-border']).className}
-                closeMenu={closeMenu}
-                topic={subTopic}
-                backLabel={
-                  index === 0
-                    ? topics.find((topic) => topic.id === expandedTopicId).name
-                    : currentlyExpandedSubTopics[index - 1].name
-                }
-                toTopic={toTopic}
-                expandedSubtopicId={
-                  currentlyExpandedSubTopics[index + 1] ? currentlyExpandedSubTopics[index + 1].id : 'no way'
-                }
-                onSubtopicExpand={(id) => {
-                  handleSubtopicExpand(id, index + 1);
-                }}
-                onGoBack={handleOnGoBack}
-                resourceToLinkProps={resourceToLinkProps}
-                lastOpen={sliderCounter === index + 2}
-                defaultCount={defaultCount}
-              />
-            ))}
+
+            {currentlyExpandedSubTopics.map((subTopic, index) => {
+              const { metadata } = subTopic;
+              const isUngrouped = metadata?.customFields['topic-resources'] === 'ungrouped' || false;
+
+              return (
+                <SubtopicLinkList
+                  isUngrouped={isUngrouped}
+                  key={subTopic.id}
+                  classes={classes}
+                  className={classes('section', ['sub-topic', 'no-border']).className}
+                  closeMenu={closeMenu}
+                  topic={subTopic}
+                  backLabel={
+                    index === 0
+                      ? topics.find((topic) => topic.id === expandedTopicId).name
+                      : currentlyExpandedSubTopics[index - 1].name
+                  }
+                  toTopic={toTopic}
+                  expandedSubtopicId={
+                    currentlyExpandedSubTopics[index + 1] ? currentlyExpandedSubTopics[index + 1].id : 'no way'
+                  }
+                  onSubtopicExpand={(id) => {
+                    handleSubtopicExpand(id, index + 1);
+                  }}
+                  onGoBack={handleOnGoBack}
+                  resourceToLinkProps={resourceToLinkProps}
+                  lastOpen={sliderCounter === index + 2}
+                  defaultCount={defaultCount}
+                />
+              );
+            })}
           </div>
         )}
       </div>

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -254,6 +254,7 @@ const messages = {
         [contentTypes.ASSESSMENT_RESOURCES]: 'Show more assessment resources',
         [contentTypes.SOURCE_MATERIAL]: 'Show more source materials',
         [contentTypes.EXTERNAL_LEARNING_RESOURCES]: 'Show more external learning resources',
+        unGrouped: 'Show more resources',
       },
       contentTypeResultsShowLess: {
         [contentTypes.SUBJECT_MATERIAL]: 'Show less subjects',
@@ -262,6 +263,7 @@ const messages = {
         [contentTypes.ASSESSMENT_RESOURCES]: 'Show less assessment resources',
         [contentTypes.SOURCE_MATERIAL]: 'Show less source materials',
         [contentTypes.EXTERNAL_LEARNING_RESOURCES]: 'Show less external learning resources',
+        unGrouped: 'Show less resources',
       },
       contentTypeResultsNoHit: {
         [contentTypes.SUBJECT_MATERIAL]: 'No subjects',
@@ -270,6 +272,7 @@ const messages = {
         [contentTypes.ASSESSMENT_RESOURCES]: 'No assessment resources',
         [contentTypes.SOURCE_MATERIAL]: 'No source materials',
         [contentTypes.EXTERNAL_LEARNING_RESOURCES]: 'No external learning resources',
+        unGrouped: 'No resources',
       },
     },
   },

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -255,6 +255,7 @@ const messages = {
         [contentTypes.ASSESSMENT_RESOURCES]: 'Vis flere vurderingsressurser',
         [contentTypes.SOURCE_MATERIAL]: 'Vis flere kildematerialer',
         [contentTypes.EXTERNAL_LEARNING_RESOURCES]: 'Vis flere eksterne læringsressurser',
+        unGrouped: 'Vis flere ressurser',
       },
       contentTypeResultsShowLess: {
         [contentTypes.SUBJECT_MATERIAL]: 'Vis mindre fagstoff',
@@ -263,6 +264,7 @@ const messages = {
         [contentTypes.ASSESSMENT_RESOURCES]: 'Vis færre vurderingsressurser',
         [contentTypes.SOURCE_MATERIAL]: 'Vis færre kildematerialer',
         [contentTypes.EXTERNAL_LEARNING_RESOURCES]: 'Vis færre eksterne læringsressurser',
+        unGrouped: 'Vis færre ressurser',
       },
       contentTypeResultsNoHit: {
         [contentTypes.SUBJECT_MATERIAL]: 'Ikke noe fagstoff',
@@ -271,6 +273,7 @@ const messages = {
         [contentTypes.ASSESSMENT_RESOURCES]: 'Ingen vurderingsressurser',
         [contentTypes.SOURCE_MATERIAL]: 'Ingen kildematerialer',
         [contentTypes.EXTERNAL_LEARNING_RESOURCES]: 'Ingen eksterne læringsressurser',
+        unGrouped: 'Ingen ressurser',
       },
     },
   },

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -255,6 +255,7 @@ const messages = {
         [contentTypes.ASSESSMENT_RESOURCES]: 'Vis fleire vurderingsressursar',
         [contentTypes.SOURCE_MATERIAL]: 'Vis fleire kjeldemateriale',
         [contentTypes.EXTERNAL_LEARNING_RESOURCES]: 'Vis fleire eksterne læringsressursar',
+        unGrouped: 'Vis fleire ressursar',
       },
       contentTypeResultsShowLess: {
         [contentTypes.SUBJECT_MATERIAL]: 'Vis mindre fagstoff',
@@ -264,6 +265,7 @@ const messages = {
         [contentTypes.ASSESSMENT_RESOURCES]: 'Vis færre vurderingsressursar',
         [contentTypes.SOURCE_MATERIAL]: 'Vis færre kjeldemateriale',
         [contentTypes.EXTERNAL_LEARNING_RESOURCES]: 'Vis færre eksterne læringsressursar',
+        unGrouped: 'Vis færre ressursar',
       },
       contentTypeResultsNoHit: {
         [contentTypes.SUBJECT_MATERIAL]: 'Ikkje noko fagstoff',
@@ -272,6 +274,7 @@ const messages = {
         [contentTypes.ASSESSMENT_RESOURCES]: 'Ingen vurderingsressursar',
         [contentTypes.SOURCE_MATERIAL]: 'Ingen kjeldemateriale',
         [contentTypes.EXTERNAL_LEARNING_RESOURCES]: 'Ingen eksterne læringsressursar',
+        unGrouped: 'Ingen ressursar',
       },
     },
   },

--- a/packages/ndla-ui/src/types.ts
+++ b/packages/ndla-ui/src/types.ts
@@ -78,7 +78,7 @@ export type SearchResult = {
 };
 
 export interface ContentTypeResultType {
-  title: string;
+  title?: string;
   contentType?: string;
   resources: Array<Resource>;
 }


### PR DESCRIPTION
Tilknyttet https://github.com/NDLANO/ndla-frontend/pull/746

Ressurser i topic-meny kan nå vises ugruppert. Se bilde eller eksempel i designmanualen:
http://localhost:6006/?path=/story/s%C3%B8k--s%C3%B8kefelt


![image](https://user-images.githubusercontent.com/17144211/129898422-13307b94-0b5c-41e6-9cd2-5cd0a485f329.png)
