### PR TITLE
2770 sync concept meta and visual

### DIFF
--- a/packages/ndla-image-search/package.json
+++ b/packages/ndla-image-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndla/image-search",
-  "version": "1.1.30-alpha.0+d3002abed",
+  "version": "1.1.30-alpha.1+c946f9de6",
   "description": "A simple library for searching images from NDLA",
   "license": "GPL-3.0",
   "main": "lib/index.js",
@@ -35,5 +35,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "d3002abed3fc6c91accfe003a21557e5536258e8"
+  "gitHead": "c946f9de6482fa9ce5bbb1098d9db20b42b72505"
 }

--- a/packages/ndla-image-search/package.json
+++ b/packages/ndla-image-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndla/image-search",
-  "version": "1.1.29",
+  "version": "1.1.30-alpha.0+d3002abed",
   "description": "A simple library for searching images from NDLA",
   "license": "GPL-3.0",
   "main": "lib/index.js",
@@ -35,5 +35,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "b4aebae76ed5808f9647b61ea27d6e0bb9968148"
+  "gitHead": "d3002abed3fc6c91accfe003a21557e5536258e8"
 }

--- a/packages/ndla-image-search/package.json
+++ b/packages/ndla-image-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndla/image-search",
-  "version": "1.1.30-alpha.2+67783b676",
+  "version": "1.1.30-alpha.4+aad6f3c4f",
   "description": "A simple library for searching images from NDLA",
   "license": "GPL-3.0",
   "main": "lib/index.js",
@@ -35,5 +35,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "67783b676041eaffe78c124aeec1768aeb60d29e"
+  "gitHead": "aad6f3c4f477d29c0dc9183d9cad017b72b6d541"
 }

--- a/packages/ndla-image-search/package.json
+++ b/packages/ndla-image-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndla/image-search",
-  "version": "1.1.30-alpha.4+aad6f3c4f",
+  "version": "1.1.30-alpha.5+059023e41",
   "description": "A simple library for searching images from NDLA",
   "license": "GPL-3.0",
   "main": "lib/index.js",
@@ -35,5 +35,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "aad6f3c4f477d29c0dc9183d9cad017b72b6d541"
+  "gitHead": "059023e41e9bc2135ff275ec3a9a55fd2cdfda68"
 }

--- a/packages/ndla-image-search/package.json
+++ b/packages/ndla-image-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndla/image-search",
-  "version": "1.1.30-alpha.1+c946f9de6",
+  "version": "1.1.30-alpha.2+67783b676",
   "description": "A simple library for searching images from NDLA",
   "license": "GPL-3.0",
   "main": "lib/index.js",
@@ -35,5 +35,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "c946f9de6482fa9ce5bbb1098d9db20b42b72505"
+  "gitHead": "67783b676041eaffe78c124aeec1768aeb60d29e"
 }

