### PR TITLE
Feilretting og forbedring av kildehenvisnings-funksjoner

### DIFF
--- a/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
+++ b/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
@@ -16,7 +16,7 @@ import {
   podcastSeriesApa7CopyString,
   getCreditString,
   getDateString,
-  getYearString,
+  getYearDurationString,
 } from '../getCopyString';
 
 // Adding @ndla/ui to package.json would cause circular dependency.
@@ -68,16 +68,16 @@ test('getYearString return correct content', () => {
   const start = '2019';
   const end = '2020';
 
-  const yearWithStart = getYearString(start, undefined, tNB);
+  const yearWithStart = getYearDurationString(start, undefined, tNB);
   expect(yearWithStart).toEqual('(2019-nå). ');
 
-  const yearWithStartAndEnd = getYearString(start, end, tNB);
+  const yearWithStartAndEnd = getYearDurationString(start, end, tNB);
   expect(yearWithStartAndEnd).toEqual('(2019-2020). ');
 
-  const yearWithNoInput = getYearString(undefined, undefined, tNB);
+  const yearWithNoInput = getYearDurationString(undefined, undefined, tNB);
   expect(yearWithNoInput).toEqual('');
 
-  const yearWithEqualStartAndEnd = getYearString(start, start, tNB);
+  const yearWithEqualStartAndEnd = getYearDurationString(start, start, tNB);
   expect(yearWithEqualStartAndEnd).toEqual('(2019). ');
 });
 
@@ -88,10 +88,11 @@ test('figureApa7CopyString return correct content', () => {
     rightsholders: [{ name: 'Bendik Person', type: 'artist' }],
     processors: [{ name: 'Celine', type: 'writer' }],
   };
+  const date = '2017-06-05T14:25:14Z';
 
   const copyString = figureApa7CopyString(
     'Tittel',
-    2010,
+    date,
     undefined,
     '/path/123',
     copyright,
@@ -100,7 +101,7 @@ test('figureApa7CopyString return correct content', () => {
     tNB,
   );
 
-  expect(copyString).toEqual('Tittel, 2010, av Etternavn, A. NDLA. (https://test.ndla.no/path/123). CC-BY-SA-4.0.');
+  expect(copyString).toEqual('Tittel, 2017, av Etternavn, A. NDLA. (https://test.ndla.no/path/123). CC-BY-SA-4.0.');
 });
 
 test('podcastSeriesApa7CopyString return correct content', () => {

--- a/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
+++ b/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
@@ -27,25 +27,25 @@ const tEN = i18nInstance.getFixedT('en');
 // Utils
 test('getCreditString returns correct content', () => {
   const roles = [
-    { name: 'Anna Etternavn', type: 'photographer' },
+    { name: 'Anna Langt Etternavn', type: 'photographer' },
     { name: 'Bendik Person', type: 'artist' },
     { name: 'Bendik Test', type: 'artist' },
   ];
 
   const creditStringWithOnePerson = getCreditString([roles[0]], false, false, tNB);
-  expect(creditStringWithOnePerson).toEqual('Etternavn, A. ');
+  expect(creditStringWithOnePerson).toEqual('Etternavn, A. L. ');
 
   const creditStringWithTwoPeople = getCreditString(roles.slice(0, 2), false, false, tNB);
-  expect(creditStringWithTwoPeople).toEqual('Etternavn, A. & Person, B. ');
+  expect(creditStringWithTwoPeople).toEqual('Etternavn, A. L. & Person, B. ');
 
   const creditStringWithMultiplePeople = getCreditString(roles, false, false, tNB);
-  expect(creditStringWithMultiplePeople).toEqual('Etternavn, A., Person, B. & Test, B. ');
+  expect(creditStringWithMultiplePeople).toEqual('Etternavn, A. L., Person, B. & Test, B. ');
 
   const creditStringWithRoles = getCreditString(roles.slice(0, 2), false, true, tNB);
-  expect(creditStringWithRoles).toEqual('Etternavn, A. (Fotograf) & Person, B. (Kunstner). ');
+  expect(creditStringWithRoles).toEqual('Etternavn, A. L. (Fotograf) & Person, B. (Kunstner). ');
 
   const creditStringWithPrefix = getCreditString(roles.slice(0, 2), true, false, tNB);
-  expect(creditStringWithPrefix).toEqual('av Etternavn, A. & Person, B. ');
+  expect(creditStringWithPrefix).toEqual('av Etternavn, A. L. & Person, B. ');
 });
 
 test('getDateString returns correct content', () => {

--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -34,7 +34,13 @@ export const getCreditString = (roles: Contributor[], byPrefix: boolean, withRol
   }
   const credits = roles.map((creator) => {
     const [lastName, ...names] = creator.name.split(' ').reverse();
-    const initials = names.length ? ', ' + names.map((name) => name[0] + '.') : '.';
+    const initials = names.length
+      ? ', ' +
+        names
+          .reverse()
+          .map((name) => name[0] + '.')
+          .join(' ')
+      : '.';
     const role = withRole && creator.type ? ` (${t(creator.type.toLowerCase())})` : '';
     return lastName + initials + role;
   });

--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -93,7 +93,17 @@ export const getDateString = (locale: string, date?: string) => {
   return formatDate(new Date(), locale);
 };
 
-export const getYearString = (
+export const getYearString = (date: string) => {
+  if (date) {
+    const dateObject = new Date(date);
+    if (dateObject && !isNaN(dateObject.getTime())) {
+      return dateObject.getFullYear() + ', ';
+    }
+  }
+  return '';
+};
+
+export const getYearDurationString = (
   start: string | number | undefined,
   end: string | number | undefined,
   t: TranslationFunction,
@@ -112,7 +122,7 @@ export const getYearString = (
 
 export const figureApa7CopyString = (
   title: string | undefined,
-  year: number | string | undefined,
+  date: string | undefined,
   src: string | undefined,
   path: string | undefined,
   copyright: Partial<CopyrightType> | undefined,
@@ -121,7 +131,7 @@ export const figureApa7CopyString = (
   t: TranslationFunction,
 ): string => {
   const titleString = getValueOrFallback(title, t('license.copyText.noTitle')) + ', ';
-  const yearString = year ? `${year}, ` : '';
+  const yearString = date ? getYearString(date) : '';
   const creators = getCreditString(copyright?.creators || copyright?.rightsholders || [], true, false, t);
   const url = `(${path ? ndlaFrontendDomain + path : src}). `;
   const licenseString = license ? license + '.' : '';
@@ -161,7 +171,7 @@ export const podcastSeriesApa7CopyString = (
   const creators = getCreditString(copyright?.creators || copyright?.rightsholders || [], false, true, t);
   const titleString = getValueOrFallback(title, t('license.copyText.noTitle')) + ' ';
   const url = `${ndlaFrontendDomain}/podkast/${seriesId}`;
-  const yearString = getYearString(startYear, endYear, t);
+  const yearString = getYearDurationString(startYear, endYear, t);
   const metaString = `[Audio ${t('license.copyText.podcast')}]. `;
 
   // Ex: Nordmann, O. (Rolle). (2020, 11. januar). Tittel [Audio podkast]. https://ndla.no/podkast/1


### PR DESCRIPTION
Fikser formatering og rekkefølge på initialer for personer med mer enn to navn i kildereferanse.

figureApa7CopyString viser kun år, men endrer den nå til å ta inn dato som streng. Så slipper man å opprette og håndtere Date-objekter hvert sted som bruker denne funksjonen.