### PR TITLE
Fix default language in storybook preview

### DIFF
--- a/packages/designmanual/.storybook/preview-head.html
+++ b/packages/designmanual/.storybook/preview-head.html
@@ -55,4 +55,7 @@
   window.MathJax.Hub.Config({
     showMathMenu: false,
   });
+  // Since the <html lang="en"> is static in storybook, we must set it this way to make i18n default to 'nb'
+  // See https://github.com/storybookjs/storybook/issues/11706
+  document.documentElement.setAttribute('lang', 'nb');
 </script>


### PR DESCRIPTION
Dersom man åpner designmanualen uten å ha språk satt i local-storage så defaultes det til engelsk. Dette fordi i18n i @ndla/ui har følgende detection-order: ['path', 'localStorage', 'htmlTag'].
Storybook sin preview <html> tag har statisk "lang='en'" attributt og derfor blir det engelsk. Denne hacken fikser dette siden det ikke er mulig å sette preview sin "lang" attributt i html-elementet. Se issue https://github.com/storybookjs/storybook/issues/11706