### PR TITLE
Scale images correctly both from left and right (v2)

### DIFF
--- a/packages/core/scss/global/utilities/utilities.grids.scss
+++ b/packages/core/scss/global/utilities/utilities.grids.scss
@@ -6,7 +6,7 @@ $denominator: auto;
   $unit: $numerator / $denominator * 100%;
   $width: ($numerator / $denominator) * 100%;
   position: relative !important;
-  right: auto;
+  right: auto !important;
   left: -($denominator - $numerator - $expand/2) / $denominator * 100%;
   width: $width + $unit !important;
   padding-left: $spacing;

--- a/packages/core/scss/global/utilities/utilities.grids.scss
+++ b/packages/core/scss/global/utilities/utilities.grids.scss
@@ -2,19 +2,13 @@ $numerator: auto;
 $denominator: auto;
 
 // Expand item
-@mixin grids-expand($numerator, $denominator, $expand, $right-aligned: false) {
+@mixin grids-expand($numerator, $denominator, $expand) {
   $unit: $numerator / $denominator * 100%;
   $width: ($numerator / $denominator) * 100%;
   position: relative !important;
-  @if $right-aligned {
-    left: auto !important;
-    float: right;
-    right: -($denominator - $numerator - $expand/2) / $denominator * 100% !important;
-  } @else {
-    right: auto !important;
-    float: left;
-    left: -($denominator - $numerator - $expand/2) / $denominator * 100% !important;
-  }
+  float: none;
+  right: 0%;
+  left: -($denominator - $numerator - $expand/2) / $denominator * 100%;
   width: $width + $unit !important;
   padding-left: $spacing;
   padding-right: $spacing;
@@ -34,7 +28,7 @@ $extra-margin: 10px;
       float: left;
       clear: left;
       width: ($cols-tablet/$maxcols) * 100% !important;
-      left: auto !important;
+      left: 0%;
       padding: 0;
       margin: $spacing ($spacing + $extra-margin) 35px 0;
     }
@@ -48,7 +42,7 @@ $extra-margin: 10px;
       float: right;
       clear: right;
       width: ($cols-tablet/$maxcols) * 100% !important;
-      left: auto !important;
+      left: 0%;
       padding: 0;
       margin: 0 0 35px ($spacing + $extra-margin);
     }

--- a/packages/core/scss/global/utilities/utilities.grids.scss
+++ b/packages/core/scss/global/utilities/utilities.grids.scss
@@ -2,12 +2,19 @@ $numerator: auto;
 $denominator: auto;
 
 // Expand item
-@mixin grids-expand($numerator, $denominator, $expand) {
+@mixin grids-expand($numerator, $denominator, $expand, $right-aligned: false) {
   $unit: $numerator / $denominator * 100%;
   $width: ($numerator / $denominator) * 100%;
   position: relative !important;
-  right: auto !important;
-  left: -($denominator - $numerator - $expand/2) / $denominator * 100% !important;
+  @if $right-aligned {
+    left: auto !important;
+    float: right;
+    right: -($denominator - $numerator - $expand/2) / $denominator * 100% !important;
+  } @else {
+    right: auto !important;
+    float: left;
+    left: -($denominator - $numerator - $expand/2) / $denominator * 100% !important;
+  }
   width: $width + $unit !important;
   padding-left: $spacing;
   padding-right: $spacing;
@@ -26,13 +33,13 @@ $extra-margin: 10px;
     @include mq(tablet) {
       float: left;
       clear: left;
-      width: ($cols-tablet/$maxcols)*100% !important;
+      width: ($cols-tablet/$maxcols) * 100% !important;
       left: auto !important;
       padding: 0;
       margin: $spacing ($spacing + $extra-margin) 35px 0;
     }
     @include mq(desktop) {
-      width: ($cols/$maxcols)*100% !important;
+      width: ($cols/$maxcols) * 100% !important;
       margin: 0 ($spacing + $extra-margin) 35px -25%;
     }
   }
@@ -40,13 +47,13 @@ $extra-margin: 10px;
     @include mq(tablet) {
       float: right;
       clear: right;
-      width: ($cols-tablet/$maxcols)*100% !important;
+      width: ($cols-tablet/$maxcols) * 100% !important;
       left: auto !important;
       padding: 0;
       margin: 0 0 35px ($spacing + $extra-margin);
     }
     @include mq(desktop) {
-      width: ($cols/$maxcols)*100% !important;
+      width: ($cols/$maxcols) * 100% !important;
       margin: 0 -25% 35px ($spacing + $extra-margin);
     }
   }

