### PR TITLE
Fixed issue with slate block menu not showing after clicking other modals by switching from focus-on to focus-trap-react

### DIFF
--- a/packages/ndla-editor/package.json
+++ b/packages/ndla-editor/package.json
@@ -30,7 +30,7 @@
     "@types/react-beautiful-dnd": "^11.0.3",
     "prismjs": "^1.22.0",
     "react-beautiful-dnd": "^12.0.0",
-    "react-focus-on": "^3.5.1",
+    "focus-trap-react": "^6.0.0",
     "react-simple-code-editor": "^0.11.0"
   },
   "peerDependencies": {

--- a/packages/ndla-editor/src/SlateBlockMenu.tsx
+++ b/packages/ndla-editor/src/SlateBlockMenu.tsx
@@ -6,9 +6,8 @@
  *
  */
 
-import React from 'react';
-import { FocusOn } from 'react-focus-on';
-import PropTypes from 'prop-types';
+import React, { forwardRef, ReactNode } from 'react';
+import FocusTrap from 'focus-trap-react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import { spacing, colors, fonts, shadows, animations } from '@ndla/core';
@@ -127,73 +126,56 @@ const buttonOpen = css`
   pointer-events: none;
 `;
 
-const FocusWrapper = ({ onToggleOpen, children }) => (
-  <FocusOn
-    onDeactivation={() => onToggleOpen(false)}
-    onClickOutside={() => onToggleOpen(false)}
-    onEscapeKey={() => onToggleOpen(false)}
-    scrollLock={false}>
-    {children}
-  </FocusOn>
-);
+interface Props {
+  isOpen: boolean;
+  onToggleOpen: (open: boolean) => void;
+  heading?: string;
+  clickItem: (data: any) => void;
+  actions: {
+    label: string;
+    icon?: ReactNode;
+    data: { type: string; object: string };
+    helpIcon?: ReactNode;
+  }[];
+  cy?: string;
+}
 
-FocusWrapper.propTypes = {
-  isOpen: PropTypes.bool,
-  onToggleOpen: PropTypes.func.isRequired,
-  children: PropTypes.node.isRequired,
-};
-
-const SlateBlockMenu = React.forwardRef(({ heading, actions, clickItem, onToggleOpen, isOpen, cy }, ref) => (
-  <>
-    <div ref={ref} css={[buttonCSS, isOpen && buttonOpen]} data-cy={cy} onMouseDown={() => onToggleOpen(!isOpen)}>
-      <Plus />
-    </div>
-    {isOpen && (
-      <FocusWrapper onToggleOpen={onToggleOpen}>
-        <Wrapper>
-          <div cy="slate-block-picker-menu">
-            <HeaderLabel>{heading}</HeaderLabel>
-            {actions.map((action) => (
-              <Item key={action.data.object}>
-                <button
-                  css={itemButton}
-                  data-cy={`create-${action.data.object}`}
-                  type="button"
-                  onClick={() => clickItem(action.data)}>
-                  {action.icon && action.icon}
-                  <span>{action.label}</span>
-                </button>
-                {action.helpIcon}
-              </Item>
-            ))}
-          </div>
-        </Wrapper>
-      </FocusWrapper>
-    )}
-  </>
-));
-
-SlateBlockMenu.propTypes = {
-  isOpen: PropTypes.bool.isRequired,
-  onToggleOpen: PropTypes.func.isRequired,
-  heading: PropTypes.string,
-  clickItem: PropTypes.func.isRequired,
-  actions: PropTypes.arrayOf(
-    PropTypes.shape({
-      label: PropTypes.string.isRequired,
-      icon: PropTypes.node,
-      data: PropTypes.shape({
-        type: PropTypes.string.isRequired,
-        object: PropTypes.string.isRequired,
-      }).isRequired,
-      helpIcon: PropTypes.node,
-    }),
+const SlateBlockMenu = forwardRef<HTMLDivElement, Props>(
+  ({ heading, actions, clickItem, onToggleOpen, isOpen, cy = 'slate-block-menu' }: Props, ref) => (
+    <>
+      <div ref={ref} css={[buttonCSS, isOpen && buttonOpen]} data-cy={cy} onMouseDown={() => onToggleOpen(!isOpen)}>
+        <Plus />
+      </div>
+      {isOpen && (
+        <FocusTrap
+          active
+          focusTrapOptions={{
+            onDeactivate: () => onToggleOpen(false),
+            clickOutsideDeactivates: true,
+            escapeDeactivates: true,
+          }}>
+          <Wrapper>
+            <div data-cy="slate-block-picker-menu">
+              <HeaderLabel>{heading}</HeaderLabel>
+              {actions.map((action) => (
+                <Item key={action.data.object}>
+                  <button
+                    css={itemButton}
+                    data-cy={`create-${action.data.object}`}
+                    type="button"
+                    onClick={() => clickItem(action.data)}>
+                    {action.icon && action.icon}
+                    <span>{action.label}</span>
+                  </button>
+                  {action.helpIcon}
+                </Item>
+              ))}
+            </div>
+          </Wrapper>
+        </FocusTrap>
+      )}
+    </>
   ),
-  cy: PropTypes.string,
-};
-
-SlateBlockMenu.defaultProps = {
-  cy: 'slate-block-picker',
-};
+);
 
 export default SlateBlockMenu;

--- a/packages/ndla-editor/src/index-javascript.js
+++ b/packages/ndla-editor/src/index-javascript.js
@@ -6,9 +6,8 @@
  *
  */
 
-import SlateBlockMenu from './SlateBlockMenu';
 import FileListEditor from './FileListEditor';
 import MovieList from './ndlaFilm/MovieList';
 import NdlaFilmThemeEditorModal from './ndlaFilm/ThemeEditorModal';
 
-export { SlateBlockMenu, MovieList, NdlaFilmThemeEditorModal, FileListEditor };
+export { MovieList, NdlaFilmThemeEditorModal, FileListEditor };

--- a/packages/ndla-editor/src/index.ts
+++ b/packages/ndla-editor/src/index.ts
@@ -19,3 +19,4 @@ export { default as FooterQualityInsurance } from './footer/FooterQualityInsuran
 export { default as FooterLinkButton } from './footer/FooterLinkButton';
 export { default as FooterStatus } from './footer/FooterStatus';
 export { default as Spinner } from './Spinner';
+export { default as SlateBlockMenu } from './SlateBlockMenu';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5527,13 +5527,6 @@ argparse@^1.0.10, argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-hidden@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.1.2.tgz#5354315a29bffdaced3993fccd826817dc8c5272"
-  integrity sha512-WAMH9q3vRimVqP+B0q2eDvx7IPDoY17A2fWwj5atTA/zTYJCNcS6HJ5YErZ5FO3PUHhrV0y0yR1NA0dRNm913A==
-  dependencies:
-    tslib "^1.0.0"
-
 aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
@@ -8349,11 +8342,6 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detect-node-es@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.0.0.tgz#c0318b9e539a5256ca780dd9575c9345af05b8ed"
-  integrity sha512-S4AHriUkTX9FoFvL4G8hXDcx6t3gp2HpfCza3Q0v6S78gul2hKWifLQbeW+ZF89+hSm2ZIc/uF3J97ZgytgTRg==
-
 detect-port-alt@1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/detect-port-alt/-/detect-port-alt-1.1.6.tgz#24707deabe932d4a3cf621302027c2b266568275"
@@ -9802,13 +9790,6 @@ focus-lock@^0.6.3:
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.8.tgz#61985fadfa92f02f2ee1d90bc738efaf7f3c9f46"
   integrity sha512-vkHTluRCoq9FcsrldC0ulQHiyBYgVJB2CX53I8r0nTC6KnEij7Of0jpBspjt3/CuNb6fyoj3aOh9J2HgQUM0og==
 
-focus-lock@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.8.1.tgz#bb36968abf77a2063fa173cb6c47b12ac8599d33"
-  integrity sha512-/LFZOIo82WDsyyv7h7oc0MJF9ACOvDRdx9rWPZ2pgMfNWu/z8hQDBtOchuB/0BVLmuFOZjV02YwUVzNsWx/EzA==
-  dependencies:
-    tslib "^1.9.3"
-
 focus-trap-react@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-6.0.0.tgz#3f5a9f68447dd374d22388fb4c50018be83e74a5"
@@ -10120,11 +10101,6 @@ get-intrinsic@^1.0.1, get-intrinsic@^1.0.2:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
-
-get-nonce@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
-  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
 
 get-package-type@^0.1.0:
   version "0.1.0"
@@ -15232,7 +15208,7 @@ react-bem-helper@1.4.1, react-bem-helper@^1.4.1:
   dependencies:
     object-assign "^4.1.1"
 
-react-clientside-effect@^1.2.0, react-clientside-effect@^1.2.2:
+react-clientside-effect@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"
   integrity sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==
@@ -15358,30 +15334,6 @@ react-focus-lock@^1.17.7:
     focus-lock "^0.6.3"
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.0"
-
-react-focus-lock@^2.3.1:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.5.0.tgz#12e3a3940e897c26e2c2a0408cd25ea3c99b3709"
-  integrity sha512-XLxj6uTXgz0US8TmqNU2jMfnXwZG0mH2r/afQqvPEaX6nyEll5LHVcEXk2XDUQ34RVeLPkO/xK5x6c/qiuSq/A==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    focus-lock "^0.8.1"
-    prop-types "^15.6.2"
-    react-clientside-effect "^1.2.2"
-    use-callback-ref "^1.2.1"
-    use-sidecar "^1.0.1"
-
-react-focus-on@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/react-focus-on/-/react-focus-on-3.5.1.tgz#b459309cbee1b0a42dac92253e434d2860a509f6"
-  integrity sha512-6iE56nYNwVU6Pke362TjqRLz/G7DBGnEugkxhPAhpXEZW5og3vhc9qDPlyiHgxoiY9kYTWjdAEFz4nJgSluANg==
-  dependencies:
-    aria-hidden "^1.1.1"
-    react-focus-lock "^2.3.1"
-    react-remove-scroll "^2.4.0"
-    react-style-singleton "^2.1.0"
-    use-callback-ref "^1.2.3"
-    use-sidecar "^1.0.1"
 
 react-height@3.0.1:
   version "3.0.1"
@@ -15515,14 +15467,6 @@ react-remove-scroll-bar@^1.1.5:
     react-style-singleton "^1.1.0"
     tslib "^1.0.0"
 
-react-remove-scroll-bar@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.2.0.tgz#d4d545a7df024f75d67e151499a6ab5ac97c8cdd"
-  integrity sha512-UU9ZBP1wdMR8qoUs7owiVcpaPwsQxUDC2lypP6mmixaGlARZa7ZIBx1jcuObLdhMOvCsnZcvetOho0wzPa9PYg==
-  dependencies:
-    react-style-singleton "^2.1.0"
-    tslib "^1.0.0"
-
 react-remove-scroll@^1.0.2:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-1.0.8.tgz#a5aadc56368345a51ba524582c842a773849f609"
@@ -15530,17 +15474,6 @@ react-remove-scroll@^1.0.2:
   dependencies:
     react-remove-scroll-bar "^1.1.5"
     tslib "^1.0.0"
-
-react-remove-scroll@^2.4.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.4.1.tgz#e0af6126621083a5064591d367291a81b2d107f5"
-  integrity sha512-K7XZySEzOHMTq7dDwcHsZA6Y7/1uX5RsWhRXVYv8rdh+y9Qz2nMwl9RX/Mwnj/j7JstCGmxyfyC0zbVGXYh3mA==
-  dependencies:
-    react-remove-scroll-bar "^2.1.0"
-    react-style-singleton "^2.1.0"
-    tslib "^1.0.0"
-    use-callback-ref "^1.2.3"
-    use-sidecar "^1.0.1"
 
 react-router-dom@^5.2.0:
   version "5.2.0"
@@ -15615,15 +15548,6 @@ react-style-singleton@^1.1.0:
   resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-1.1.1.tgz#b2b698765519da812b80f55ab3c5fc5d849a2e63"
   integrity sha512-0JD+XC5veR3oxf7GzIXipr89sM8R3rWnOR/gpzIV0DnoRBrcTvvkqyMu9icDYqM/6CWJhYcH5Jdy6Nim7PmoTQ==
   dependencies:
-    invariant "^2.2.4"
-    tslib "^1.0.0"
-
-react-style-singleton@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.1.1.tgz#ce7f90b67618be2b6b94902a30aaea152ce52e66"
-  integrity sha512-jNRp07Jza6CBqdRKNgGhT3u9umWvils1xsuMOjZlghBDH2MU0PL2WZor4PGYjXpnRCa9DQSlHMs/xnABWOwYbA==
-  dependencies:
-    get-nonce "^1.0.0"
     invariant "^2.2.4"
     tslib "^1.0.0"
 
@@ -18346,16 +18270,6 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-callback-ref@^1.2.1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.4.tgz#d86d1577bfd0b955b6e04aaf5971025f406bea3c"
-  integrity sha512-rXpsyvOnqdScyied4Uglsp14qzag1JIemLeTWGKbwpotWht57hbP78aNT+Q4wdFKQfQibbUX4fb6Qb4y11aVOQ==
-
-use-callback-ref@^1.2.3:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.5.tgz#6115ed242cfbaed5915499c0a9842ca2912f38a5"
-  integrity sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==
-
 use-composed-ref@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/use-composed-ref/-/use-composed-ref-1.1.0.tgz#9220e4e94a97b7b02d7d27eaeab0b37034438bbc"
@@ -18379,14 +18293,6 @@ use-memo-one@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.1.tgz#39e6f08fe27e422a7d7b234b5f9056af313bd22c"
   integrity sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==
-
-use-sidecar@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.3.tgz#17a4e567d4830c0c0ee100040e85a7fe68611e0f"
-  integrity sha512-ygJwGUBeQfWgDls7uTrlEDzJUUR67L8Rm14v/KfFtYCdHhtjHZx1Krb3DIQl3/Q5dJGfXLEQ02RY8BdNBv87SQ==
-  dependencies:
-    detect-node-es "^1.0.0"
-    tslib "^1.9.3"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2889
Gjennom fiksing av dette fant jeg ut at React Router 6 må oppgraderes før man kan linke lokalt. Før vi kan gjøre det må vi over til React 17 i Frontend-packages, da React Router 6 er avhengig av dette. 
Hvordan teste: 
1. Lag en ny fil i ED og kopier over innholdet fra SlateBlockMenu. 
2. Erstatt SlateBlockMenu-importen i SlateBlockPicker.
3. Gå inn på http://localhost:3000/subject-matter/learning-resource/31322/edit/nb
4. Marker en seksjon med tekst og trykk på enten inline-konsept eller fotnote. Lukk deretter modalen som dukket opp.
5. Gå til ny linje og trykk på pluss-knappen. Den skal nå funke.