### PR TITLE
Notion dialog renders content in flex column

### DIFF
--- a/packages/ndla-notion/src/NotionDialog.js
+++ b/packages/ndla-notion/src/NotionDialog.js
@@ -10,7 +10,7 @@ import NotionBody from './NotionBody';
 const NotionDialogContentWrapper = styled.div`
   padding-bottom: ${spacing.normal};
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
 `;
 
 export const NotionDialogContent = ({ children, ...rest }) => (


### PR DESCRIPTION
Den gamle stylingen med `flex-wrap: wrap` gjorde at tekst kunne havne til høyre for bilde. Feks i forhåndsvisning av forklaringen eller visning av forklaring i listing-frontend. Se feks https://liste.test.ndla.no/nb/concepts/2879. Nå vil elementene alltid ligge ovenfor hverandre.

Hvordan teste:
1. checkout
   - listing: `master`
   - frontend-packages: `2774-bugfix-concept-layout`
2. `ndla link listing-frontend -l ndla-notion`
3. `yarn install --force` i listing
4. Åpne feks http://localhost:3000/nb/concepts/2879. Teksten skal plasseres under bildet.
5. På https://liste.test.ndla.no/nb/concepts/2879 plasseres teksten til høyre for bildet.