### PR TITLE
Added visible prop to filter categories on frontpage.

### DIFF
--- a/packages/designmanual/dummydata/mockPrograms.js
+++ b/packages/designmanual/dummydata/mockPrograms.js
@@ -726,6 +726,7 @@ export const subjectCategories = [
   },
   {
     name: 'Utgåtte',
+    visible: true,
     subjects: [
       { name: 'Matematikk 1P (LK06)', id: 'archived_subject_1', path: '#' },
       { name: 'Matematikk 1P-Y (LK06)', id: 'archived_subject_2', path: '#' },
@@ -743,6 +744,7 @@ export const subjectCategories = [
   },
   {
     name: 'Kommende',
+    visible: true,
     subjects: [
       { name: 'Informasjonsteknologi Vg2 - 2021 BETA', id: 'beta_subject_1', path: '#' },
       { name: 'Yrkesfaglig fordypning (HS-HEA Vg2) - 2021 BETA', id: 'beta_subject_2', path: '#' },

--- a/packages/ndla-ui/src/Frontpage/FrontpageAllSubjects.tsx
+++ b/packages/ndla-ui/src/Frontpage/FrontpageAllSubjects.tsx
@@ -79,6 +79,7 @@ type subjectProps = {
 type categoryProps = {
   type?: string;
   name?: string;
+  visible?: boolean;
   subjects: subjectProps[];
 };
 
@@ -188,10 +189,11 @@ const FrontpageAllSubjects = ({
 
   categories.forEach((category: categoryProps) => {
     allSubjects.push(...category.subjects);
-    data.push({
-      title: category.name || t(`subjectCategories.${category.type}`),
-      content: renderList(category.subjects, onNavigate, onToggleSubject, subjectViewType, selectedSubjects),
-    });
+    category.visible &&
+      data.push({
+        title: category.name || t(`subjectCategories.${category.type}`),
+        content: renderList(category.subjects, onNavigate, onToggleSubject, subjectViewType, selectedSubjects),
+      });
   });
 
   data.unshift({


### PR DESCRIPTION
NDLANO/Issues#2742 og https://trello.com/c/OonNFR4c/1236-justering-forsidefaner

Legger på visible på gruppe for å skjule på forsida, men likevel kunne ha med alle fag i Alle-fana.

Test:
* Sjekk forside på designmanual og sjå at fanene Alle, Utgått og Kommende er med.