### PR TITLE
Add export of formatMessage to ndla-ui

### DIFF
--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -102,5 +102,5 @@ export { default as AuthorInfo } from './AuthorInfo';
 export { default as Breadcrumb, BreadcrumbBlock } from './Breadcrumb';
 
 export type { BreadcrumbItemProps } from './Breadcrumblist/Breadcrumblist';
-export { i18nInstance, formatNestedMessages } from './i18n';
+export { i18nInstance, formatNestedMessages, formatMessage } from './i18n';
 export { default as ResourceGroup } from './ResourceGroup';


### PR DESCRIPTION
Etter å ha flyttet formatMessage over fra i18n-pakken til ndla-ui så blir den ikke eksportert. 