### PR TITLE
2760 Disabled all markdown parsing except for emphasis, sub and sup

### DIFF
--- a/packages/util/src/markdownHelpers.ts
+++ b/packages/util/src/markdownHelpers.ts
@@ -10,9 +10,39 @@
 import { Remarkable } from 'remarkable';
 import parse from 'html-react-parser';
 
-export const parseMarkdown = (embeddedCaption: string) => {
+export type ParseType = 'caption' | 'body';
+
+export const parseMarkdown = (embeddedCaption: string, parser: ParseType = 'caption') => {
   const markdown = new Remarkable({ breaks: true, html: true });
   markdown.inline.ruler.enable(['sub', 'sup']);
+  if (parser === 'caption') {
+    markdown.block.ruler.disable([
+      'table',
+      'footnote',
+      'blockquote',
+      'code',
+      'fences',
+      'footnote',
+      'heading',
+      'hr',
+      'htmlblock',
+      'lheading',
+      'list',
+      'table',
+    ]);
+    markdown.inline.ruler.disable([
+      'autolink',
+      'backticks',
+      'del',
+      'entity',
+      'escape',
+      'footnote_ref',
+      'htmltag',
+      'links',
+      'newline',
+      'text',
+    ]);
+  }
   const caption = embeddedCaption || '';
   /**
    * Whitespace must be escaped in order for ^superscript^ and ~subscript~

--- a/packages/util/src/markdownHelpers.ts
+++ b/packages/util/src/markdownHelpers.ts
@@ -16,6 +16,7 @@ export const parseMarkdown = (embeddedCaption: string, parser: ParseType = 'capt
   const markdown = new Remarkable({ breaks: true, html: true });
   markdown.inline.ruler.enable(['sub', 'sup']);
   if (parser === 'caption') {
+    markdown.set({ html: false, breaks: false });
     markdown.block.ruler.disable([
       'table',
       'footnote',


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2760

Inntil videre har jeg skrudd av nesten all markdown-parsing for captions. Nå støttes **bold**, *kursiv*, <sup>sup</sup> og <sub>sub</sub>

Kan testes ved å linke inn ndla-ui og ndla-util, for deretter å se på http://localhost:3000/subject-matter/learning-resource/31182/edit/nb. Alternativt kan man forsøke å oppdatere captions til å ta i bruk noe fra https://jonschlinkert.github.io/remarkable/demo/. 
