### PR TITLE
Byttet ut contentUri med path i ResourceItem for å fikse fagstofflenker

### DIFF
--- a/packages/ndla-ui/src/ResourceGroup/ResourceItem.tsx
+++ b/packages/ndla-ui/src/ResourceGroup/ResourceItem.tsx
@@ -235,7 +235,7 @@ const ResourceItem = ({
   contentTypeName,
   contentTypeDescription,
   name,
-  contentUri,
+  path,
   contentType,
   active,
   additional,
@@ -264,7 +264,7 @@ const ResourceItem = ({
           </Heading>
         </ActiveWrapper>
       ) : (
-        <ResourceLink to={contentUri}>
+        <ResourceLink to={path}>
           <IconWrapper>
             <ContentTypeBadge type={contentType} background border={false} />
           </IconWrapper>


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2684

Kan testes lokalt via linking ved å navigere seg til fagstoff fra forsiden på ndla.no. 