### PR TITLE
Noen nye tekster.

### DIFF
--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -178,6 +178,7 @@ const messages = {
       dialogHeader: '{{title}} is under construction',
       dialogText: 'Read more at',
     },
+    archived: 'This is an expired and unmaintained subject.',
   },
   subjectsPage: {
     chooseSubject: 'Choose subject',
@@ -391,6 +392,9 @@ const messages = {
       copyTitle: 'Copy link',
       hasCopiedTitle: 'Link copied',
     },
+    image: {
+      rules: 'Rules for use of image:',
+    },
     images: {
       heading: 'How to use images from the article',
       description: 'Remember to copy the text to be attached to the image where you use it.',
@@ -529,7 +533,8 @@ const messages = {
     en: 'English',
     fr: 'French',
     de: 'German',
-    se: 'Sami',
+    se: 'Northern Sami',
+    sma: 'Southern Sami',
     es: 'Spanish',
     zh: 'Chinese',
     unknown: 'Unknown',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -177,6 +177,7 @@ const messages = {
       dialogHeader: '{{title}} er under arbeid.',
       dialogText: 'Du kan lese mer om hva dette betyr på',
     },
+    archived: 'Dette er et utgått fag som ikke vedlikeholdes.',
   },
   subjectsPage: {
     errorDescription: 'Beklager, en feil oppstod under lasting av fagene.',
@@ -402,6 +403,9 @@ const messages = {
       copyTitle: 'Kopier lenke',
       hasCopiedTitle: 'Lenke kopiert',
     },
+    image: {
+      rules: 'Regler for bruk av bildet:',
+    },
     images: {
       heading: 'Slik bruker du bilder fra artikkelen',
       description: 'Husk å kopiere teksten som skal legges ved bildet der du bruker det.',
@@ -528,7 +532,8 @@ const messages = {
     en: 'Engelsk',
     fr: 'Fransk',
     de: 'Tysk',
-    se: 'Samisk',
+    se: 'Nordsamisk',
+    sma: 'Sørsamisk',
     es: 'Spansk',
     zh: 'Kinesisk',
     unknown: 'Ukjent',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -177,6 +177,7 @@ const messages = {
       dialogHeader: '{{title}} er under arbeid.',
       dialogText: 'Du kan lese meir om kva dette betyr på',
     },
+    archived: 'Dette er eit utgått fag som ikkje blir halde ved like.',
   },
   subjectsPage: {
     errorDescription: 'Orsak, ein feil oppstod under lasting av faga.',
@@ -403,6 +404,9 @@ const messages = {
       copyTitle: 'Kopier lenke',
       hasCopiedTitle: 'Lenke kopiert',
     },
+    image: {
+      rules: 'Reglar for bruk av biletet:',
+    },
     images: {
       heading: 'Slik bruker du bilete frå artikkelen',
       description: 'Hugs å kopiere teksten som skal leggjast ved biletet der du bruker det.',
@@ -529,7 +533,8 @@ const messages = {
     en: 'Engelsk',
     fr: 'Fransk',
     de: 'Tysk',
-    se: 'Samisk',
+    se: 'Nordsamisk',
+    sma: 'Sørsamisk',
     es: 'Spansk',
     zh: 'Kinesisk',
     unknown: 'Ukjent',


### PR DESCRIPTION
license.image.rules brukes for visuelt element for emner. Var enklere å legge til enn å skrive om den komponenten.

Litt språkvask, samt fiksing av manglende prop for bilde som visuelt element.