### PR TITLE
Set cursor to pointer on Notion close button

### DIFF
--- a/packages/ndla-notion/src/NotionHeader.js
+++ b/packages/ndla-notion/src/NotionHeader.js
@@ -39,6 +39,7 @@ const NotionHeaderWrapper = styled.div`
     background: none;
     color: ${colors.brand.primary};
     box-shadow: ${misc.textLinkBoxShadow};
+    cursor: pointer;
     &:hover,
     &:focus {
       box-shadow: none;


### PR DESCRIPTION
Relatert til NDLANO/Issues#2919

Bumper ed, article-converter og ndla-frontend etter merge og release.

Hvordan teste:
1. Åpne design-manual på /?path=/story/forklaringstjenesten--forklaringstjenesten
2. Trykk på en forklaring.
3. Lukk-knappen skal ha cursor som hånd👆  og ikke vanlig peker.