### PR TITLE
Show Topic image as circle shape in all cases

### DIFF
--- a/packages/ndla-ui/src/Topic/Topic.tsx
+++ b/packages/ndla-ui/src/Topic/Topic.tsx
@@ -80,6 +80,7 @@ const VisualElementButton = styled(Button)`
 `;
 
 const TopicHeaderImage = styled.img`
+  border-radius: 50%;
   width: 100%;
   height: 100%;
   object-fit: none;


### PR DESCRIPTION
Fixes NDLANO/Issues#2817

https://ndla.no/subject:1:22dee9ab-5b1a-4c23-8c97-c68107b881bb/topic:2:77165/topic:2:198089/ viser rektangulære bilder og ikke sirkelformede.

Litt usikker på grunnen til at koden er strukturert slik i utgangspunktet, men i de tilfellene der `topic.article.visualElement` ikke eksisterer så ble bilde vist, men uten border-radius. Har nå satt `border-radius: 50%` i dette tilfellet.

Hvordan teste:
1. Sjekk ut denne branchen.
2. ndla-frontend på master
3. `ndla link ndla-frontend -l ndla-ui`
4. Åpne den samme siden lokalt og sjekk at bildene er runde.