### PR TITLE
Add param to ImageSearch to display checkbox for setting metaimage

### DIFF
--- a/packages/ndla-image-search/src/ImageSearch.js
+++ b/packages/ndla-image-search/src/ImageSearch.js
@@ -356,7 +356,8 @@ class ImageSearch extends React.Component {
   }
 
   render() {
-    const { searchPlaceholder, searchButtonTitle, useImageTitle, showMetaImageCheckbox } = this.props;
+    const { searchPlaceholder, searchButtonTitle, useImageTitle, showMetaImageCheckbox, useAsMetaImageLabel } =
+      this.props;
 
     const { queryObject, images, selectedImage, lastPage, searching, queryString } = this.state;
 
@@ -400,6 +401,7 @@ class ImageSearch extends React.Component {
               onSelectImage={this.onSelectImage}
               useImageTitle={useImageTitle}
               showMetaImageCheckbox={showMetaImageCheckbox}
+              useAsMetaImageLabel={useAsMetaImageLabel}
             />
           ))}
         </div>
@@ -429,6 +431,7 @@ ImageSearch.propTypes = {
   noResults: PropTypes.node,
   onSaveAsMetaImage: PropTypes.func,
   showMetaImageCheckbox: PropTypes.bool,
+  useAsMetaImageLabel: PropTypes.string,
 };
 
 export default ImageSearch;

--- a/packages/ndla-image-search/src/ImageSearch.js
+++ b/packages/ndla-image-search/src/ImageSearch.js
@@ -356,7 +356,7 @@ class ImageSearch extends React.Component {
   }
 
   render() {
-    const { searchPlaceholder, searchButtonTitle, useImageTitle, showMetaImageCheckbox, useAsMetaImageLabel } =
+    const { searchPlaceholder, searchButtonTitle, useImageTitle, showMetaImageCheckbox, metaImageCheckboxLabel } =
       this.props;
 
     const { queryObject, images, selectedImage, lastPage, searching, queryString } = this.state;
@@ -401,7 +401,7 @@ class ImageSearch extends React.Component {
               onSelectImage={this.onSelectImage}
               useImageTitle={useImageTitle}
               showMetaImageCheckbox={showMetaImageCheckbox}
-              useAsMetaImageLabel={useAsMetaImageLabel}
+              metaImageCheckboxLabel={metaImageCheckboxLabel}
             />
           ))}
         </div>
@@ -431,7 +431,11 @@ ImageSearch.propTypes = {
   noResults: PropTypes.node,
   onSaveAsMetaImage: PropTypes.func,
   showMetaImageCheckbox: PropTypes.bool,
-  useAsMetaImageLabel: PropTypes.string,
+  metaImageCheckboxLabel: PropTypes.string,
+};
+
+ImageSearch.defaultProps = {
+  showMetaImageCheckbox: false,
 };
 
 export default ImageSearch;

--- a/packages/ndla-image-search/src/ImageSearch.js
+++ b/packages/ndla-image-search/src/ImageSearch.js
@@ -320,9 +320,13 @@ class ImageSearch extends React.Component {
     }
   }
 
