### PR TITLE
Source and img tags are now direct children of picture tag in Image

### DIFF
--- a/packages/ndla-ui/src/Image/Image.jsx
+++ b/packages/ndla-ui/src/Image/Image.jsx
@@ -59,13 +59,13 @@ const Image = ({ alt, src, lazyLoad, lazyLoadSrc, crop, focalPoint, contentType,
   }
 
   return (
-    <picture>
-      <StyledImageWrapper>
+    <StyledImageWrapper>
+      <picture>
         <source type={contentType} srcSet={srcSet} sizes={sizes} />
         <img alt={alt} src={`${src}?${queryString}`} {...rest} />
-        {expandButton}
-      </StyledImageWrapper>
-    </picture>
+      </picture>
+      {expandButton}
+    </StyledImageWrapper>
   );
 };
 

--- a/packages/ndla-ui/src/Image/__tests__/__snapshots__/Image-test.jsx.snap
+++ b/packages/ndla-ui/src/Image/__tests__/__snapshots__/Image-test.jsx.snap
@@ -5,10 +5,10 @@ exports[`Image renderers correctly 1`] = `
   position: relative;
 }
 
-<picture>
-  <div
-    className="emotion-0 emotion-1"
-  >
+<div
+  className="emotion-0 emotion-1"
+>
+  <picture>
     <source
       sizes="(min-width: 1024px) 1024px, 100vw"
       srcSet="https://example.com/image.png?width=2720 2720w, https://example.com/image.png?width=2080 2080w, https://example.com/image.png?width=1760 1760w, https://example.com/image.png?width=1440 1440w, https://example.com/image.png?width=1120 1120w, https://example.com/image.png?width=1000 1000w, https://example.com/image.png?width=960 960w, https://example.com/image.png?width=800 800w, https://example.com/image.png?width=640 640w, https://example.com/image.png?width=480 480w, https://example.com/image.png?width=320 320w, https://example.com/image.png?width=240 240w, https://example.com/image.png?width=180 180w"
@@ -17,8 +17,8 @@ exports[`Image renderers correctly 1`] = `
       alt="example"
       src="https://example.com/image.png?width=1024"
     />
-  </div>
-</picture>
+  </picture>
+</div>
 `;
 
 exports[`Image with crop and focalpoint props renderers correctly 1`] = `
@@ -26,10 +26,10 @@ exports[`Image with crop and focalpoint props renderers correctly 1`] = `
   position: relative;
 }
 
-<picture>
-  <div
-    className="emotion-0 emotion-1"
-  >
+<div
+  className="emotion-0 emotion-1"
+>
+  <picture>
     <source
       sizes="(min-width: 1024px) 1024px, 100vw"
       srcSet="https://example.com/image.png?width=2720&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 2720w, https://example.com/image.png?width=2080&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 2080w, https://example.com/image.png?width=1760&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 1760w, https://example.com/image.png?width=1440&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 1440w, https://example.com/image.png?width=1120&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 1120w, https://example.com/image.png?width=1000&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 1000w, https://example.com/image.png?width=960&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 960w, https://example.com/image.png?width=800&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 800w, https://example.com/image.png?width=640&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 640w, https://example.com/image.png?width=480&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 480w, https://example.com/image.png?width=320&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 320w, https://example.com/image.png?width=240&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 240w, https://example.com/image.png?width=180&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28 180w"
@@ -38,8 +38,8 @@ exports[`Image with crop and focalpoint props renderers correctly 1`] = `
       alt="example"
       src="https://example.com/image.png?width=1024&cropStartX=14.59&cropEndX=79.63&cropStartY=20&cropEndY=100&focalX=65.08&focalY=45.28"
     />
-  </div>
-</picture>
+  </picture>
+</div>
 `;
 
 exports[`Lazyloaded image renderers correctly 1`] = `


### PR DESCRIPTION
Fikser automatisk skalering av bilder i Image-komponenten. Dette fungerte ikke fordi `<source>` og `<img>` ikke var direkte barn av `<picture>`.