### PR TITLE
Reintroduserte css-filer som kontrollerte utseendet på strukturressurser

### DIFF
--- a/packages/ndla-ui/src/ResourceGroup/component.resource-group.scss
+++ b/packages/ndla-ui/src/ResourceGroup/component.resource-group.scss
@@ -1,0 +1,208 @@
+/**
+** RESOURCE GROUPS
+** List resource groups with different colors (and icons)
+**/
+
+@keyframes fakeLoadingAnimation {
+  0% {
+    opacity: 0.5;
+  }
+  99% {
+    opacity: 0.5;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeInAdditionals {
+  0% {
+    opacity: 0;
+    transform: translate3d(-10px, 0px, 0px);
+    position: absolute;
+  }
+  49% {
+    position: absolute;
+  }
+  50% {
+    position: static;
+    opacity: 0;
+    transform: translate3d(-10px, 0px, 0px);
+  }
+  100% {
+    position: static;
+    opacity: 1;
+    height: auto;
+  }
+}
+
+.c-resource-group {
+  &:before {
+    content: '';
+    display: table;
+    clear: both;
+  }
+
+  &--showall {
+    ul {
+      animation-name: fakeLoadingAnimation;
+      animation-duration: 0.4s;
+    }
+    .c-topic-resource__item--additional {
+      animation-name: fadeInAdditionals;
+      animation-duration: 0.8s;
+      animation-fill-mode: forwards;
+    }
+  }
+
+  ul {
+    margin-bottom: $spacing--small;
+  }
+
+  li {
+    background-color: rgba($brand-grey--light, 0.4);
+    border: 1px solid rgba(0, 0, 0, 0);
+    .c-topic-resource__link {
+      min-height: 62px;
+      @include mq(tablet) {
+        min-height: 68px;
+      }
+      @include mq(desktop) {
+        min-height: 70px;
+      }
+    }
+    .c-topic-resource__icon {
+      padding-right: $spacing--small;
+      @include mq(tablet) {
+        padding-right: $spacing--small;
+        padding-left: $spacing--small / 2;
+      }
+      @include mq(desktop) {
+        padding-right: $spacing--small * 1.5;
+      }
+    }
+  }
+  .c-topic-resource__body {
+    display: flex;
+    align-items: center;
+    padding-right: 1rem;
+  }
+
+  &__header {
+    border-bottom: 2px solid $brand-grey--light;
+    margin-bottom: $spacing--small / 4;
+    &--invertedStyle {
+      color: #fff;
+    }
+  }
+
+  &--subject-material {
+    li {
+      background-color: $subject-material-light;
+    }
+    li:before {
+      background-color: $subject-material-dark;
+    }
+    .c-topic-resource__item--additional {
+      background-color: $subject-material-additional;
+      border: 1px dashed rgba($subject-material-dark, 0.4);
+    }
+  }
+
+  &--tasks-and-activities {
+    li {
+      background-color: $tasks-and-activities-light;
+    }
+    li:before {
+      background-color: $tasks-and-activities-dark;
+    }
+    .c-topic-resource__item--additional {
+      background-color: $tasks-and-activities-additional;
+      border: 1px dashed rgba($tasks-and-activities-dark, 0.4);
+    }
+  }
+
+  &--assessment-resources {
+    li {
+      background-color: $assessment-resource-light;
+    }
+    li:before {
+      background-color: $assessment-resource-dark;
+    }
+    .c-topic-resource__item--additional {
+      background-color: $assessment-resource-additional;
+      border: 1px dashed $assessment-resource-dark;
+    }
+  }
+
+  &--learning-path {
+    li {
+      background-color: $learning-path-background;
+    }
+    li:before {
+      background-color: $learning-path-dark;
+    }
+    .c-topic-resource__item--additional {
+      background-color: $learning-path-background-additional;
+      border: 1px dashed rgba($learning-path-dark, 0.4);
+    }
+  }
+
+  &--external-learning-resources {
+    li {
+      background-color: $external-learning-resource-background;
+    }
+    li:before {
+      background-color: $external-learning-resource-dark;
+    }
+    .c-topic-resource__item--additional {
+      background-color: $external-learning-resource-additional;
+      border: 1px dashed rgba($external-learning-resource-dark, 0.4);
+    }
+  }
+
+  &--source-material {
+    li {
+      background-color: $source-material-background;
+    }
+    li:before {
+      background-color: $source-material-dark;
+    }
+    .c-topic-resource__item--additional {
+      background-color: $source-material-additional;
+      border: 1px dashed rgba($source-material-dark, 0.4);
+    }
+  }
+  &--un-grouped {
+    li {
+      border: 1px solid #d1d6db;
+      border-radius: 5px;
+      background: none;
+      margin-bottom: $spacing--small / 2;
+      * {
+        transition: all 0.2s;
+      }
+      &.c-topic-resource__item--spacer {
+        margin-bottom: $spacing--medium;
+      }
+      a:hover .c-topic-resource__icon .c-content-type-badge {
+        width: 38px;
+        height: 38px;
+
+        svg {
+          width: 20px;
+          height: 20px;
+        }
+        &.c-content-type-badge--subject-material,
+        &.c-content-type-badge--learning-path,
+        &.c-content-type-badge--source-material,
+        &.c-content-type-badge--external-learning-resources {
+          svg {
+            width: 26px;
+            height: 26px;
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/ndla-ui/src/ResourceGroup/component.topic-resource.scss
+++ b/packages/ndla-ui/src/ResourceGroup/component.topic-resource.scss
@@ -1,0 +1,172 @@
+/**
+** TOPIC RESOURCE LIST
+** List items inside a resource group
+**/
+
+.c-topic-resource {
+  @include mq($from: desktop) {
+    @include grids-expand(4, 6, 2);
+    margin-top: $spacing--large;
+  }
+
+  &__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    @include mq($from: tablet) {
+      flex-direction: row;
+    }
+  }
+
+  &__body {
+    flex: 1 1 auto;
+    justify-content: space-between;
+    text-align: left;
+    .c-icon {
+      flex-shrink: 0;
+    }
+  }
+
+  &__item {
+    max-width: 100%;
+    margin-bottom: $spacing--small / 4;
+    &--active {
+      .c-topic-resource__link {
+        color: $brand-grey-dark;
+        span {
+          box-shadow: none;
+        }
+        small {
+          padding-left: $spacing--small;
+          font-weight: $font-weight-normal;
+        }
+      }
+      &.subject-material:before {
+        background-color: $subject-material-dark;
+      }
+      &.tasks-and-activities:before {
+        background-color: $tasks-and-activities-dark;
+      }
+      &.assessment-resources:before {
+        background-color: $assessment-resource-dark;
+      }
+      &.learning-path:before {
+        background-color: $learning-path-dark;
+      }
+      &.external-learning-resources:before {
+        background-color: $external-learning-resource-dark;
+      }
+      &.source-material:before {
+        background-color: $source-material-dark;
+      }
+      &:before {
+        @include mq(tablet) {
+          content: '';
+          display: block;
+          position: absolute;
+          width: $spacing--small;
+          height: $spacing--small;
+          border-radius: 100%;
+          transform: translate(-($spacing + $spacing--small), $spacing + 1);
+        }
+      }
+    }
+    &__icon {
+      display: flex;
+      align-items: center;
+    }
+    &__type {
+      font-family: $font;
+      @include font-size(14px, 18px);
+      font-weight: $font-weight-semibold;
+      color: $text-light-color;
+      text-align: right;
+    }
+  }
+
+  &__link {
+    display: flex;
+    color: $brand-color--dark;
+    align-items: center;
+    width: auto;
+
+    h2 {
+      font-weight: $font-weight-semibold;
+      transform: translateY(-1px);
+      @include font-size(16px, 26px);
+      @include mq(tablet) {
+        @include font-size(18px);
+      }
+      @include mq(desktop) {
+        @include font-size(20px);
+      }
+    }
+    h2 span {
+      box-shadow: $link;
+    }
+
+    padding: $spacing--small;
+    box-shadow: none;
+
+    &:hover,
+    &:focus {
+      box-shadow: none;
+
+      h2 span {
+        box-shadow: $link--hover;
+      }
+    }
+  }
+
+  &__item--hidden {
+    opacity: 0;
+    display: none;
+  }
+
+  &__icon {
+    display: flex;
+    text-align: center;
+    justify-content: center;
+    width: 42px;
+    box-sizing: content-box;
+    padding-right: $spacing--small;
+    @include mq(tablet) {
+      padding-right: $spacing;
+    }
+  }
+
+  &__title {
+    text-transform: none;
+    letter-spacing: 0;
+    margin: 0;
+    display: inline;
+    @include font-size(18px);
+    @include mq(tablet) {
+      @include font-size(20px);
+    }
+  }
+
+  &__button-wrapper {
+    text-align: center;
+  }
+
+  &__button {
+    margin: $spacing--small auto;
+  }
+
+  &__additional-resources-trigger {
+    background: $brand-grey--lightest;
+    border: 1px dashed $brand-color--light;
+    text-align: center;
+    padding: $spacing--small $spacing--small $spacing;
+    font-family: $font;
+    p {
+      @include font-size(16px, 18px);
+      margin: $spacing--small;
+    }
+  }
+}
+
+.c-topic-resource__list__additional-icons {
+  line-height: 0;
+}

--- a/packages/ndla-ui/src/main.scss
+++ b/packages/ndla-ui/src/main.scss
@@ -23,11 +23,13 @@
 @import 'global/components/component.logo';
 @import 'MediaList/component.medialist';
 @import 'RelatedArticleList/component.related-articles';
+@import 'ResourceGroup/component.resource-group';
 @import 'ResourcesWrapper/component.resources';
 @import 'ContentTypeBadge/component.content-type-badge';
 @import 'global/components/component.source-list';
 @import 'Table/component.tables';
 @import 'TopicIntroductionList/component.topic-introduction';
+@import 'ResourceGroup/component.topic-resource';
 @import 'TopicMenu/component.topic-menu';
 @import 'Filter/component.filter';
 @import 'Translation/component.translation';


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2685

Uten disse filene vil ikke ressurser i strukturredigering se riktige ut. Burde dette kanskje vært definert i ed istedenfor her? De brukes tross alt ikke i frontend-packages, de eksporteres bare.