### PR TITLE
Do not use locale for translations in getCopyString functions

### DIFF
--- a/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
+++ b/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/* eslint-env jest */
+
+import { getCopyString } from '../getCopyString';
+
+const fakeTranslator = (id: string) => {
+  switch (id) {
+    case 'license.copyText.internet':
+      return '[Internett]. ';
+    case 'license.copyText.downloadedFrom':
+      return 'Hentet fra: ';
+    case 'license.copyText.readDate':
+      return 'Lest: ';
+    case 'license.copyText.noTitle':
+      return 'Uten tittel';
+    case 'photographer':
+      return 'Fotograf';
+    case 'artist':
+      return 'Kunstner';
+    case 'writer':
+      return 'Forfatter';
+    default:
+      return 'ERROR';
+  }
+};
+
+test('getCopyString returns correct content', () => {
+  const copyright = {
+    creators: [{ name: 'Person1', type: 'photographer' }],
+    rightholders: [{ name: 'Person2', type: 'artist' }],
+    processors: [{ name: 'Person3', type: 'writer' }],
+  };
+  const copyString = getCopyString('Tittel', undefined, 'path/123', copyright, 'https://test.ndla.no', (id: string) =>
+    fakeTranslator(id),
+  );
+
+  expect(copyString).toContain(' Lest: ');
+
+  const [content, date] = copyString.split(' Lest: ');
+
+  expect(content).toBe(
+    'Fotograf: Person1. Forfatter: Person3. Tittel [Internett]. Hentet fra: https://test.ndla.nopath/123',
+  );
+
+  expect(date).toMatch(/\d{2}.\d{2}.\d{4}/);
+});

--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -1,4 +1,4 @@
-import { TFunction } from 'i18next';
+import { TFunction } from 'react-i18next';
 import { Contributor } from './contributorTypes';
 
 export const getLicenseCredits = (copyright?: {

--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -1,5 +1,4 @@
 import { TFunction } from 'i18next';
-import { LocaleType } from './types';
 import { Contributor } from './contributorTypes';
 
 export const getLicenseCredits = (copyright?: {
@@ -14,14 +13,14 @@ export const getLicenseCredits = (copyright?: {
   };
 };
 
-const makeCreditCopyString = (roles: Contributor[], locale: LocaleType, t: TFunction) => {
+const makeCreditCopyString = (roles: Contributor[], t: TFunction) => {
   if (!roles?.length) {
     return '';
   }
   return (
     roles
       .map((creator) => {
-        const type = creator.type && t(locale, `${creator.type.toLowerCase()}`);
+        const type = creator.type && t(`${creator.type.toLowerCase()}`);
         return `${type}: ${creator.name?.trim()}`;
       })
       .join(', ') + '. '
@@ -55,15 +54,14 @@ export const getCopyString = (
         processors?: Contributor[];
       }
     | undefined,
-  locale: LocaleType,
   ndlaFrontendDomain: string | undefined,
   t: TFunction,
 ): string => {
   const credits = getLicenseCredits(copyright);
-  const creators = makeCreditCopyString(credits.creators, locale, t);
-  const processors = makeCreditCopyString(credits.processors, locale, t);
-  const rightsholders = makeCreditCopyString(credits.rightsholders, locale, t);
-  const titleString = getValueOrFallback(title, t(locale, 'license.copyText.noTitle')) + ' ';
+  const creators = makeCreditCopyString(credits.creators, t);
+  const processors = makeCreditCopyString(credits.processors, t);
+  const rightsholders = makeCreditCopyString(credits.rightsholders, t);
+  const titleString = getValueOrFallback(title, t('license.copyText.noTitle')) + ' ';
   const url = path ? ndlaFrontendDomain + path : src;
   const date = makeDateString();
 
@@ -72,12 +70,12 @@ export const getCopyString = (
     creators +
     processors +
     titleString +
-    t(locale, 'license.copyText.internet') +
+    t('license.copyText.internet') +
     rightsholders +
-    t(locale, 'license.copyText.downloadedFrom') +
+    t('license.copyText.downloadedFrom') +
     url +
     ' ' +
-    t(locale, 'license.copyText.readDate') +
+    t('license.copyText.readDate') +
     date
   );
 };

--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -63,7 +63,7 @@ export const getCopyString = (
   const processors = makeCreditCopyString(credits.processors, t);
   const rightsholders = makeCreditCopyString(credits.rightsholders, t);
   const titleString = getValueOrFallback(title, t('license.copyText.noTitle')) + ' ';
-  const url = path ? ndlaFrontendDomain + path : src;
+  const url = (path ? ndlaFrontendDomain + path : src) + ' ';
   const date = makeDateString();
 
   // Ex: Fotograf: Ola Nordmann. Tittel [Internett]. Opphaver: NTB. Hentet fra: www.ndla.no/urn:resource:123 Lest: 04.05.2021
@@ -75,7 +75,6 @@ export const getCopyString = (
     rightsholders +
     t('license.copyText.downloadedFrom') +
     url +
-    ' ' +
     t('license.copyText.readDate') +
     date
   );

--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -1,4 +1,3 @@
-import { TFunction } from 'react-i18next';
 import { Contributor } from './contributorTypes';
 
 export const getLicenseCredits = (copyright?: {
@@ -13,7 +12,9 @@ export const getLicenseCredits = (copyright?: {
   };
 };
 
-const makeCreditCopyString = (roles: Contributor[], t: TFunction) => {
+type TranslationFunction = (id: string) => string;
+
+const makeCreditCopyString = (roles: Contributor[], t: TranslationFunction) => {
   if (!roles?.length) {
     return '';
   }
@@ -55,7 +56,7 @@ export const getCopyString = (
       }
     | undefined,
   ndlaFrontendDomain: string | undefined,
-  t: TFunction,
+  t: TranslationFunction,
 ): string => {
   const credits = getLicenseCredits(copyright);
   const creators = makeCreditCopyString(credits.creators, t);

--- a/packages/ndla-licenses/src/types.ts
+++ b/packages/ndla-licenses/src/types.ts
@@ -28,8 +28,6 @@ export interface RightType {
   en: RightLocaleInfo;
 }
 
-export type LocaleType = 'nb' | 'nn' | 'en';
-
 const locales = ['nb', 'nn', 'en'] as const;
 export type Locale = typeof locales[number];
 


### PR DESCRIPTION
En liten glipp i første versjon av getCopyString-funksjonen. Locale skal ikke brukes i translation-funksjonen