### PR TITLE
Fix CopyParagraph header indentation

### DIFF
--- a/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
+++ b/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
@@ -16,8 +16,7 @@ import Tooltip from '@ndla/tooltip';
 import { copyTextToClipboard } from '@ndla/util';
 
 const IconButton = styled.button`
-  float: left;
-  position: relative;
+  position: absolute;
   left: -3em;
   top: 0.1em;
   background: none;
@@ -33,14 +32,10 @@ const IconButton = styled.button`
 `;
 
 const ContainerDiv = styled.div`
+  position: relative;
   &:hover button {
     cursor: pointer;
     opacity: 0.5;
-  }
-
-  & h2 {
-    position: relative;
-    left: -2em;
   }
 `;
 


### PR DESCRIPTION
Relatert til NDLANO/Issues#2951

Fikser en feil som førte til at header med lang tekst som ble vist over flere ble feil indentert.

Den enkleste måten å teste dette er nok å åpne https://test.ndla.no/nb/subject:1:ff69c291-6374-4766-80c2-47d5840d8bbf/topic:1:7042c278-5b24-4f45-8875-30f034cbeaab/topic:1:68b378fb-2d7e-4301-b0a1-ab10fea6aac9/resource:5de66b75-3aee-4f4b-9ec5-0905a3d1b7bd og legge til stylen manuelt med inspector.

Vanlig måte:
1. Start article-converter lokalt med ndla-ui og ndla-article-scripts linket inn.
2. Start graphql-api med lokal article-converter
3. Start ndla-frontend med lokal article-converter og graphql-api
4. Åpne artikkelen over lokalt.
