### PR TITLE
Lets width be undefined for ImageLink.

### DIFF
--- a/packages/ndla-ui/src/Image/Image.jsx
+++ b/packages/ndla-ui/src/Image/Image.jsx
@@ -13,12 +13,13 @@ import styled from '@emotion/styled';
 import LazyLoadImage from './LazyLoadImage';
 
 export const makeSrcQueryString = (width, crop, focalPoint) => {
-  const cropParams = crop
-    ? `&cropStartX=${crop.startX}&cropEndX=${crop.endX}&cropStartY=${crop.startY}&cropEndY=${crop.endY}`
-    : '';
-  const focalPointParams = focalPoint ? `&focalX=${focalPoint.x}&focalY=${focalPoint.y}` : '';
+  const widthParams = width && `width=${width}`;
+  const cropParams =
+    crop && `cropStartX=${crop.startX}&cropEndX=${crop.endX}&cropStartY=${crop.startY}&cropEndY=${crop.endY}`;
+  const focalPointParams = focalPoint && `focalX=${focalPoint.x}&focalY=${focalPoint.y}`;
+  const params = [widthParams, cropParams, focalPointParams].filter((p) => p).join('&');
 
-  return `width=${width}${cropParams}${focalPointParams}`;
+  return params;
 };
 
 const getSrcSet = (src, crop, focalPoint) => {

--- a/packages/ndla-ui/src/Image/ImageLink.js
+++ b/packages/ndla-ui/src/Image/ImageLink.js
@@ -18,7 +18,11 @@ const StyledLink = styled.a`
 
 export function ImageLink({ src, crop, children, ...rest }) {
   return (
-    <StyledLink target="_blank" href={`${src}?${makeSrcQueryString(10720, crop)}`} rel="noopener noreferrer" {...rest}>
+    <StyledLink
+      target="_blank"
+      href={`${src}?${makeSrcQueryString(undefined, crop)}`}
+      rel="noopener noreferrer"
+      {...rest}>
       {children}
     </StyledLink>
   );

--- a/packages/ndla-ui/src/Image/__tests__/Image-test.jsx
+++ b/packages/ndla-ui/src/Image/__tests__/Image-test.jsx
@@ -10,7 +10,7 @@
 
 import React from 'react';
 import renderer from 'react-test-renderer';
-import Image from '../Image';
+import Image, { makeSrcQueryString } from '../Image';
 
 test('Image renderers correctly', () => {
   const component = renderer.create(<Image alt="example" src="https://example.com/image.png" />);
@@ -45,4 +45,22 @@ test('Image with crop and focalpoint props renderers correctly', () => {
   );
 
   expect(component.toJSON()).toMatchSnapshot();
+});
+
+test('makeSrcQueryString renders correctly', () => {
+  const crop = {
+    startX: 14.59,
+    endX: 79.63,
+    startY: 20,
+    endY: 100,
+  };
+  const focalPoint = {
+    x: 65.08,
+    y: 45.28,
+  };
+  expect(makeSrcQueryString(undefined, undefined, undefined)).toMatch('');
+  expect(makeSrcQueryString(1024, undefined, undefined)).toMatch('width=1024');
+  expect(makeSrcQueryString(undefined, crop, undefined)).toMatchSnapshot();
+  expect(makeSrcQueryString(undefined, undefined, focalPoint)).toMatchSnapshot();
+  expect(makeSrcQueryString(1024, crop, focalPoint)).toMatchSnapshot();
 });

--- a/packages/ndla-ui/src/Image/__tests__/__snapshots__/Image-test.jsx.snap
+++ b/packages/ndla-ui/src/Image/__tests__/__snapshots__/Image-test.jsx.snap
@@ -73,3 +73,9 @@ exports[`Lazyloaded image renderers correctly 1`] = `
   />
 </div>
 `;
+
+exports[`makeSrcQueryString renders correctly 1`] = `"cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100"`;
+
+exports[`makeSrcQueryString renders correctly 2`] = `"focalX=65.08&focalY=45.28"`;
+
+exports[`makeSrcQueryString renders correctly 3`] = `"width=1024&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28"`;


### PR DESCRIPTION
Når du klikker på et bilde i en artikkel åpnes bildet i eget vindu, men med parameter `width=10720`. Dette er stort nok til at dei aller fleste bilder vises i full størrelse, men siden det spesifiseres bredde-parameter så skjer det en konvertering av bildet som ikkje er nødvendig. 
Endringa gjør width-parameter valgfritt uten at det ødelegger generering av parameterliste.