### PR TITLE
#2888: Add `CopyParagraphButton` component

### DIFF
--- a/packages/ndla-ui/src/Article/ArticleContent.tsx
+++ b/packages/ndla-ui/src/Article/ArticleContent.tsx
@@ -13,6 +13,7 @@ import {
   // @ts-ignore
 } from '@ndla/article-scripts';
 import { initAudioPlayers } from '../AudioPlayer';
+import { initCopyParagraphButtons } from '../CopyParagraphButton';
 import { Locale } from '../types';
 
 type Props = {
@@ -24,6 +25,7 @@ const ArticleContent = ({ content, locale, ...rest }: Props) => {
     removeEventListenerForResize();
     initArticleScripts();
     initAudioPlayers(locale);
+    initCopyParagraphButtons();
     return () => {
       removeEventListenerForResize();
     };

--- a/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
+++ b/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { useEffect, useState } from 'react';
+
+import styled from '@emotion/styled';
+import { Link } from '@ndla/icons/common';
+import { useTranslation } from 'react-i18next';
+// @ts-ignore
+import Tooltip from '@ndla/tooltip';
+import { copyTextToClipboard } from '@ndla/util';
+
+const IconButton = styled.button`
+  float: left;
+  position: relative;
+  left: -3em;
+  top: 0.1em;
+  background: none;
+  border: 0;
+  z-index: 1;
+  transition: 0.2s;
+  opacity: 0;
+
+  & svg {
+    width: 30px;
+    height: 30px;
+  }
+`;
+
+const ContainerDiv = styled.div`
+  &:hover button {
+    cursor: pointer;
+    opacity: 0.5;
+  }
+
+  & h2 {
+    position: relative;
+    left: -2em;
+  }
+`;
+
+interface Props {
+  title?: string | null;
+}
+
+const CopyParagraphButton = ({ title }: Props) => {
+  const { t } = useTranslation();
+  const [hasCopied, setHasCopied] = useState(false);
+  useEffect(() => {
+    if (hasCopied) {
+      setTimeout(() => setHasCopied(false), 3000);
+    }
+  }, [hasCopied]);
+
+  if (!title) return null;
+
+  const onCopyClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
+    setHasCopied(true);
+    const copyId = event.currentTarget.getAttribute('data-title');
+    const { location } = window;
+    const newHash = `#${copyId}`;
+    const port = location.port ? `:${location.port}` : '';
+    const urlToCopy = `${location.protocol}//${location.hostname}${port}${location.pathname}${location.search}${newHash}`;
+
+    copyTextToClipboard(urlToCopy);
+  };
+
+  const sanitizedTitle = encodeURIComponent(title.replace(/ /g, '-'));
+  const tooltip = hasCopied ? t('article.copyPageLinkCopied') : t('article.copyHeaderLink');
+  return (
+    <ContainerDiv data-header-copy-container data-title={title}>
+      <IconButton onClick={onCopyClick} data-title={sanitizedTitle}>
+        <Tooltip tooltip={tooltip}>
+          <Link title={''} />
+        </Tooltip>
+      </IconButton>
+      <h2 id={sanitizedTitle} tabIndex={0}>
+        {title}
+      </h2>
+    </ContainerDiv>
+  );
+};
+
+export default CopyParagraphButton;

--- a/packages/ndla-ui/src/CopyParagraphButton/index.tsx
+++ b/packages/ndla-ui/src/CopyParagraphButton/index.tsx
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import CopyParagraphButton from './CopyParagraphButton';
+import initCopyParagraphButtons from './initCopyParagraphButtons';
+
+export { CopyParagraphButton, initCopyParagraphButtons };
+export default CopyParagraphButton;

--- a/packages/ndla-ui/src/CopyParagraphButton/initCopyParagraphButtons.tsx
+++ b/packages/ndla-ui/src/CopyParagraphButton/initCopyParagraphButtons.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import CopyParagraphButton from './CopyParagraphButton';
+
+const forEachElement = (selector: string, callback: Function) => {
+  const nodeList = document.querySelectorAll(selector);
+  for (let i = 0; i < nodeList.length; i += 1) {
+    callback(nodeList[i], i);
+  }
+};
+
+const initCopyParagraphButtons = () => {
+  forEachElement('[data-header-copy-container]', (el: HTMLElement) => {
+    const title = el.getAttribute('data-title');
+    ReactDOM.hydrate(<CopyParagraphButton title={title} />, el);
+  });
+};
+
+export default initCopyParagraphButtons;

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -135,3 +135,5 @@ export {
 } from './Subject';
 
 export { default as ContentCard } from './ContentCard';
+
+export { default as CopyParagraphButton } from './CopyParagraphButton';

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -327,6 +327,7 @@ const messages = {
     multipleAuthorsLabelAriaConjunction: 'and',
     copyPageLink: 'Copy page-link',
     copyPageLinkCopied: 'Link copied',
+    copyHeaderLink: 'Copy link to header',
     conjunction: 'and',
     supplierLabel: 'Rightsholder: {{name}}',
     multipleSuppliersLabel: 'Rightsholders: {{names}}',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -326,6 +326,7 @@ const messages = {
     multipleAuthorsLabelAriaConjunction: 'og',
     copyPageLink: 'Kopier lenke til siden',
     copyPageLinkCopied: 'Lenke kopiert',
+    copyHeaderLink: 'Kopier lenke til overskriften',
     conjunction: 'og',
     supplierLabel: 'Rettighetshaver: {{name}}',
     multipleSuppliersLabel: 'Rettighetshavere: {{names}}',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -327,6 +327,7 @@ const messages = {
     multipleAuthorsLabelAriaConjunction: 'og',
     copyPageLink: 'Kopier lenke til sida',
     copyPageLinkCopied: 'Lenke kopiert',
+    copyHeaderLink: 'Kopier lenke til overskrifta',
     conjunction: 'og',
     supplierLabel: 'Rettshavar: {{name}}',
     multipleSuppliersLabel: 'Rettshavarar: {{names}}',

--- a/packages/tooltip/index.js
+++ b/packages/tooltip/index.js
@@ -1,3 +1,0 @@
-import Tooltip from './Tooltip';
-
-export default Tooltip;


### PR DESCRIPTION
Relates to NDLANO/Issues#2888

Legger til komponenten som vil bytte ut "alle" `h2` headere i artikler i article-converter / ndla-frontend (via `ArticleContent`)

For testing så anbefaler jeg å vente til jeg får ut PR'ene i article-converter og ndla-frontend som depender på denne, men bare å se på koden :smile: