### PR TITLE
Add getCopyString and getLicenseCredits to license package

### DIFF
--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -1,0 +1,83 @@
+import { TFunction } from 'i18next';
+import { LocaleType } from './types';
+import { Contributor } from './contributorTypes';
+
+export const getLicenseCredits = (copyright?: {
+  creators?: Contributor[];
+  rightsholders?: Contributor[];
+  processors?: Contributor[];
+}) => {
+  return {
+    creators: copyright?.creators ?? [],
+    rightsholders: copyright?.rightsholders ?? [],
+    processors: copyright?.processors ?? [],
+  };
+};
+
+const makeCreditCopyString = (roles: Contributor[], locale: LocaleType, t: TFunction) => {
+  if (!roles?.length) {
+    return '';
+  }
+  return (
+    roles
+      .map((creator) => {
+        const type = creator.type && t(locale, `${creator.type.toLowerCase()}`);
+        return `${type}: ${creator.name?.trim()}`;
+      })
+      .join(', ') + '. '
+  );
+};
+
+const getValueOrFallback = <T>(value: T | undefined, fallback: T): T => {
+  if (value === undefined) {
+    return fallback;
+  }
+  return value;
+};
+
+const makeDateString = () => {
+  const timeElapsed = Date.now();
+  const today = new Date(timeElapsed);
+  const dd = String(today.getDate()).padStart(2, '0');
+  const mm = String(today.getMonth() + 1).padStart(2, '0');
+  const yyyy = today.getFullYear();
+  return `${dd}.${mm}.${yyyy}`;
+};
+
+export const getCopyString = (
+  title: string | undefined,
+  src: string | undefined,
+  path: string | undefined,
+  copyright:
+    | {
+        creators?: Contributor[];
+        rightsholders?: Contributor[];
+        processors?: Contributor[];
+      }
+    | undefined,
+  locale: LocaleType,
+  ndlaFrontendDomain: string | undefined,
+  t: TFunction,
+): string => {
+  const credits = getLicenseCredits(copyright);
+  const creators = makeCreditCopyString(credits.creators, locale, t);
+  const processors = makeCreditCopyString(credits.processors, locale, t);
+  const rightsholders = makeCreditCopyString(credits.rightsholders, locale, t);
+  const titleString = getValueOrFallback(title, t(locale, 'license.copyText.noTitle')) + ' ';
+  const url = path ? ndlaFrontendDomain + path : src;
+  const date = makeDateString();
+
+  // Ex: Fotograf: Ola Nordmann. Tittel [Internett]. Opphaver: NTB. Hentet fra: www.ndla.no/urn:resource:123 Lest: 04.05.2021
+  return (
+    creators +
+    processors +
+    titleString +
+    t(locale, 'license.copyText.internet') +
+    rightsholders +
+    t(locale, 'license.copyText.downloadedFrom') +
+    url +
+    ' ' +
+    t(locale, 'license.copyText.readDate') +
+    date
+  );
+};

--- a/packages/ndla-licenses/src/index.ts
+++ b/packages/ndla-licenses/src/index.ts
@@ -20,3 +20,5 @@ export { BY, SA, NC, ND, PD, CC0, CC, COPYRIGHTED, getLicenseRightByAbbreviation
 export { getLicenseByAbbreviation, getLicenseByNBTitle, isCreativeCommonsLicense } from './licenses';
 
 export { LicenseByline, LicenseDescription } from './LicenseByline';
+
+export { getCopyString, getLicenseCredits } from './getCopyString';

--- a/packages/ndla-licenses/src/types.ts
+++ b/packages/ndla-licenses/src/types.ts
@@ -28,6 +28,8 @@ export interface RightType {
   en: RightLocaleInfo;
 }
 
+export type LocaleType = 'nb' | 'nn' | 'en';
+
 const locales = ['nb', 'nn', 'en'] as const;
 export type Locale = typeof locales[number];
 


### PR DESCRIPTION
Relatert til NDLANO/Issues#2447

For å vise knapp for kopiering av kildehenvisning i ndla-frontend trengs streng for kopiering. Det finnes funksjoner for å generere disse i article-converter. Funksjonene jeg har lagt til her nå er identiske, men har lagt til parametre for translation og domene for at det skal fungere.