### PR TITLE
Fix ContentTypeBadge import

### DIFF
--- a/packages/ndla-ui/src/LearningPaths/LearningPathMobileHeader.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathMobileHeader.tsx
@@ -10,8 +10,7 @@ import styled from '@emotion/styled';
 import { colors, fonts, spacing } from '@ndla/core';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
-// @ts-ignore
-import { LearningPathBadge } from '../index-javascript';
+import { LearningPathBadge } from '../';
 
 const StyledWrapper = styled.div`
   display: flex;


### PR DESCRIPTION
Fikk feilmelding i ndla-frontend da jeg oppdaterte ndla-ui. En import som må endres fordi komponenten er flyttet til index.ts.