### PR TITLE
Fix byline license-icons

### DIFF
--- a/packages/ndla-ui/src/Figure/component.figure.scss
+++ b/packages/ndla-ui/src/Figure/component.figure.scss
@@ -79,15 +79,20 @@
     border: none;
     cursor: pointer;
     color: $brand-color;
-    box-shadow: $link;
     padding: 0;
     @include font-size(14px);
     &:hover {
-      box-shadow: $link--hover;
+      box-shadow: $link;
     }
 
-    &.c-figure__captionbtn svg {
-      display: none;
+    &.c-figure__captionbtn {
+      box-shadow: $link;
+      &:hover {
+        box-shadow: $link--hover;
+      }
+      svg {
+        display: none;
+      }
     }
     &.c-figure__toggleSynstolket {
       margin-left: 10px;

--- a/packages/ndla-ui/src/Figure/component.figure.scss
+++ b/packages/ndla-ui/src/Figure/component.figure.scss
@@ -81,9 +81,6 @@
     color: $brand-color;
     padding: 0;
     @include font-size(14px);
-    &:hover {
-      box-shadow: $link;
-    }
 
     &.c-figure__captionbtn {
       box-shadow: $link;


### PR DESCRIPTION
https://trello.com/c/xmXa6POJ/141-fjerne-understreking-av-lisensikonene