### PR TITLE
fix broken import

### DIFF
--- a/packages/ndla-ui/src/Article/ArticleByline.tsx
+++ b/packages/ndla-ui/src/Article/ArticleByline.tsx
@@ -15,7 +15,7 @@ import Button, { CopyButton } from '@ndla/button';
 import { colors, fonts, spacing } from '@ndla/core';
 import { copyTextToClipboard, printPage } from '@ndla/util';
 import { useTranslation } from 'react-i18next';
-import LicenseByline from '@ndla/licenses/src/LicenseByline/LicenseByline';
+import { LicenseByline } from '@ndla/licenses';
 import { getLicenseByAbbreviation } from '@ndla/licenses';
 
 const Wrapper = styled.div`


### PR DESCRIPTION
Fixes broken import, test are failing in ndla-frontend with the following message: 
```
Cannot find module '@ndla/licenses/src/LicenseByline/LicenseByline' from 'node_modules/@ndla/ui/lib/Article/ArticleByline.js'
```