### PR TITLE
kvalitetssikra OG fritt

### DIFF
--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -232,7 +232,7 @@ const messages = {
     blog: 'Fra bloggen',
   },
   meta: {
-    description: 'Kvalitetssikrede fritt tilgjengelige nettbaserte læremidler for videregående opplæring',
+    description: 'Kvalitetssikrede og fritt tilgjengelige nettbaserte læremidler for videregående opplæring',
     keywords: 'læremiddel,fag,skole,videregående,lærling,pensum,fagstoff',
   },
   masthead: {

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -231,7 +231,7 @@ const messages = {
     errorDescription: 'Orsak, ein feil oppstod under lasting av faga.',
   },
   meta: {
-    description: 'Kvalitetssikra fritt tilgjengelege nettbaserte læremiddel for vidaregåande opplæring',
+    description: 'Kvalitetssikra og fritt tilgjengelege nettbaserte læremiddel for vidaregåande opplæring',
     keywords: 'læremiddel,fag,skole,skule,vidaregåande,lærling,pensum,fagstoff, ',
   },
   masthead: {


### PR DESCRIPTION
Det må heite
nb: Kvalitetssikrede **og** fritt tilgjengelige nettbaserte læremidler for videregående opplæring
nn: Kvalitetssikra **og** fritt tilgjengelege nettbaserte læremiddel for vidaregåande opplæring