### PR TITLE
Removed i18nextProvider and switched ReactDOM.render over to ReactDOM.hydrate

### DIFF
--- a/packages/ndla-ui/src/AudioPlayer/initAudioPlayers.tsx
+++ b/packages/ndla-ui/src/AudioPlayer/initAudioPlayers.tsx
@@ -10,7 +10,6 @@ import ReactDOM from 'react-dom';
 
 import Controls from './Controls';
 import SpeechControl from './SpeechControl';
-import LocaleProvider from '../locale/LocaleProvider';
 import { Locale } from '../types';
 import { truncateDescription } from './AudioPlayer';
 
@@ -23,19 +22,15 @@ const forEachElement = (selector: string, callback: Function) => {
 
 const initAudioPlayers = (locale: Locale) => {
   forEachElement('[data-audio-player]', (el: HTMLElement) => {
+    console.log(el);
     const src = el.getAttribute('data-src');
     const title = el.getAttribute('data-title');
     const speech = el.getAttribute('data-speech');
     if (src && title) {
       if (speech) {
-        ReactDOM.render(<SpeechControl src={src} title={title} />, el);
+        ReactDOM.hydrate(<SpeechControl src={src} title={title} />, el);
       } else {
-        ReactDOM.render(
-          <LocaleProvider locale={locale}>
-            <Controls src={src} title={title} />
-          </LocaleProvider>,
-          el,
-        );
+        ReactDOM.hydrate(<Controls src={src} title={title} />, el);
       }
     }
   });

--- a/packages/ndla-ui/src/AudioPlayer/initAudioPlayers.tsx
+++ b/packages/ndla-ui/src/AudioPlayer/initAudioPlayers.tsx
@@ -22,7 +22,6 @@ const forEachElement = (selector: string, callback: Function) => {
 
 const initAudioPlayers = (locale: Locale) => {
   forEachElement('[data-audio-player]', (el: HTMLElement) => {
-    console.log(el);
     const src = el.getAttribute('data-src');
     const title = el.getAttribute('data-title');
     const speech = el.getAttribute('data-speech');


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2783

Det overordnede problemet er her fortsatt: `Controls` og `SpeechControl` rendres utenfor appen. Løsningen i denne PR'en er derfor ikke ideell, men den er bedre enn den nåværende situasjonen. 

`LocaleProvider` har blitt fjernet, slik at vi ikke tukler med `18nNextInstance` på samme måte. Dette har den uheldige side-effekten av at komponentene som blir rendret på nytt i `initAudioPlayers` alltid vil være på bokmål. Jeg fikset dette ved å bytte over til `ReactDOM.hydrate`, som gir oss funksjonaliteten uten at innholdet faktisk endrer seg. 