-  onSelectImage(image) {
+  onSelectImage(image, saveAsMetaImage) {
+    const { onImageSelect, onSaveAsMetaImage } = this.props;
     this.setState({ selectedImage: undefined });
-    this.props.onImageSelect(image);
+    onImageSelect(image);
+    if (saveAsMetaImage) {
+      onSaveAsMetaImage && onSaveAsMetaImage(image);
+    }
   }
 
   changeQueryPage(queryObject) {
@@ -352,7 +356,7 @@ class ImageSearch extends React.Component {
   }
 
   render() {
-    const { searchPlaceholder, searchButtonTitle, useImageTitle } = this.props;
+    const { searchPlaceholder, searchButtonTitle, useImageTitle, showMetaImageCheckbox } = this.props;
 
     const { queryObject, images, selectedImage, lastPage, searching, queryString } = this.state;
 
@@ -395,6 +399,7 @@ class ImageSearch extends React.Component {
               selectedImage={selectedImage}
               onSelectImage={this.onSelectImage}
               useImageTitle={useImageTitle}
+              showMetaImageCheckbox={showMetaImageCheckbox}
             />
           ))}
         </div>
@@ -422,6 +427,8 @@ ImageSearch.propTypes = {
   locale: PropTypes.string.isRequired,
   useImageTitle: PropTypes.string.isRequired,
   noResults: PropTypes.node,
+  onSaveAsMetaImage: PropTypes.func,
+  showMetaImageCheckbox: PropTypes.bool,
 };
 
 export default ImageSearch;

--- a/packages/ndla-image-search/src/ImageSearchResult.js
+++ b/packages/ndla-image-search/src/ImageSearchResult.js
@@ -19,6 +19,7 @@ export default function ImageSearchResult({
   onSelectImage,
   useImageTitle,
   showMetaImageCheckbox,
+  useAsMetaImageLabel,
 }) {
   const active = selectedImage && selectedImage.id === image.id ? 'active' : '';
 
@@ -40,6 +41,7 @@ export default function ImageSearchResult({
           image={selectedImage}
           onSelectImage={onSelectImage}
           useImageTitle={useImageTitle}
+          useAsMetaImageLabel={useAsMetaImageLabel}
           showMetaImageCheckbox={showMetaImageCheckbox}
         />
       ) : (
@@ -61,4 +63,5 @@ ImageSearchResult.propTypes = {
   onSelectImage: PropTypes.func.isRequired,
   useImageTitle: PropTypes.string.isRequired,
   showMetaImageCheckbox: PropTypes.bool,
+  useAsMetaImageLabel: PropTypes.string,
 };

--- a/packages/ndla-image-search/src/ImageSearchResult.js
+++ b/packages/ndla-image-search/src/ImageSearchResult.js
@@ -12,7 +12,14 @@ import Button from '@ndla/button';
 import PreviewImage from './PreviewImage';
 import { getPreviewSrcSets } from './util/imageUtil';
 
-export default function ImageSearchResult({ image, onImageClick, selectedImage, onSelectImage, useImageTitle }) {
+export default function ImageSearchResult({
+  image,
+  onImageClick,
+  selectedImage,
+  onSelectImage,
+  useImageTitle,
+  showMetaImageCheckbox,
+}) {
   const active = selectedImage && selectedImage.id === image.id ? 'active' : '';
 
   return (
@@ -29,7 +36,12 @@ export default function ImageSearchResult({ image, onImageClick, selectedImage, 
         </Button>
       </div>
       {selectedImage && selectedImage.id === image.id ? (
-        <PreviewImage image={selectedImage} onSelectImage={onSelectImage} useImageTitle={useImageTitle} />
+        <PreviewImage
+          image={selectedImage}
+          onSelectImage={onSelectImage}
+          useImageTitle={useImageTitle}
+          showMetaImageCheckbox={showMetaImageCheckbox}
+        />
       ) : (
         ''
       )}
@@ -48,4 +60,5 @@ ImageSearchResult.propTypes = {
   }),
   onSelectImage: PropTypes.func.isRequired,
   useImageTitle: PropTypes.string.isRequired,
+  showMetaImageCheckbox: PropTypes.bool,
 };

--- a/packages/ndla-image-search/src/ImageSearchResult.js
+++ b/packages/ndla-image-search/src/ImageSearchResult.js
@@ -19,7 +19,7 @@ export default function ImageSearchResult({
   onSelectImage,
   useImageTitle,
   showMetaImageCheckbox,
-  useAsMetaImageLabel,
+  metaImageCheckboxLabel,
 }) {
   const active = selectedImage && selectedImage.id === image.id ? 'active' : '';
 
@@ -41,7 +41,7 @@ export default function ImageSearchResult({
           image={selectedImage}
           onSelectImage={onSelectImage}
           useImageTitle={useImageTitle}
-          useAsMetaImageLabel={useAsMetaImageLabel}
+          metaImageCheckboxLabel={metaImageCheckboxLabel}
           showMetaImageCheckbox={showMetaImageCheckbox}
         />
       ) : (
@@ -62,6 +62,6 @@ ImageSearchResult.propTypes = {
   }),
   onSelectImage: PropTypes.func.isRequired,
   useImageTitle: PropTypes.string.isRequired,
-  showMetaImageCheckbox: PropTypes.bool,
+  showMetaImageCheckbox: PropTypes.bool.isRequired,
   useAsMetaImageLabel: PropTypes.string,
 };

--- a/packages/ndla-image-search/src/PreviewImage.js
+++ b/packages/ndla-image-search/src/PreviewImage.js
@@ -6,16 +6,20 @@
  *
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Button from '@ndla/button';
 import { uuid } from '@ndla/util';
+import { CheckboxItem } from '@ndla/forms';
+
 import { getSrcSets } from './util/imageUtil';
 
 const convertWithFallBack = (fieldName, value, fallback) =>
   value[fieldName] && value[fieldName][fieldName] ? value[fieldName][fieldName] : fallback;
 
-const PreviewImage = ({ image, onSelectImage, useImageTitle }) => {
+const PreviewImage = ({ image, onSelectImage, useImageTitle, showMetaImageCheckbox }) => {
+  const [saveAsMetaImage, setSaveAsMetaImage] = useState(false);
+
   const tags = convertWithFallBack('tags', image.tags, []);
   return (
     <div className="image-preview">
@@ -43,9 +47,20 @@ const PreviewImage = ({ image, onSelectImage, useImageTitle }) => {
             <span key={uuid()} className="tag_item">{`#${tag}`}</span>
           ))}
         </div>
-        <Button data-cy="use-image" onClick={() => onSelectImage(image)}>
+        <Button data-cy="use-image" onClick={() => onSelectImage(image, saveAsMetaImage)}>
           {useImageTitle}
         </Button>
+        {showMetaImageCheckbox && (
+          <div>
+            <CheckboxItem
+              label={'Bruk som metabilde'}
+              checked={saveAsMetaImage}
+              value=""
+              id={'any'}
+              onChange={() => setSaveAsMetaImage((prev) => !prev)}
+            />
+          </div>
+        )}
       </div>
       <div className="clear" />
     </div>
@@ -77,6 +92,7 @@ PreviewImage.propTypes = {
   }).isRequired,
   onSelectImage: PropTypes.func.isRequired,
   useImageTitle: PropTypes.string.isRequired,
+  showMetaImageCheckbox: PropTypes.bool,
 };
 
 export default PreviewImage;

--- a/packages/ndla-image-search/src/PreviewImage.js
+++ b/packages/ndla-image-search/src/PreviewImage.js
@@ -17,7 +17,7 @@ import { getSrcSets } from './util/imageUtil';
 const convertWithFallBack = (fieldName, value, fallback) =>
   value[fieldName] && value[fieldName][fieldName] ? value[fieldName][fieldName] : fallback;
 
-const PreviewImage = ({ image, onSelectImage, useImageTitle, showMetaImageCheckbox }) => {
+const PreviewImage = ({ image, onSelectImage, useImageTitle, showMetaImageCheckbox, useAsMetaImageLabel }) => {
   const [saveAsMetaImage, setSaveAsMetaImage] = useState(false);
 
   const tags = convertWithFallBack('tags', image.tags, []);
@@ -53,10 +53,8 @@ const PreviewImage = ({ image, onSelectImage, useImageTitle, showMetaImageCheckb
         {showMetaImageCheckbox && (
           <div>
             <CheckboxItem
-              label={'Bruk som metabilde'}
+              label={useAsMetaImageLabel}
               checked={saveAsMetaImage}
-              value=""
-              id={'any'}
               onChange={() => setSaveAsMetaImage((prev) => !prev)}
             />
           </div>
@@ -93,6 +91,7 @@ PreviewImage.propTypes = {
   onSelectImage: PropTypes.func.isRequired,
   useImageTitle: PropTypes.string.isRequired,
   showMetaImageCheckbox: PropTypes.bool,
+  useAsMetaImageLabel: PropTypes.string,
 };
 
 export default PreviewImage;

--- a/packages/ndla-image-search/src/PreviewImage.js
+++ b/packages/ndla-image-search/src/PreviewImage.js
@@ -17,7 +17,7 @@ import { getSrcSets } from './util/imageUtil';
 const convertWithFallBack = (fieldName, value, fallback) =>
   value[fieldName] && value[fieldName][fieldName] ? value[fieldName][fieldName] : fallback;
 
-const PreviewImage = ({ image, onSelectImage, useImageTitle, showMetaImageCheckbox, useAsMetaImageLabel }) => {
+const PreviewImage = ({ image, onSelectImage, useImageTitle, showMetaImageCheckbox, metaImageCheckboxLabel }) => {
   const [saveAsMetaImage, setSaveAsMetaImage] = useState(false);
 
   const tags = convertWithFallBack('tags', image.tags, []);
@@ -53,7 +53,7 @@ const PreviewImage = ({ image, onSelectImage, useImageTitle, showMetaImageCheckb
         {showMetaImageCheckbox && (
           <div>
             <CheckboxItem
-              label={useAsMetaImageLabel}
+              label={metaImageCheckboxLabel}
               checked={saveAsMetaImage}
               onChange={() => setSaveAsMetaImage((prev) => !prev)}
             />
@@ -90,8 +90,8 @@ PreviewImage.propTypes = {
   }).isRequired,
   onSelectImage: PropTypes.func.isRequired,
   useImageTitle: PropTypes.string.isRequired,
-  showMetaImageCheckbox: PropTypes.bool,
-  useAsMetaImageLabel: PropTypes.string,
+  showMetaImageCheckbox: PropTypes.bool.isRequired,
+  metaImageCheckboxLabel: PropTypes.string,
 };
 
 export default PreviewImage;


### PR DESCRIPTION
Tilknyttet https://github.com/NDLANO/editorial-frontend/pull/1160

Legger til støtte for å vise fram en checkbox i bildesøk. Resten av implementasjonen for å sette metabilde gjøres i ed.

Hvordan teste:
- `git checkout 2725-prompt-metaimage-selection` dette repoet og ed.
- `ndla link editorial-frontend -l ndla-image-search`
- Åpne artikkel
    - Legg inn bilde i editoren. Det skal være mulig å huke av for at det skal settes som metabilde.
- Åpne forklaring og emne
    - Legg inn bilde som visuelt element. Det skal være mulig å gjøre det samme her også.