### PR TITLE
Add ndla icon to package.json where missing

### DIFF
--- a/packages/ndla-accordion/package.json
+++ b/packages/ndla-accordion/package.json
@@ -25,7 +25,8 @@
     "es"
   ],
   "dependencies": {
-    "@ndla/core": "^0.7.3"
+    "@ndla/core": "^0.7.3",
+    "@ndla/icons": "^1.4.1"
   },
   "peerDependencies": {
     "@emotion/core": "^10.0.9",

--- a/packages/ndla-image-search/package.json
+++ b/packages/ndla-image-search/package.json
@@ -29,6 +29,7 @@
     "@ndla/button": "^1.1.5",
     "@ndla/core": "^0.7.3",
     "@ndla/forms": "^1.0.58",
+    "@ndla/icons": "^1.4.1",
     "@ndla/licenses": "^1.1.7",
     "@ndla/pager": "^1.0.14",
     "@ndla/util": "^2.0.1"

--- a/packages/ndla-modal/package.json
+++ b/packages/ndla-modal/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@ndla/button": "^1.1.5",
     "@ndla/core": "^0.7.3",
+    "@ndla/icons": "^1.4.1",
     "@ndla/util": "^2.0.1",
     "@reach/dialog": "^0.2.9"
   },

--- a/packages/ndla-modal/src/ModalCloseButton.tsx
+++ b/packages/ndla-modal/src/ModalCloseButton.tsx
@@ -7,7 +7,6 @@
  */
 
 import React, { ReactNode } from 'react';
-//@ts-ignore
 import styled from '@emotion/styled';
 
 import { useTranslation } from 'react-i18next';

--- a/packages/ndla-notion/package.json
+++ b/packages/ndla-notion/package.json
@@ -26,6 +26,7 @@
   ],
   "dependencies": {
     "@ndla/core": "^0.7.3",
+    "@ndla/icons": "^1.4.1",
     "@ndla/licenses": "^1.1.7",
     "@ndla/modal": "^1.1.19"
   },

--- a/packages/ndla-ui/src/Filter/FilterButtons.tsx
+++ b/packages/ndla-ui/src/Filter/FilterButtons.tsx
@@ -12,9 +12,7 @@ import styled from '@emotion/styled';
 import Button from '@ndla/button';
 import { breakpoints, colors, fonts, mq, spacing } from '@ndla/core';
 import { useTranslation } from 'react-i18next';
-// @ts-ignore
 import { Cross as CrossIcon, Plus as PlusIcon } from '@ndla/icons/action';
-// @ts-ignore
 import Modal, { ModalHeader, ModalBody, ModalCloseButton } from '@ndla/modal';
 
 // @ts-ignore

--- a/packages/ndla-ui/src/LearningPaths/LearningPathMenu.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathMenu.tsx
@@ -14,7 +14,6 @@ import { useTranslation } from 'react-i18next';
 import Tooltip from '@ndla/tooltip';
 import { useWindowSize } from '@ndla/hooks';
 import { colors, spacing, misc, mq, breakpoints } from '@ndla/core';
-// @ts-ignore
 import { ArrowExpandRight, ArrowExpandLeft } from '@ndla/icons/action';
 import LearningPathMenuModalWrapper from './LearningPathMenuModalWrapper';
 import LearningPathMenuAside from './LearningPathMenuAside';


### PR DESCRIPTION
Ikke noen funksjonelle endringer.

Ikoner er brukt flere steder uten at pakken er definert i package.json. Legger det til to steder og rydder litt opp i noen imports.
