### PR TITLE
Fixed ed and frontend-packages typescript mismatch.

### DIFF
--- a/packages/ndla-editor/src/footer/FooterStatus.tsx
+++ b/packages/ndla-editor/src/footer/FooterStatus.tsx
@@ -94,7 +94,6 @@ type Props = {
     warningSavedWithoutComment: string;
     newStatusPrefix: string;
     statusLabel: string;
-    commentPlaceholder: string;
   };
   options: Array<optionProps>;
   onSave(comment: string, statusId: string): void;

--- a/packages/ndla-editor/src/versionLogs/VersionHistory.tsx
+++ b/packages/ndla-editor/src/versionLogs/VersionHistory.tsx
@@ -51,7 +51,7 @@ type Props = {
     date: string;
     note: string;
     status?: string;
-    id: string;
+    id: number;
   }[];
 };
 

--- a/packages/ndla-ui/src/i18n/__tests__/formatMessage-test.ts
+++ b/packages/ndla-ui/src/i18n/__tests__/formatMessage-test.ts
@@ -9,7 +9,7 @@
 /* eslint-env jest */
 import IntlMessageFormat from 'intl-messageformat';
 import memoizeIntlConstructor from 'intl-format-cache';
-import formatMessage from '../formatMessage';
+import { formatMessage } from '../formatMessage';
 
 const getMessageFormat = memoizeIntlConstructor(IntlMessageFormat);
 const locale = 'nb';

--- a/packages/ndla-ui/src/i18n/formatMessage.ts
+++ b/packages/ndla-ui/src/i18n/formatMessage.ts
@@ -12,13 +12,13 @@ interface Messages {
   [key: string]: string;
 }
 
-export default function formatMessage(
+export const formatMessage = (
   locale: string,
   messages: Messages,
   getMessageFormat: any,
   id: string,
   values: { [key: string]: any } = {},
-): string {
+): string => {
   // `id` is a required parameter.
   invariant(id, 'An `id` must be provided to format a message.');
 
@@ -58,4 +58,4 @@ export default function formatMessage(
   }
 
   return formattedMessage || message || id;
-}
+};

--- a/packages/ndla-ui/src/i18n/index.ts
+++ b/packages/ndla-ui/src/i18n/index.ts
@@ -8,4 +8,4 @@
 
 export { i18nInstance } from './i18n';
 export { formatNestedMessages } from './formatNestedMessages';
-export { default as formatMessage } from './formatMessage';
+export { formatMessage } from './formatMessage';


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2686

Flyttet også `formatMessage` fra å være en default export til å være en named export, som fikser et problem i article-converter.