--- a/packages/core/scss/global/utilities/utilities.grids.scss
+++ b/packages/core/scss/global/utilities/utilities.grids.scss
@@ -6,8 +6,7 @@ $denominator: auto;
   $unit: $numerator / $denominator * 100%;
   $width: ($numerator / $denominator) * 100%;
   position: relative !important;
-  float: none;
-  right: 0%;
+  right: auto;
   left: -($denominator - $numerator - $expand/2) / $denominator * 100%;
   width: $width + $unit !important;
   padding-left: $spacing;
@@ -28,7 +27,7 @@ $extra-margin: 10px;
       float: left;
       clear: left;
       width: ($cols-tablet/$maxcols) * 100% !important;
-      left: 0%;
+      left: auto !important;
       padding: 0;
       margin: $spacing ($spacing + $extra-margin) 35px 0;
     }
@@ -42,7 +41,7 @@ $extra-margin: 10px;
       float: right;
       clear: right;
       width: ($cols-tablet/$maxcols) * 100% !important;
-      left: 0%;
+      left: auto !important;
       padding: 0;
       margin: 0 0 35px ($spacing + $extra-margin);
     }

--- a/packages/ndla-ui/src/Figure/Figure.tsx
+++ b/packages/ndla-ui/src/Figure/Figure.tsx
@@ -121,9 +121,9 @@ interface FigureCaptionProps {
 
 const Figure = ({ children, type = 'full', resizeIframe, ...rest }: Props) => {
   const typeClass = type === 'full-column' ? 'c-figure--full-column' : `u-float-${type}`;
-  const left = ['small-right', 'xsmall-right'].includes(type);
+  const right = ['small-right', 'xsmall-right'].includes(type);
   return (
-    <figure data-sizetype={type} {...classes('', { resize: !!resizeIframe, left }, typeClass)} {...rest}>
+    <figure data-sizetype={type} {...classes('', { resize: !!resizeIframe, right }, typeClass)} {...rest}>
       {isFunction(children) ? children({ typeClass }) : children}
     </figure>
   );

--- a/packages/ndla-ui/src/Figure/Figure.tsx
+++ b/packages/ndla-ui/src/Figure/Figure.tsx
@@ -121,8 +121,9 @@ interface FigureCaptionProps {
 
 const Figure = ({ children, type = 'full', resizeIframe, ...rest }: Props) => {
   const typeClass = type === 'full-column' ? 'c-figure--full-column' : `u-float-${type}`;
+  const left = ['small-right', 'xsmall-right'].includes(type);
   return (
-    <figure data-sizetype={type} {...classes('', { resize: !!resizeIframe }, typeClass)} {...rest}>
+    <figure data-sizetype={type} {...classes('', { resize: !!resizeIframe, left }, typeClass)} {...rest}>
       {isFunction(children) ? children({ typeClass }) : children}
     </figure>
   );

--- a/packages/ndla-ui/src/Figure/component.figure.scss
+++ b/packages/ndla-ui/src/Figure/component.figure.scss
@@ -17,6 +17,26 @@
 **/
 
 /* 1. */
+
+@keyframes rightFloatTransition {
+  0% {
+    float: right;
+    right: -(6 - 4 - 2/2) / 4 * 100%;
+    left: 0%;
+    margin-top: 48px;
+  }
+
+  99% {
+    float: right;
+  }
+  100% {
+    float: none;
+    left: 16.6%;
+    right: 0%;
+    margin-top: 24px;
+  }
+}
+
 .c-figure {
   img {
     width: 100%;
@@ -40,7 +60,7 @@
     margin: $spacing--large 0 $spacing--large;
     @include grids-expand(4, 6, 2);
   }
-  transition: transform 0.4s, width 0.4s, height 0.4s;
+  transition: transform 0.4s, width 0.4s, height 0.4s, margin 0.4s;
 
   &--full-column {
     left: auto !important;
@@ -51,10 +71,10 @@
     padding-bottom: $spacing--large;
     margin-bottom: 0;
   }
-  &--right {
-    @include grids-expand(4, 6, 2, true);
-  }
+
   &.expanded {
+    animation-name: rightFloatTransition;
+    animation-duration: 0.4s;
     .c-figure__caption--hidden-caption {
       display: block;
       opacity: 0;

--- a/packages/ndla-ui/src/Figure/component.figure.scss
+++ b/packages/ndla-ui/src/Figure/component.figure.scss
@@ -37,7 +37,7 @@
   position: relative;
 
   @include mq($from: desktop) {
-    margin: $spacing--large 0 $spacing--large;
+    margin: $spacing 0 $spacing--large;
     @include grids-expand(4, 6, 2);
   }
   transition: transform 0.4s, width 0.4s, height 0.4s;
@@ -50,6 +50,9 @@
     padding-right: 0;
     padding-bottom: $spacing--large;
     margin-bottom: 0;
+  }
+  &--left {
+    @include grids-expand(4, 6, 2, true);
   }
   &.expanded {
     .c-figure__caption--hidden-caption {
@@ -74,7 +77,7 @@
   background-color: $white;
   padding: $spacing--small 0;
   display: block;
-  border-bottom: 1px solid #D1D6DB;
+  border-bottom: 1px solid #d1d6db;
 }
 
 .c-figure__caption--hidden-caption {
@@ -119,7 +122,7 @@
     margin-bottom: $spacing--small;
   }
   p {
-    margin:0;
+    margin: 0;
   }
 }
 
@@ -179,7 +182,7 @@
   padding: $spacing--small;
   transition: all 0.3s ease-out;
   background: rgba($white, 0.2);
-  border:0;
+  border: 0;
 
   .expanded-icon {
     display: none;

--- a/packages/ndla-ui/src/Figure/component.figure.scss
+++ b/packages/ndla-ui/src/Figure/component.figure.scss
@@ -51,8 +51,8 @@
     padding-bottom: $spacing--large;
     margin-bottom: 0;
   }
-  &--left {
-    @include grids-expand(4, 6, 2, true);
+  &--right {
+    @include grids-expand(4, 6, 2, false);
   }
   &.expanded {
     .c-figure__caption--hidden-caption {

--- a/packages/ndla-ui/src/Figure/component.figure.scss
+++ b/packages/ndla-ui/src/Figure/component.figure.scss
@@ -20,39 +20,19 @@
 
 @keyframes rightFloatTransition {
   0% {
-    float: right;
-    right: -25%;
-    left: 0%;
-    margin: 0 -25% 35px 34px;
-  }
-
-  99.99% {
-    float: right;
+    left: 75%;
   }
   100% {
-    float: none;
-    left: 16.6%;
-    right: 0%;
-    margin: 24px 0 48px;
+    left: -16.6%;
   }
 }
 
 @keyframes smallRightFloatTransition {
   0% {
-    float: right;
-    right: -0%;
-    left: 0%;
-    margin: 0 0 35px 34px;
-  }
-
-  99.99% {
-    float: right;
+    left: 78.5%;
   }
   100% {
-    float: none;
-    left: 16.6%;
-    right: 0%;
-    margin: 24px 0 48px;
+    left: -16.6%;
   }
 }
 

--- a/packages/ndla-ui/src/Figure/component.figure.scss
+++ b/packages/ndla-ui/src/Figure/component.figure.scss
@@ -37,7 +37,7 @@
   position: relative;
 
   @include mq($from: desktop) {
-    margin: $spacing 0 $spacing--large;
+    margin: $spacing--large 0 $spacing--large;
     @include grids-expand(4, 6, 2);
   }
   transition: transform 0.4s, width 0.4s, height 0.4s;
@@ -52,7 +52,7 @@
     margin-bottom: 0;
   }
   &--right {
-    @include grids-expand(4, 6, 2, false);
+    @include grids-expand(4, 6, 2, true);
   }
   &.expanded {
     .c-figure__caption--hidden-caption {

--- a/packages/ndla-ui/src/Figure/component.figure.scss
+++ b/packages/ndla-ui/src/Figure/component.figure.scss
@@ -21,12 +21,31 @@
 @keyframes rightFloatTransition {
   0% {
     float: right;
-    right: -(6 - 4 - 2/2) / 4 * 100%;
+    right: -25%;
     left: 0%;
     margin: 0 -25% 35px 34px;
   }
 
-  99% {
+  99.99% {
+    float: right;
+  }
+  100% {
+    float: none;
+    left: 16.6%;
+    right: 0%;
+    margin: 24px 0 48px;
+  }
+}
+
+@keyframes smallRightFloatTransition {
+  0% {
+    float: right;
+    right: -0%;
+    left: 0%;
+    margin: 0 0 35px 34px;
+  }
+
+  99.99% {
     float: right;
   }
   100% {
@@ -76,6 +95,13 @@
       @include mq($from: desktop) {
         animation-name: rightFloatTransition;
         animation-duration: 0.4s;
+      }
+
+      &[data-sizetype='xsmall-right'] {
+        @include mq($from: desktop) {
+          animation-name: smallRightFloatTransition;
+          animation-duration: 0.4s;
+        }
       }
     }
   }

--- a/packages/ndla-ui/src/Figure/component.figure.scss
+++ b/packages/ndla-ui/src/Figure/component.figure.scss
@@ -23,7 +23,7 @@
     float: right;
     right: -(6 - 4 - 2/2) / 4 * 100%;
     left: 0%;
-    margin-top: 48px;
+    margin: 0 -25% 35px 34px;
   }
 
   99% {
@@ -33,7 +33,7 @@
     float: none;
     left: 16.6%;
     right: 0%;
-    margin-top: 24px;
+    margin: 24px 0 48px;
   }
 }
 
@@ -60,7 +60,7 @@
     margin: $spacing--large 0 $spacing--large;
     @include grids-expand(4, 6, 2);
   }
-  transition: transform 0.4s, width 0.4s, height 0.4s, margin 0.4s;
+  transition: transform 0.4s, width 0.4s, height 0.4s;
 
   &--full-column {
     left: auto !important;
@@ -71,10 +71,15 @@
     padding-bottom: $spacing--large;
     margin-bottom: 0;
   }
-
+  &--right {
+    &.expanded {
+      @include mq($from: desktop) {
+        animation-name: rightFloatTransition;
+        animation-duration: 0.4s;
+      }
+    }
+  }
   &.expanded {
-    animation-name: rightFloatTransition;
-    animation-duration: 0.4s;
     .c-figure__caption--hidden-caption {
       display: block;
       opacity: 0;


### PR DESCRIPTION
Se https://github.com/NDLANO/Issues/issues/2927. Har laget to forslag til løsninger. Testes ved å gå til "Bilder" i designmanualen.

Her er en alternativ løsning hvor animation keyframes er brukt for å fake riktig animasjon på bildeskalering. Den skal være riktig så lenge det er et element ovenfor med 24px margin (feks en paragraf). Om dette ikke er tilfellet vil den nok hoppe 24px ned på slutten av animasjonen

Fordelen sammenliknet med den andre løsningen er at det ekspanderte bildet ikke har `float: right`. Margin collapsing er derfor ikke et problem. Det er derimot usikkert om animasjonen vil se riktig ut på alle enheter