### PR TITLE
Added possibility to add additional header content for a notion

### DIFF
--- a/packages/ndla-notion/src/Notion.tsx
+++ b/packages/ndla-notion/src/Notion.tsx
@@ -58,20 +58,20 @@ interface Props {
   ariaLabel: string;
   children?: ReactNode;
   content?: ReactNode;
+  headerContent?: ReactNode;
   customCSS?: InterpolationWithTheme<any>;
 }
-const Notion = ({ id, ariaLabel, content, children, title, customCSS }: Props) => (
+const Notion = ({ id, ariaLabel, content, children, title, customCSS, headerContent }: Props) => (
   <span css={NotionCSS} id={id} data-notion>
     <button type="button" aria-label={ariaLabel} className={'link'} data-notion-link>
       {children}
     </button>
     {createUniversalPortal(
-      <NotionDialog id={id} title={title} customCSS={customCSS}>
+      <NotionDialog id={id} title={title} customCSS={customCSS} headerContent={headerContent}>
         {content}
       </NotionDialog>,
       'body',
     )}
   </span>
 );
-
 export default Notion;

--- a/packages/ndla-notion/src/NotionDialog.tsx
+++ b/packages/ndla-notion/src/NotionDialog.tsx
@@ -177,9 +177,10 @@ interface Props {
   ariaHidden?: boolean;
   children?: ReactNode;
   customCSS: InterpolationWithTheme<any>;
+  headerContent?: ReactNode;
 }
 
-const NotionDialog = ({ title, children, id, subTitle, ariaHidden = true, customCSS }: Props) => (
+const NotionDialog = ({ title, children, id, subTitle, ariaHidden = true, customCSS, headerContent }: Props) => (
   <NotionDialogStyledWrapper
     aria-hidden={ariaHidden}
     role="dialog"
@@ -187,7 +188,7 @@ const NotionDialog = ({ title, children, id, subTitle, ariaHidden = true, custom
     aria-labelledby={id}
     aria-describedby={id}
     css={customCSS}>
-    <NotionHeader title={title} subTitle={subTitle} />
+    <NotionHeader title={title} subTitle={subTitle} children={headerContent} />
     <NotionBody>{children}</NotionBody>
   </NotionDialogStyledWrapper>
 );

--- a/packages/ndla-notion/src/NotionHeader.tsx
+++ b/packages/ndla-notion/src/NotionHeader.tsx
@@ -6,12 +6,15 @@
  *
  */
 
-import React, { MouseEvent } from 'react';
+import React, { MouseEvent, ReactNode } from 'react';
 import styled from '@emotion/styled';
 import { useTranslation } from 'react-i18next';
 import { spacing, colors, fonts, misc } from '@ndla/core';
 
-const NotionHeaderWrapper = styled.div`
+interface NotionHeaderWrapperProps {
+  hasChildren?: boolean;
+}
+const NotionHeaderWrapper = styled.div<NotionHeaderWrapperProps>`
   margin: ${spacing.normal} ${spacing.normal} ${spacing.small};
   padding-bottom: ${spacing.small};
   display: flex;
@@ -20,7 +23,7 @@ const NotionHeaderWrapper = styled.div`
   border-bottom: 2px solid ${colors.brand.tertiary};
   h1 {
     margin: 0;
-    flex-grow: 1;
+    flex-grow: ${(p) => (p.hasChildren ? 0 : 1)};
     font-weight: ${fonts.weight.bold};
     ${fonts.sizes('22px', 1.2)};
     color: ${colors.text.primary};
@@ -56,6 +59,7 @@ interface NotionHeaderProps {
   title: string;
   subTitle?: string;
   onClose?: (event: MouseEvent<HTMLButtonElement>) => void;
+  children?: ReactNode;
 }
 
 type NotionHeaderWithoutExitButtonProps = Omit<NotionHeaderProps, 'onClose'>;
@@ -64,11 +68,12 @@ export const NotionHeaderWithoutExitButton = ({ title, subTitle }: NotionHeaderW
   <NotionHeaderWrapper>{notionTitle(title, subTitle)}</NotionHeaderWrapper>
 );
 
-const NotionHeader = ({ title, subTitle, onClose }: NotionHeaderProps) => {
+const NotionHeader = ({ title, subTitle, onClose, children }: NotionHeaderProps) => {
   const { t } = useTranslation();
   return (
-    <NotionHeaderWrapper>
+    <NotionHeaderWrapper hasChildren={!!children}>
       {notionTitle(title, subTitle)}
+      {children}
       {onClose ? (
         <button type="button" onClick={onClose}>
           {t('notions.closeNotion')}


### PR DESCRIPTION
Relatert til https://github.com/NDLANO/Issues/issues/2918
Tanken er at man skal kunne passere inn en publisert-komponent som kan plasseres i NotionHeader. 