### PR TITLE
Remove unused variables and fix invalid prop for Frontpage components.

### DIFF
--- a/packages/ndla-ui/src/Frontpage/FrontpageHeader.tsx
+++ b/packages/ndla-ui/src/Frontpage/FrontpageHeader.tsx
@@ -50,13 +50,11 @@ const HeaderIllustrationWrapper = styled.div`
 `;
 
 export type FrontPageHeaderProps = {
-  languageOptions: string;
   locale: string;
   showHeader: boolean;
 };
 
 const FrontpageHeader: React.FunctionComponent<FrontPageHeaderProps & WithTranslation> = ({
-  languageOptions,
   locale,
   showHeader = true,
   children,

--- a/packages/ndla-ui/src/Frontpage/FrontpageProgramMenu.tsx
+++ b/packages/ndla-ui/src/Frontpage/FrontpageProgramMenu.tsx
@@ -87,7 +87,7 @@ const BottomCursor = styled(Cursor)`
 `;
 
 type Props = {
-  programItems: [ItemProps];
+  programItems: ItemProps[];
   subjectCategories: subjectsProps['categories'];
 };
 


### PR DESCRIPTION
Etter oppgradering av ndla-ui ville ikke NDLA-frontend lenger kjøre. Bare småplukk, fjerner en ubrukt variabel og endret en prop til å være et array. 