### PR TITLE
Sort ungrouped resources in masthead topicmenu

### DIFF
--- a/packages/ndla-ui/src/TopicMenu/SubtopicLinkList.jsx
+++ b/packages/ndla-ui/src/TopicMenu/SubtopicLinkList.jsx
@@ -209,12 +209,14 @@ class SubtopicLinkList extends Component {
                 resourceToLinkProps={resourceToLinkProps}
                 onNavigate={closeMenu}
                 contentTypeResult={{
-                  resources: topic.contentTypeResults.flatMap((grouped) =>
-                    grouped.resources.map((res) => ({
-                      ...res,
-                      contentType: grouped.contentType,
-                    })),
-                  ),
+                  resources: topic.contentTypeResults
+                    .flatMap((grouped) =>
+                      grouped.resources.map((res) => ({
+                        ...res,
+                        contentType: grouped.contentType,
+                      })),
+                    )
+                    .sort((a, b) => a.rank - b.rank),
                 }}
                 messages={{
                   noHit: t(`masthead.menu.contentTypeResultsNoHit.unGrouped`),


### PR DESCRIPTION
Legger til sortering av ugrupperte ressurser basert på rank.

Hvordan teste:
1. `ndla link ndla-frontend -l ndla-ui`
2. Mulig `yarn install --force` i ndla-frontend
3. Start ndla-frontend
4. Åpne `http://localhost:3000/nn/subject:1:a3c1b65a-c41f-4879-b650-32a13fe1801b/topic:2:1:187398/topic:4:1:165209/`
5. Sammenlikn læringsressursene på siden med de som dukker opp ved trykk på "innhold" øverst til venstre. Disse listene skal nå være identisk sortert.