### PR TITLE
Add utility functionality for parsing markdown to html. Add markdown parsing to FigureCaption by default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/react-dom": "^16.8.2",
     "@types/react-router-dom": "^5.1.7",
     "@types/react-test-renderer": "^16.8.1",
+    "@types/remarkable": "^2.0.3",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.1.0",
     "babel-plugin-emotion": "^10.0.33",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@types/react-dom": "^16.8.2",
     "@types/react-router-dom": "^5.1.7",
     "@types/react-test-renderer": "^16.8.1",
-    "@types/remarkable": "^2.0.3",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.1.0",
     "babel-plugin-emotion": "^10.0.33",

--- a/packages/ndla-ui/src/Figure/Figure.js
+++ b/packages/ndla-ui/src/Figure/Figure.js
@@ -12,7 +12,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import BEMHelper from 'react-bem-helper';
-import { isFunction } from '@ndla/util';
+import { isFunction, parseMarkdown } from '@ndla/util';
 import { useTranslation } from 'react-i18next';
 import { Link as LinkIcon } from '@ndla/icons/common';
 import { LicenseByline } from '@ndla/licenses';
@@ -39,7 +39,7 @@ export const FigureCaption = ({
   const { t } = useTranslation();
   return (
     <figcaption {...classes('caption', hideFigcaption && 'hidden-caption')}>
-      {caption ? <div {...classes('info')}>{caption}</div> : null}
+      {caption ? <div {...classes('info')}>{parseMarkdown(caption)}</div> : null}
       <footer {...classes('byline')}>
         <div {...classes('byline-licenselist')}>
           <LicenseByline licenseRights={licenseRights} locale={locale} marginRight>

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -27,7 +27,8 @@
     "types"
   ],
   "dependencies": {
-    "defined": "1.0.0"
+    "defined": "1.0.0",
+    "remarkable": "^2.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "defined": "1.0.0",
-    "remarkable": "^2.0.0"
+    "remarkable": "^2.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -17,3 +17,4 @@ export { resizeObserver } from './resizeObserver';
 export { setCookie, getCookie, deleteCookie, isValidCookie } from './cookieHandler';
 export { printPage } from './printPage';
 export { default as joinArrayWithConjunction } from './joinArrayWithConjunction';
+export { parseMarkdown } from './markdownHelpers';

--- a/packages/util/src/markdownHelpers.ts
+++ b/packages/util/src/markdownHelpers.ts
@@ -6,6 +6,7 @@
  *
  */
 
+//@ts-ignore
 import { Remarkable } from 'remarkable';
 import parse from 'html-react-parser';
 

--- a/packages/util/src/markdownHelpers.ts
+++ b/packages/util/src/markdownHelpers.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Remarkable } from 'remarkable';
+import parse from 'html-react-parser';
+
+export const parseMarkdown = (embeddedCaption: string) => {
+  const markdown = new Remarkable({ breaks: true, html: true });
+  markdown.inline.ruler.enable(['sub', 'sup']);
+  const caption = embeddedCaption || '';
+  /**
+   * Whitespace must be escaped in order for ^superscript^ and ~subscript~
+   * to render properly. Superfluous whitespace must be escaped in order for
+   * text within *italics* and *bold* to render properly.
+   */
+  const escapedMarkdown = markdown.render(caption.split(' ').join('\\ '));
+  return parse(escapedMarkdown.split('\\').join(''));
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4212,11 +4212,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/highlight.js@^9.7.0":
-  version "9.12.4"
-  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.4.tgz#8c3496bd1b50cc04aeefd691140aa571d4dbfa34"
-  integrity sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==
-
 "@types/history@*":
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.7.tgz#613957d900fab9ff84c8dfb24fa3eef0c2a40896"
@@ -4476,14 +4471,6 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
-
-"@types/remarkable@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@types/remarkable/-/remarkable-2.0.3.tgz#ba2e5edada8f0fe64c658beb2127e06ac0b9c1c8"
-  integrity sha512-QQUBeYApuHCNl9Br6ZoI3PlKmwZ69JHrlJktJXnjxobia9liZgsI70fm8PnCqVFAcefYK+9PGzR5L/hzCslNYQ==
-  dependencies:
-    "@types/highlight.js" "^9.7.0"
-    highlight.js "^9.7.0"
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -10185,11 +10172,6 @@ highlight.js@^10.1.1, highlight.js@~10.2.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.2.1.tgz#09784fe2e95612abbefd510948945d4fe6fa9668"
   integrity sha512-A+sckVPIb9zQTUydC9lpRX1qRFO/N0OKEh0NwIr65ckvWA/oMY8v9P3+kGRK3w2ULSh9E8v5MszXafodQ6039g==
 
-highlight.js@^9.7.0:
-  version "9.18.5"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.5.tgz#d18a359867f378c138d6819edfc2a8acd5f29825"
-  integrity sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==
-
 highlight.js@~9.13.0:
   version "9.13.1"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.13.1.tgz#054586d53a6863311168488a0f58d6c505ce641e"
@@ -15567,7 +15549,7 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
-remarkable@^2.0.0:
+remarkable@^2.0.0, remarkable@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/remarkable/-/remarkable-2.0.1.tgz#280ae6627384dfb13d98ee3995627ca550a12f31"
   integrity sha512-YJyMcOH5lrR+kZdmB0aJJ4+93bEojRZ1HGDn9Eagu6ibg7aVZhc3OWbbShRid+Q5eAfsEqWxpe+g5W5nYNfNiA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4212,6 +4212,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/highlight.js@^9.7.0":
+  version "9.12.4"
+  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.4.tgz#8c3496bd1b50cc04aeefd691140aa571d4dbfa34"
+  integrity sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==
+
 "@types/history@*":
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.7.tgz#613957d900fab9ff84c8dfb24fa3eef0c2a40896"
@@ -4471,6 +4476,14 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
+
+"@types/remarkable@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/remarkable/-/remarkable-2.0.3.tgz#ba2e5edada8f0fe64c658beb2127e06ac0b9c1c8"
+  integrity sha512-QQUBeYApuHCNl9Br6ZoI3PlKmwZ69JHrlJktJXnjxobia9liZgsI70fm8PnCqVFAcefYK+9PGzR5L/hzCslNYQ==
+  dependencies:
+    "@types/highlight.js" "^9.7.0"
+    highlight.js "^9.7.0"
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -10171,6 +10184,11 @@ highlight.js@^10.1.1, highlight.js@~10.2.0:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.2.1.tgz#09784fe2e95612abbefd510948945d4fe6fa9668"
   integrity sha512-A+sckVPIb9zQTUydC9lpRX1qRFO/N0OKEh0NwIr65ckvWA/oMY8v9P3+kGRK3w2ULSh9E8v5MszXafodQ6039g==
+
+highlight.js@^9.7.0:
+  version "9.18.5"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.5.tgz#d18a359867f378c138d6819edfc2a8acd5f29825"
+  integrity sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==
 
 highlight.js@~9.13.0:
   version "9.13.1"


### PR DESCRIPTION
https://github.com/NDLANO/Issues/issues/2613

Konsekvensen av dette er at alle FigureCaptions vil være i en `<p/>`. Alternativet er å flytte det "opp", slik at man istedenfor parser i ed og article-converter.