--- a/packages/ndla-image-search/src/ImageSearch.js
+++ b/packages/ndla-image-search/src/ImageSearch.js
@@ -101,7 +101,7 @@ const ImageSearchWrapper = styled.div`
     border-width: ${spacing.normal};
     margin-left: -${spacing.normal};
   }
-}
+
 
 .image-preview {
   animation: fadeInSearchPreview 300ms ease;

--- a/packages/ndla-image-search/src/ImageSearch.js
+++ b/packages/ndla-image-search/src/ImageSearch.js
@@ -321,11 +321,11 @@ class ImageSearch extends React.Component {
   }
 
   onSelectImage(image, saveAsMetaImage) {
-    const { onImageSelect, onSaveAsMetaImage } = this.props;
+    const { onImageSelect, checkboxAction } = this.props;
     this.setState({ selectedImage: undefined });
     onImageSelect(image);
     if (saveAsMetaImage) {
-      onSaveAsMetaImage && onSaveAsMetaImage(image);
+      checkboxAction && checkboxAction(image);
     }
   }
 
@@ -356,8 +356,7 @@ class ImageSearch extends React.Component {
   }
 
   render() {
-    const { searchPlaceholder, searchButtonTitle, useImageTitle, showMetaImageCheckbox, metaImageCheckboxLabel } =
-      this.props;
+    const { searchPlaceholder, searchButtonTitle, useImageTitle, showCheckbox, checkboxLabel } = this.props;
 
     const { queryObject, images, selectedImage, lastPage, searching, queryString } = this.state;
 
@@ -400,8 +399,8 @@ class ImageSearch extends React.Component {
               selectedImage={selectedImage}
               onSelectImage={this.onSelectImage}
               useImageTitle={useImageTitle}
-              showMetaImageCheckbox={showMetaImageCheckbox}
-              metaImageCheckboxLabel={metaImageCheckboxLabel}
+              showCheckbox={showCheckbox}
+              checkboxLabel={checkboxLabel}
             />
           ))}
         </div>
@@ -429,13 +428,13 @@ ImageSearch.propTypes = {
   locale: PropTypes.string.isRequired,
   useImageTitle: PropTypes.string.isRequired,
   noResults: PropTypes.node,
-  onSaveAsMetaImage: PropTypes.func,
-  showMetaImageCheckbox: PropTypes.bool,
-  metaImageCheckboxLabel: PropTypes.string,
+  checkboxAction: PropTypes.func,
+  showCheckbox: PropTypes.bool,
+  checkboxLabel: PropTypes.string,
 };
 
 ImageSearch.defaultProps = {
-  showMetaImageCheckbox: false,
+  showCheckbox: false,
 };
 
 export default ImageSearch;

--- a/packages/ndla-image-search/src/ImageSearchResult.js
+++ b/packages/ndla-image-search/src/ImageSearchResult.js
@@ -18,8 +18,8 @@ export default function ImageSearchResult({
   selectedImage,
   onSelectImage,
   useImageTitle,
-  showMetaImageCheckbox,
-  metaImageCheckboxLabel,
+  showCheckbox,
+  checkboxLabel,
 }) {
   const active = selectedImage && selectedImage.id === image.id ? 'active' : '';
 
@@ -41,8 +41,8 @@ export default function ImageSearchResult({
           image={selectedImage}
           onSelectImage={onSelectImage}
           useImageTitle={useImageTitle}
-          metaImageCheckboxLabel={metaImageCheckboxLabel}
-          showMetaImageCheckbox={showMetaImageCheckbox}
+          checkboxLabel={checkboxLabel}
+          showCheckbox={showCheckbox}
         />
       ) : (
         ''
@@ -62,6 +62,6 @@ ImageSearchResult.propTypes = {
   }),
   onSelectImage: PropTypes.func.isRequired,
   useImageTitle: PropTypes.string.isRequired,
-  showMetaImageCheckbox: PropTypes.bool.isRequired,
+  showCheckbox: PropTypes.bool.isRequired,
   useAsMetaImageLabel: PropTypes.string,
 };

--- a/packages/ndla-image-search/src/PreviewImage.js
+++ b/packages/ndla-image-search/src/PreviewImage.js
@@ -17,7 +17,7 @@ import { getSrcSets } from './util/imageUtil';
 const convertWithFallBack = (fieldName, value, fallback) =>
   value[fieldName] && value[fieldName][fieldName] ? value[fieldName][fieldName] : fallback;
 
-const PreviewImage = ({ image, onSelectImage, useImageTitle, showMetaImageCheckbox, metaImageCheckboxLabel }) => {
+const PreviewImage = ({ image, onSelectImage, useImageTitle, showCheckbox, checkboxLabel }) => {
   const [saveAsMetaImage, setSaveAsMetaImage] = useState(false);
 
   const tags = convertWithFallBack('tags', image.tags, []);
@@ -50,10 +50,10 @@ const PreviewImage = ({ image, onSelectImage, useImageTitle, showMetaImageCheckb
         <Button data-cy="use-image" onClick={() => onSelectImage(image, saveAsMetaImage)}>
           {useImageTitle}
         </Button>
-        {showMetaImageCheckbox && (
+        {showCheckbox && (
           <div>
             <CheckboxItem
-              label={metaImageCheckboxLabel}
+              label={checkboxLabel}
               checked={saveAsMetaImage}
               onChange={() => setSaveAsMetaImage((prev) => !prev)}
             />
@@ -90,8 +90,8 @@ PreviewImage.propTypes = {
   }).isRequired,
   onSelectImage: PropTypes.func.isRequired,
   useImageTitle: PropTypes.string.isRequired,
-  showMetaImageCheckbox: PropTypes.bool.isRequired,
-  metaImageCheckboxLabel: PropTypes.string,
+  showCheckbox: PropTypes.bool.isRequired,
+  checkboxLabel: PropTypes.string,
 };
 
 export default PreviewImage;


### PR DESCRIPTION
Gjør props relatert til checkbox i image-search mer generelt for å kunne brukes til andre formål. Skal nå både kunne brukes til å sette visuelt element fra metabilde og omvendt.

Relatert til NDLANO/Issues#2770. 

Alphaversjoner av pakken er lenket inn og kan testes direkte i PR:
https://github.com/NDLANO/editorial-frontend/pull/1304