### PR TITLE
Made hover color on LicenseIconList a little brighter when using light theme

### DIFF
--- a/packages/ndla-licenses/src/LicenseByline/LicenseIconList.tsx
+++ b/packages/ndla-licenses/src/LicenseByline/LicenseIconList.tsx
@@ -63,7 +63,7 @@ export const StyledLicenseIconButton = styled.button<StyledLicenseIconButtonprop
   background: transparent;
   &:hover,
   &:focus {
-    color: ${colors.text.light};
+    color: ${(p) => (p.light ? colors.brand.light : colors.text.light)};
     span {
       display: block;
       opacity: 1;


### PR DESCRIPTION
Tilbakemelding fra https://github.com/NDLANO/ndla-frontend/pull/861