### PR TITLE
Fix getcopystring testdata path

### DIFF
--- a/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
+++ b/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
@@ -37,7 +37,7 @@ test('getCopyString returns correct content', () => {
     rightholders: [{ name: 'Person2', type: 'artist' }],
     processors: [{ name: 'Person3', type: 'writer' }],
   };
-  const copyString = getCopyString('Tittel', undefined, 'path/123', copyright, 'https://test.ndla.no', (id: string) =>
+  const copyString = getCopyString('Tittel', undefined, '/path/123', copyright, 'https://test.ndla.no', (id: string) =>
     fakeTranslator(id),
   );
 
@@ -46,7 +46,7 @@ test('getCopyString returns correct content', () => {
   const [content, date] = copyString.split(' Lest: ');
 
   expect(content).toBe(
-    'Fotograf: Person1. Forfatter: Person3. Tittel [Internett]. Hentet fra: https://test.ndla.nopath/123',
+    'Fotograf: Person1. Forfatter: Person3. Tittel [Internett]. Hentet fra: https://test.ndla.no/path/123',
   );
 
   expect(date).toMatch(/\d{2}.\d{2}.\d{4}/);


### PR DESCRIPTION
En liten typo i en test som ble oppdaget før publisering av https://github.com/NDLANO/frontend-packages/pull/992. Sjekker at testene går gjennom og merger.