### PR TITLE
Endrer css for å skalere bilde bedre for emner

### DIFF
--- a/packages/ndla-ui/src/Topic/Topic.tsx
+++ b/packages/ndla-ui/src/Topic/Topic.tsx
@@ -80,7 +80,7 @@ const TopicHeaderImage = styled.img`
   border-radius: 50%;
   width: 100%;
   height: 100%;
-  object-fit: none;
+  object-fit: cover;
   transition: transform ${animations.durations.fast};
   ${VisualElementButton}:hover & {
     transform: scale(1.1);


### PR DESCRIPTION
Problemet kan sees på https://staging.ndla.no/nb/subject:1:ff69c291-6374-4766-80c2-47d5840d8bbf/topic:1:d80bd6db-2485-4063-ba6c-3a040d039da2/topic:1:00d325d9-d87a-4ef6-9514-7017b0e6a291/

det nederste bildet vises for zooma fordi vi ikkje setter en fit på bildet. Ved å sette object-fit: cover ser det bedre ut i denne sammenhengen. 

Test: Link inn lokalt og sammenlign emnevisninga rundt om kring om det ser greit ut, og spesifikt på den innlinka sida.