### PR TITLE
Scale images correctly both from left and right

### DIFF
--- a/packages/core/scss/global/utilities/utilities.grids.scss
+++ b/packages/core/scss/global/utilities/utilities.grids.scss
@@ -2,12 +2,19 @@ $numerator: auto;
 $denominator: auto;
 
 // Expand item
-@mixin grids-expand($numerator, $denominator, $expand) {
+@mixin grids-expand($numerator, $denominator, $expand, $right-aligned: false) {
   $unit: $numerator / $denominator * 100%;
   $width: ($numerator / $denominator) * 100%;
   position: relative !important;
-  right: auto !important;
-  left: -($denominator - $numerator - $expand/2) / $denominator * 100% !important;
+  @if $right-aligned {
+    left: auto !important;
+    float: right;
+    right: -($denominator - $numerator - $expand/2) / $denominator * 100% !important;
+  } @else {
+    right: auto !important;
+    float: left;
+    left: -($denominator - $numerator - $expand/2) / $denominator * 100% !important;
+  }
   width: $width + $unit !important;
   padding-left: $spacing;
   padding-right: $spacing;
@@ -26,13 +33,13 @@ $extra-margin: 10px;
     @include mq(tablet) {
       float: left;
       clear: left;
-      width: ($cols-tablet/$maxcols)*100% !important;
+      width: ($cols-tablet/$maxcols) * 100% !important;
       left: auto !important;
       padding: 0;
       margin: $spacing ($spacing + $extra-margin) 35px 0;
     }
     @include mq(desktop) {
-      width: ($cols/$maxcols)*100% !important;
+      width: ($cols/$maxcols) * 100% !important;
       margin: 0 ($spacing + $extra-margin) 35px -25%;
     }
   }
@@ -40,13 +47,13 @@ $extra-margin: 10px;
     @include mq(tablet) {
       float: right;
       clear: right;
-      width: ($cols-tablet/$maxcols)*100% !important;
+      width: ($cols-tablet/$maxcols) * 100% !important;
       left: auto !important;
       padding: 0;
       margin: 0 0 35px ($spacing + $extra-margin);
     }
     @include mq(desktop) {
-      width: ($cols/$maxcols)*100% !important;
+      width: ($cols/$maxcols) * 100% !important;
       margin: 0 -25% 35px ($spacing + $extra-margin);
     }
   }

--- a/packages/ndla-ui/src/Figure/Figure.tsx
+++ b/packages/ndla-ui/src/Figure/Figure.tsx
@@ -121,9 +121,9 @@ interface FigureCaptionProps {
 
 const Figure = ({ children, type = 'full', resizeIframe, ...rest }: Props) => {
   const typeClass = type === 'full-column' ? 'c-figure--full-column' : `u-float-${type}`;
-  const left = ['small-right', 'xsmall-right'].includes(type);
+  const right = ['small-right', 'xsmall-right'].includes(type);
   return (
-    <figure data-sizetype={type} {...classes('', { resize: !!resizeIframe, left }, typeClass)} {...rest}>
+    <figure data-sizetype={type} {...classes('', { resize: !!resizeIframe, right }, typeClass)} {...rest}>
       {isFunction(children) ? children({ typeClass }) : children}
     </figure>
   );

--- a/packages/ndla-ui/src/Figure/Figure.tsx
+++ b/packages/ndla-ui/src/Figure/Figure.tsx
@@ -121,8 +121,9 @@ interface FigureCaptionProps {
 
 const Figure = ({ children, type = 'full', resizeIframe, ...rest }: Props) => {
   const typeClass = type === 'full-column' ? 'c-figure--full-column' : `u-float-${type}`;
+  const left = ['small-right', 'xsmall-right'].includes(type);
   return (
-    <figure data-sizetype={type} {...classes('', { resize: !!resizeIframe }, typeClass)} {...rest}>
+    <figure data-sizetype={type} {...classes('', { resize: !!resizeIframe, left }, typeClass)} {...rest}>
       {isFunction(children) ? children({ typeClass }) : children}
     </figure>
   );

--- a/packages/ndla-ui/src/Figure/component.figure.scss
+++ b/packages/ndla-ui/src/Figure/component.figure.scss
@@ -37,7 +37,7 @@
   position: relative;
 
   @include mq($from: desktop) {
-    margin: $spacing--large 0 $spacing--large;
+    margin: $spacing 0 $spacing--large;
     @include grids-expand(4, 6, 2);
   }
   transition: transform 0.4s, width 0.4s, height 0.4s;
@@ -50,6 +50,9 @@
     padding-right: 0;
     padding-bottom: $spacing--large;
     margin-bottom: 0;
+  }
+  &--left {
+    @include grids-expand(4, 6, 2, true);
   }
   &.expanded {
     .c-figure__caption--hidden-caption {
@@ -74,7 +77,7 @@
   background-color: $white;
   padding: $spacing--small 0;
   display: block;
-  border-bottom: 1px solid #D1D6DB;
+  border-bottom: 1px solid #d1d6db;
 }
 
 .c-figure__caption--hidden-caption {
@@ -119,7 +122,7 @@
     margin-bottom: $spacing--small;
   }
   p {
-    margin:0;
+    margin: 0;
   }
 }
 
@@ -179,7 +182,7 @@
   padding: $spacing--small;
   transition: all 0.3s ease-out;
   background: rgba($white, 0.2);
-  border:0;
+  border: 0;
 
   .expanded-icon {
     display: none;

--- a/packages/ndla-ui/src/Figure/component.figure.scss
+++ b/packages/ndla-ui/src/Figure/component.figure.scss
@@ -51,8 +51,8 @@
     padding-bottom: $spacing--large;
     margin-bottom: 0;
   }
-  &--left {
-    @include grids-expand(4, 6, 2, true);
+  &--right {
+    @include grids-expand(4, 6, 2, false);
   }
   &.expanded {
     .c-figure__caption--hidden-caption {

--- a/packages/ndla-ui/src/Figure/component.figure.scss
+++ b/packages/ndla-ui/src/Figure/component.figure.scss
@@ -37,7 +37,7 @@
   position: relative;
 
   @include mq($from: desktop) {
-    margin: $spacing 0 $spacing--large;
+    margin: $spacing--large 0 $spacing--large;
     @include grids-expand(4, 6, 2);
   }
   transition: transform 0.4s, width 0.4s, height 0.4s;
@@ -52,7 +52,7 @@
     margin-bottom: 0;
   }
   &--right {
-    @include grids-expand(4, 6, 2, false);
+    @include grids-expand(4, 6, 2, true);
   }
   &.expanded {
     .c-figure__caption--hidden-caption {


### PR DESCRIPTION
Se https://github.com/NDLANO/Issues/issues/2927. Har laget to forslag til løsninger. Testes ved å gå til "Bilder" i designmanualen.

Animasjonene fungerer fint nå, men dersom elementer over og under har margin, vil summen av marginen bli større. Dette er fordi margin collapsing ikke fungerer når `float` er satt i css.


Har gjort et par endringer for å få animasjonene til å gå i riktig retning. Dette styres av en ny klasse `&--right`
- float-styling er nå alltid satt, og er basert på om bildet er høyrejustert eller venstrejustert.
- left/right-posisjon swappes nå dersom bildet er høyrejustert. Dette gjøres i grids-expand.

