### PR TITLE
CopyParagraphButton hydrate should no longer cause duplicate anchors

### DIFF
--- a/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
+++ b/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
@@ -101,7 +101,7 @@ const CopyParagraphButton = ({ title, content, hydrate }: Props) => {
           <Link title={''} />
         </Tooltip>
       </IconButton>
-      <h2 tabIndex={0} dangerouslySetInnerHTML={{ __html: content || '' }}></h2>
+      <h2 id={sanitizedTitle} tabIndex={0} dangerouslySetInnerHTML={{ __html: content || '' }}></h2>
     </WrapperComponent>
   );
 };

--- a/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
+++ b/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
@@ -46,13 +46,6 @@ const ContainerDiv = styled.div`
   }
 `;
 
-const AnchorDiv = styled.div`
-  display: block;
-  position: absolute;
-  top: -100px;
-  visibility: hidden;
-`;
-
 interface Props {
   title?: string | null;
   content?: string | null;
@@ -108,7 +101,6 @@ const CopyParagraphButton = ({ title, content, hydrate }: Props) => {
           <Link title={''} />
         </Tooltip>
       </IconButton>
-      <AnchorDiv id={sanitizedTitle} />
       <h2 tabIndex={0} dangerouslySetInnerHTML={{ __html: content || '' }}></h2>
     </WrapperComponent>
   );

--- a/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
+++ b/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 
 import styled from '@emotion/styled';
 import { Link } from '@ndla/icons/common';
@@ -33,6 +33,8 @@ const IconButton = styled.button`
 `;
 
 const ContainerDiv = styled.div`
+  position: relative;
+
   &:hover button {
     cursor: pointer;
     opacity: 0.5;
@@ -44,12 +46,37 @@ const ContainerDiv = styled.div`
   }
 `;
 
+const AnchorDiv = styled.div`
+  display: block;
+  position: absolute;
+  top: -100px;
+  visibility: hidden;
+`;
+
 interface Props {
   title?: string | null;
   content?: string | null;
+  hydrate?: boolean;
 }
 
-const CopyParagraphButton = ({ title, content }: Props) => {
+interface WrapperProps {
+  title: string;
+  hydrate?: boolean;
+  children: ReactNode;
+}
+
+const WrapperComponent = ({ title, hydrate, children }: WrapperProps) => {
+  if (hydrate) {
+    return <>{children}</>;
+  }
+  return (
+    <ContainerDiv data-header-copy-container data-title={title}>
+      {children}
+    </ContainerDiv>
+  );
+};
+
+const CopyParagraphButton = ({ title, content, hydrate }: Props) => {
   const { t } = useTranslation();
   const [hasCopied, setHasCopied] = useState(false);
   useEffect(() => {
@@ -73,15 +100,17 @@ const CopyParagraphButton = ({ title, content }: Props) => {
 
   const sanitizedTitle = encodeURIComponent(title.replace(/ /g, '-'));
   const tooltip = hasCopied ? t('article.copyPageLinkCopied') : t('article.copyHeaderLink');
+
   return (
-    <ContainerDiv data-header-copy-container data-title={title}>
+    <WrapperComponent hydrate={hydrate} title={title}>
       <IconButton onClick={onCopyClick} data-title={sanitizedTitle}>
         <Tooltip tooltip={tooltip}>
           <Link title={''} />
         </Tooltip>
       </IconButton>
-      <h2 id={sanitizedTitle} tabIndex={0} dangerouslySetInnerHTML={{ __html: content || '' }}></h2>
-    </ContainerDiv>
+      <AnchorDiv id={sanitizedTitle} />
+      <h2 tabIndex={0} dangerouslySetInnerHTML={{ __html: content || '' }}></h2>
+    </WrapperComponent>
   );
 };
 

--- a/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
+++ b/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
@@ -33,8 +33,6 @@ const IconButton = styled.button`
 `;
 
 const ContainerDiv = styled.div`
-  position: relative;
-
   &:hover button {
     cursor: pointer;
     opacity: 0.5;

--- a/packages/ndla-ui/src/CopyParagraphButton/initCopyParagraphButtons.tsx
+++ b/packages/ndla-ui/src/CopyParagraphButton/initCopyParagraphButtons.tsx
@@ -19,8 +19,7 @@ const forEachElement = (selector: string, callback: Function) => {
 const initCopyParagraphButtons = () => {
   forEachElement('[data-header-copy-container]', (el: HTMLElement) => {
     const title = el.getAttribute('data-title');
-    const content = el.innerHTML;
-    ReactDOM.hydrate(<CopyParagraphButton title={title} content={content} />, el);
+    ReactDOM.hydrate(<CopyParagraphButton title={title} content={title} />, el);
   });
 };
 

--- a/packages/ndla-ui/src/CopyParagraphButton/initCopyParagraphButtons.tsx
+++ b/packages/ndla-ui/src/CopyParagraphButton/initCopyParagraphButtons.tsx
@@ -19,7 +19,7 @@ const forEachElement = (selector: string, callback: Function) => {
 const initCopyParagraphButtons = () => {
   forEachElement('[data-header-copy-container]', (el: HTMLElement) => {
     const title = el.getAttribute('data-title');
-    ReactDOM.hydrate(<CopyParagraphButton title={title} content={title} />, el);
+    ReactDOM.hydrate(<CopyParagraphButton title={title} content={title} hydrate={true} />, el);
   });
 };
 


### PR DESCRIPTION
Oppgradering av denne pakken skal fikse deler av NDLANO/Issues#2937

Hvordan teste:
1. Link inn ndla-ui i ndla-frontend med `ndla link ndla-frontend -l ndla-ui` fra denne branchen.
2. Åpne http://localhost:3000/nb/subject:1:f3d2143b-66e3-428c-89ca-72c1abc659ea/topic:5:186579/topic:3:47954/resource:1:152116.
3. anchors skal ikke lenger være duplikate. Anchor vises fortsatt i audio, men dette burde vi finne en løsning på i article-converter heller.