### PR TITLE
En feil oppstod ikke

### DIFF
--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -803,7 +803,7 @@ const messages = {
   concept: {
     showDescription: 'Vis beskrivelsen av forklaringen.',
     error: {
-      title: 'En feil oppstod ikke',
+      title: 'En feil oppstod',
       content: 'Kunne ikke laste beskrivelsen av forklaringen.',
     },
   },

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -804,7 +804,7 @@ const messages = {
   concept: {
     showDescription: 'Vis skildring av forklaringa',
     error: {
-      title: 'Ein feil oppstod ikke',
+      title: 'Ein feil oppstod',
       content: 'Kunne ikkje laste skildringa av forklaringa.',
     },
   },


### PR DESCRIPTION
Kunne kanskje vore En feil oppstod: ikke publisert

Retta nn/nb
 __En feil oppstod ikke__ til __En feil oppstod__ 
