### PR TITLE
apa reference updates

### DIFF
--- a/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
+++ b/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
@@ -24,30 +24,49 @@ import { i18nInstance } from '../../../ndla-ui';
 const tNB = i18nInstance.getFixedT('nb');
 const tEN = i18nInstance.getFixedT('en');
 
-// Utils
-test('getCreditString returns correct content', () => {
-  const roles = [
-    { name: 'Anna Langt Etternavn', type: 'photographer' },
-    { name: 'Bendik Person', type: 'artist' },
-    { name: 'Bendik Test', type: 'artist' },
-  ];
+// function getCreditString
+const roles = [
+  { name: 'Anna Langt Etternavn', type: 'photographer' },
+  { name: 'Bendik Person', type: 'artist' },
+  { name: 'Bendik Test', type: 'artist' },
+];
 
-  const creditStringWithOnePerson = getCreditString({ creators: [roles[0]] }, {}, tNB);
-  expect(creditStringWithOnePerson).toEqual('Etternavn, A. L. ');
+const creators = [{ name: 'Anna Etternavn', type: 'photographer' }];
+const rightsholders = [{ name: 'Stor Bedrift', type: 'distributor' }];
+const processors = [{ name: 'Celine', type: 'writer' }];
+const copyright = {
+  creators,
+  rightsholders,
+  processors,
+};
 
-  const creditStringWithTwoPeople = getCreditString({ creators: roles.slice(0, 2) }, {}, tNB);
-  expect(creditStringWithTwoPeople).toEqual('Etternavn, A. L. & Person, B. ');
+test('getCreditString returns correct string for one person', () => {
+  const creditString = getCreditString({ creators: [roles[0]] }, {}, tNB);
+  expect(creditString).toEqual('Etternavn, A. L. ');
+});
 
-  const creditStringWithMultiplePeople = getCreditString({ creators: roles }, {}, tNB);
-  expect(creditStringWithMultiplePeople).toEqual('Etternavn, A. L., Person, B. & Test, B. ');
+test('getCreditString returns correct string for two people', () => {
+  const creditString = getCreditString({ creators: roles.slice(0, 2) }, {}, tNB);
+  expect(creditString).toEqual('Etternavn, A. L. & Person, B. ');
+});
 
-  const creditStringWithRoles = getCreditString({ creators: roles.slice(0, 2) }, { withRole: true }, tNB);
-  expect(creditStringWithRoles).toEqual('Etternavn, A. L. (Fotograf) & Person, B. (Kunstner). ');
+test('getCreditString returns correct string for three people', () => {
+  const creditString = getCreditString({ creators: roles }, {}, tNB);
+  expect(creditString).toEqual('Etternavn, A. L., Person, B. & Test, B. ');
+});
 
-  const creditStringWithPrefix = getCreditString({ creators: roles.slice(0, 2) }, { byPrefix: true }, tNB);
-  expect(creditStringWithPrefix).toEqual('av Etternavn, A. L. & Person, B. ');
+test('getCreditString returns correct content with withRoles param', () => {
+  const creditString = getCreditString({ creators: roles.slice(0, 2) }, { withRole: true }, tNB);
+  expect(creditString).toEqual('Etternavn, A. L. (Fotograf) & Person, B. (Kunstner). ');
+});
 
-  const creditStringWithRightsholders = getCreditString(
+test('getCreditString returns correct content with byPrefix param', () => {
+  const creditString = getCreditString({ creators: roles.slice(0, 2) }, { byPrefix: true }, tNB);
+  expect(creditString).toEqual('av Etternavn, A. L. & Person, B. ');
+});
+
+test('getCreditString returns correct content when using rightsholders', () => {
+  const creditString = getCreditString(
     {
       rightsholders: [
         { type: 'distributor', name: 'Stor Bedrift' },
@@ -58,62 +77,73 @@ test('getCreditString returns correct content', () => {
     {},
     tNB,
   );
-  expect(creditStringWithRightsholders).toEqual('Stor Bedrift, Liten Bedrift & Organisasjon. ');
+  expect(creditString).toEqual('Stor Bedrift, Liten Bedrift & Organisasjon. ');
 });
 
-test('getCreditString picks correct order of role type', () => {
-  const creators = [{ name: 'Anna Etternavn', type: 'photographer' }];
-  const rightsholders = [{ name: 'Stor Bedrift', type: 'distributor' }];
-  const processors = [{ name: 'Celine', type: 'writer' }];
-  const copyright = {
-    creators,
-    rightsholders,
-    processors,
-  };
-
+test('getCreditString uses correct role when all are present', () => {
   const creditStringWithAll = getCreditString(copyright, {}, tNB);
   expect(creditStringWithAll).toEqual('Etternavn, A. ');
+});
 
+test('getCreditString uses correct role when creators is missing', () => {
   const creditStringWithoutCreators = getCreditString({ rightsholders, processors }, {}, tNB);
   expect(creditStringWithoutCreators).toEqual('Stor Bedrift. ');
+});
 
+test('getCreditString uses correct role when rightsholders is missing', () => {
   const creditStringWithoutRightsholders = getCreditString({ creators, processors }, {}, tNB);
   expect(creditStringWithoutRightsholders).toEqual('Etternavn, A. ');
+});
 
+test('getCreditString uses correct role when processors is missing', () => {
   const creditStringWithoutProcessors = getCreditString({ creators, rightsholders }, {}, tNB);
   expect(creditStringWithoutProcessors).toEqual('Etternavn, A. ');
 });
 
-test('getDateString returns correct content', () => {
-  const date = '2017-06-05T14:25:14Z';
-  const invalidDate = '123abc';
+// getDateString
+const date = '2017-06-05T14:25:14Z';
+const invalidDate = '123abc';
+
+test('getDateString returns correct date when using valid date and NB locale', () => {
   const dateNO = getDateString('nb', date);
   expect(dateNO).toEqual('2017, 5. juni');
+});
 
+test('getDateString returns correct date when using valid date and EN locale', () => {
   const dateEN = getDateString('en', date);
   expect(dateEN).toEqual('2017, June 5');
+});
 
+test('getDateString returns correct date (current) when using invalid date', () => {
   const dateWithInvalidInput = getDateString('nb', invalidDate);
   expect(dateWithInvalidInput).toMatch(/\d{4}, \d{1,2}. [a-zA-Z]+/);
+});
 
+test('getDateString returns correct date when given no input', () => {
   const dateWithNoInput = getDateString('en');
   expect(dateWithNoInput).toMatch(/\d{4}, [a-zA-Z]+ \d{1,2}/);
 });
 
-test('getYearString return correct content', () => {
-  const start = '2019';
-  const end = '2020';
-
-  const yearWithStart = getYearDurationString(start, undefined, tNB);
+// function getYearString
+const startYear = '2019';
+const endYear = '2020';
+test('getYearString returns correct string with only startYear param', () => {
+  const yearWithStart = getYearDurationString(startYear, undefined, tNB);
   expect(yearWithStart).toEqual('(2019-nå). ');
+});
 
-  const yearWithStartAndEnd = getYearDurationString(start, end, tNB);
+test('getYearString returns correct string with both params', () => {
+  const yearWithStartAndEnd = getYearDurationString(startYear, endYear, tNB);
   expect(yearWithStartAndEnd).toEqual('(2019-2020). ');
+});
 
+test('getYearString returns empty string when no params are used', () => {
   const yearWithNoInput = getYearDurationString(undefined, undefined, tNB);
   expect(yearWithNoInput).toEqual('');
+});
 
-  const yearWithEqualStartAndEnd = getYearDurationString(start, start, tNB);
+test('getYearString return corrct string when start and end is identical', () => {
+  const yearWithEqualStartAndEnd = getYearDurationString(startYear, startYear, tNB);
   expect(yearWithEqualStartAndEnd).toEqual('(2019). ');
 });
 

--- a/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
+++ b/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
@@ -32,20 +32,57 @@ test('getCreditString returns correct content', () => {
     { name: 'Bendik Test', type: 'artist' },
   ];
 
-  const creditStringWithOnePerson = getCreditString([roles[0]], false, false, tNB);
+  const creditStringWithOnePerson = getCreditString({ creators: [roles[0]] }, false, false, tNB);
   expect(creditStringWithOnePerson).toEqual('Etternavn, A. L. ');
 
-  const creditStringWithTwoPeople = getCreditString(roles.slice(0, 2), false, false, tNB);
+  const creditStringWithTwoPeople = getCreditString({ creators: roles.slice(0, 2) }, false, false, tNB);
   expect(creditStringWithTwoPeople).toEqual('Etternavn, A. L. & Person, B. ');
 
-  const creditStringWithMultiplePeople = getCreditString(roles, false, false, tNB);
+  const creditStringWithMultiplePeople = getCreditString({ creators: roles }, false, false, tNB);
   expect(creditStringWithMultiplePeople).toEqual('Etternavn, A. L., Person, B. & Test, B. ');
 
-  const creditStringWithRoles = getCreditString(roles.slice(0, 2), false, true, tNB);
+  const creditStringWithRoles = getCreditString({ creators: roles.slice(0, 2) }, false, true, tNB);
   expect(creditStringWithRoles).toEqual('Etternavn, A. L. (Fotograf) & Person, B. (Kunstner). ');
 
-  const creditStringWithPrefix = getCreditString(roles.slice(0, 2), true, false, tNB);
+  const creditStringWithPrefix = getCreditString({ creators: roles.slice(0, 2) }, true, false, tNB);
   expect(creditStringWithPrefix).toEqual('av Etternavn, A. L. & Person, B. ');
+
+  const creditStringWithRightsholders = getCreditString(
+    {
+      rightsholders: [
+        { type: 'distributor', name: 'Stor Bedrift' },
+        { type: 'distributor', name: 'Liten Bedrift' },
+        { type: 'distributor', name: 'Organisasjon' },
+      ],
+    },
+    false,
+    false,
+    tNB,
+  );
+  expect(creditStringWithRightsholders).toEqual('Stor Bedrift, Liten Bedrift & Organisasjon. ');
+});
+
+test('getCreditString picks correct order of role type', () => {
+  const creators = [{ name: 'Anna Etternavn', type: 'photographer' }];
+  const rightsholders = [{ name: 'Stor Bedrift', type: 'distributor' }];
+  const processors = [{ name: 'Celine', type: 'writer' }];
+  const copyright = {
+    creators,
+    rightsholders,
+    processors,
+  };
+
+  const creditStringWithAll = getCreditString(copyright, false, false, tNB);
+  expect(creditStringWithAll).toEqual('Etternavn, A. ');
+
+  const creditStringWithoutCreators = getCreditString({ rightsholders, processors }, false, false, tNB);
+  expect(creditStringWithoutCreators).toEqual('Stor Bedrift. ');
+
+  const creditStringWithoutRightsholders = getCreditString({ creators, processors }, false, false, tNB);
+  expect(creditStringWithoutRightsholders).toEqual('Etternavn, A. ');
+
+  const creditStringWithoutProcessors = getCreditString({ creators, rightsholders }, false, false, tNB);
+  expect(creditStringWithoutProcessors).toEqual('Etternavn, A. ');
 });
 
 test('getDateString returns correct content', () => {

--- a/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
+++ b/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
@@ -32,19 +32,19 @@ test('getCreditString returns correct content', () => {
     { name: 'Bendik Test', type: 'artist' },
   ];
 
-  const creditStringWithOnePerson = getCreditString({ creators: [roles[0]] }, false, false, tNB);
+  const creditStringWithOnePerson = getCreditString({ creators: [roles[0]] }, {}, tNB);
   expect(creditStringWithOnePerson).toEqual('Etternavn, A. L. ');
 
-  const creditStringWithTwoPeople = getCreditString({ creators: roles.slice(0, 2) }, false, false, tNB);
+  const creditStringWithTwoPeople = getCreditString({ creators: roles.slice(0, 2) }, {}, tNB);
   expect(creditStringWithTwoPeople).toEqual('Etternavn, A. L. & Person, B. ');
 
-  const creditStringWithMultiplePeople = getCreditString({ creators: roles }, false, false, tNB);
+  const creditStringWithMultiplePeople = getCreditString({ creators: roles }, {}, tNB);
   expect(creditStringWithMultiplePeople).toEqual('Etternavn, A. L., Person, B. & Test, B. ');
 
-  const creditStringWithRoles = getCreditString({ creators: roles.slice(0, 2) }, false, true, tNB);
+  const creditStringWithRoles = getCreditString({ creators: roles.slice(0, 2) }, { withRole: true }, tNB);
   expect(creditStringWithRoles).toEqual('Etternavn, A. L. (Fotograf) & Person, B. (Kunstner). ');
 
-  const creditStringWithPrefix = getCreditString({ creators: roles.slice(0, 2) }, true, false, tNB);
+  const creditStringWithPrefix = getCreditString({ creators: roles.slice(0, 2) }, { byPrefix: true }, tNB);
   expect(creditStringWithPrefix).toEqual('av Etternavn, A. L. & Person, B. ');
 
   const creditStringWithRightsholders = getCreditString(
@@ -55,8 +55,7 @@ test('getCreditString returns correct content', () => {
         { type: 'distributor', name: 'Organisasjon' },
       ],
     },
-    false,
-    false,
+    {},
     tNB,
   );
   expect(creditStringWithRightsholders).toEqual('Stor Bedrift, Liten Bedrift & Organisasjon. ');
@@ -72,16 +71,16 @@ test('getCreditString picks correct order of role type', () => {
     processors,
   };
 
-  const creditStringWithAll = getCreditString(copyright, false, false, tNB);
+  const creditStringWithAll = getCreditString(copyright, {}, tNB);
   expect(creditStringWithAll).toEqual('Etternavn, A. ');
 
-  const creditStringWithoutCreators = getCreditString({ rightsholders, processors }, false, false, tNB);
+  const creditStringWithoutCreators = getCreditString({ rightsholders, processors }, {}, tNB);
   expect(creditStringWithoutCreators).toEqual('Stor Bedrift. ');
 
-  const creditStringWithoutRightsholders = getCreditString({ creators, processors }, false, false, tNB);
+  const creditStringWithoutRightsholders = getCreditString({ creators, processors }, {}, tNB);
   expect(creditStringWithoutRightsholders).toEqual('Etternavn, A. ');
 
-  const creditStringWithoutProcessors = getCreditString({ creators, rightsholders }, false, false, tNB);
+  const creditStringWithoutProcessors = getCreditString({ creators, rightsholders }, {}, tNB);
   expect(creditStringWithoutProcessors).toEqual('Etternavn, A. ');
 });
 

--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -28,30 +28,61 @@ const _oldGetCreditCopyString = (roles: Contributor[], t: TranslationFunction) =
   );
 };
 
-export const getCreditString = (roles: Contributor[], byPrefix: boolean, withRole: boolean, t: TranslationFunction) => {
-  if (!roles?.length) {
+export const getCreditString = (
+  copyright: Partial<CopyrightType> | undefined,
+  byPrefix: boolean,
+  withRole: boolean,
+  t: TranslationFunction,
+) => {
+  const formatNames = (credits: string[], forcePunctuation?: boolean) => {
+    const lastCredit = credits.pop();
+
+    const formattedCredits = credits.length ? credits.join(', ') + ' & ' + lastCredit : lastCredit;
+
+    const prefix = byPrefix ? t('license.copyText.by') + ' ' : '';
+    const punctuation = forcePunctuation || withRole ? '.' : '';
+    return prefix + formattedCredits + punctuation + ' ';
+  };
+  const makeInitialsString = (roles: Contributor[]) => {
+    const credits = roles.map((creator) => {
+      const [lastName, ...names] = creator.name.split(' ').reverse();
+      const initials = names.length
+        ? ', ' +
+          names
+            .reverse()
+            .map((name) => name[0] + '.')
+            .join(' ')
+        : '.';
+      const role = withRole && creator.type ? ` (${t(creator.type.toLowerCase())})` : '';
+      return lastName + initials + role;
+    });
+    return formatNames(credits);
+  };
+
+  const makeRegularString = (roles: Contributor[]) => {
+    const credits = roles.map((creator) => {
+      const role = withRole && creator.type ? ` (${t(creator.type.toLowerCase())})` : '';
+      return creator.name + role;
+    });
+    return formatNames(credits, true);
+  };
+
+  if (!copyright) {
     return '';
   }
-  const credits = roles.map((creator) => {
-    const [lastName, ...names] = creator.name.split(' ').reverse();
-    const initials = names.length
-      ? ', ' +
-        names
-          .reverse()
-          .map((name) => name[0] + '.')
-          .join(' ')
-      : '.';
-    const role = withRole && creator.type ? ` (${t(creator.type.toLowerCase())})` : '';
-    return lastName + initials + role;
-  });
+  const { creators, rightsholders, processors } = copyright;
 
-  const lastCredit = credits.pop();
+  if (creators?.length) {
+    return makeInitialsString(creators);
+  }
+  if (rightsholders?.length) {
+    return makeRegularString(rightsholders);
+  }
+  if (processors?.length) {
+    return makeInitialsString(processors);
+  }
 
-  const formattedCredits = credits.length ? credits.join(', ') + ' & ' + lastCredit : lastCredit;
-
-  const prefix = byPrefix ? t('license.copyText.by') + ' ' : '';
-  const punctuation = withRole ? '.' : '';
-  return prefix + formattedCredits + punctuation + ' ';
+  return '';
 };
 
 const getValueOrFallback = <T>(value: T | undefined, fallback: T): T => {
@@ -132,7 +163,7 @@ export const figureApa7CopyString = (
 ): string => {
   const titleString = getValueOrFallback(title, t('license.copyText.noTitle')) + ', ';
   const yearString = date ? getYearString(date) : '';
-  const creators = getCreditString(copyright?.creators || copyright?.rightsholders || [], true, false, t);
+  const creators = getCreditString(copyright, true, false, t);
   const url = `(${path ? ndlaFrontendDomain + path : src}). `;
   const licenseString = license ? license + '.' : '';
 
@@ -150,7 +181,7 @@ export const webpageReferenceApa7CopyString = (
   ndlaFrontendDomain: string | undefined,
   t: TranslationFunction,
 ): string => {
-  const creators = getCreditString(copyright?.creators || copyright?.rightsholders || [], false, false, t);
+  const creators = getCreditString(copyright, false, false, t);
   const titleString = getValueOrFallback(title, t('license.copyText.noTitle')) + '. ';
   const url = `${path ? ndlaFrontendDomain + path : src}`;
   const dateString = `(${getDateString(locale, lastUpdated)}). `;
@@ -168,7 +199,7 @@ export const podcastSeriesApa7CopyString = (
   ndlaFrontendDomain: string | undefined,
   t: TranslationFunction,
 ) => {
-  const creators = getCreditString(copyright?.creators || copyright?.rightsholders || [], false, true, t);
+  const creators = getCreditString(copyright, false, true, t);
   const titleString = getValueOrFallback(title, t('license.copyText.noTitle')) + ' ';
   const url = `${ndlaFrontendDomain}/podkast/${seriesId}`;
   const yearString = getYearDurationString(startYear, endYear, t);
@@ -188,7 +219,7 @@ export const podcastEpisodeApa7CopyString = (
   ndlaFrontendDomain: string | undefined,
   t: TranslationFunction,
 ) => {
-  const creators = getCreditString(copyright?.creators || copyright?.rightsholders || [], false, true, t);
+  const creators = getCreditString(copyright, false, true, t);
   const titleString = getValueOrFallback(title, t('license.copyText.noTitle')) + ' ';
   const url = `${ndlaFrontendDomain}/podkast/${seriesId}#episode-${episodeId}`;
   const dateString = `(${getDateString(locale, date)}). `;

--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -30,8 +30,10 @@ const _oldGetCreditCopyString = (roles: Contributor[], t: TranslationFunction) =
 
 export const getCreditString = (
   copyright: Partial<CopyrightType> | undefined,
-  byPrefix: boolean,
-  withRole: boolean,
+  config: {
+    byPrefix?: boolean;
+    withRole?: boolean;
+  },
   t: TranslationFunction,
 ) => {
   const formatNames = (credits: string[], forcePunctuation?: boolean) => {
@@ -39,8 +41,8 @@ export const getCreditString = (
 
     const formattedCredits = credits.length ? credits.join(', ') + ' & ' + lastCredit : lastCredit;
 
-    const prefix = byPrefix ? t('license.copyText.by') + ' ' : '';
-    const punctuation = forcePunctuation || withRole ? '.' : '';
+    const prefix = config.byPrefix ? t('license.copyText.by') + ' ' : '';
+    const punctuation = forcePunctuation || config.withRole ? '.' : '';
     return prefix + formattedCredits + punctuation + ' ';
   };
   const makeInitialsString = (roles: Contributor[]) => {
@@ -53,7 +55,7 @@ export const getCreditString = (
             .map((name) => name[0] + '.')
             .join(' ')
         : '.';
-      const role = withRole && creator.type ? ` (${t(creator.type.toLowerCase())})` : '';
+      const role = config.withRole && creator.type ? ` (${t(creator.type.toLowerCase())})` : '';
       return lastName + initials + role;
     });
     return formatNames(credits);
@@ -61,7 +63,7 @@ export const getCreditString = (
 
   const makeRegularString = (roles: Contributor[]) => {
     const credits = roles.map((creator) => {
-      const role = withRole && creator.type ? ` (${t(creator.type.toLowerCase())})` : '';
+      const role = config.withRole && creator.type ? ` (${t(creator.type.toLowerCase())})` : '';
       return creator.name + role;
     });
     return formatNames(credits, true);
@@ -163,7 +165,7 @@ export const figureApa7CopyString = (
 ): string => {
   const titleString = getValueOrFallback(title, t('license.copyText.noTitle')) + ', ';
   const yearString = date ? getYearString(date) : '';
-  const creators = getCreditString(copyright, true, false, t);
+  const creators = getCreditString(copyright, { byPrefix: true }, t);
   const url = `(${path ? ndlaFrontendDomain + path : src}). `;
   const licenseString = license ? license + '.' : '';
 
@@ -181,7 +183,7 @@ export const webpageReferenceApa7CopyString = (
   ndlaFrontendDomain: string | undefined,
   t: TranslationFunction,
 ): string => {
-  const creators = getCreditString(copyright, false, false, t);
+  const creators = getCreditString(copyright, {}, t);
   const titleString = getValueOrFallback(title, t('license.copyText.noTitle')) + '. ';
   const url = `${path ? ndlaFrontendDomain + path : src}`;
   const dateString = `(${getDateString(locale, lastUpdated)}). `;
@@ -199,7 +201,7 @@ export const podcastSeriesApa7CopyString = (
   ndlaFrontendDomain: string | undefined,
   t: TranslationFunction,
 ) => {
-  const creators = getCreditString(copyright, false, true, t);
+  const creators = getCreditString(copyright, { withRole: true }, t);
   const titleString = getValueOrFallback(title, t('license.copyText.noTitle')) + ' ';
   const url = `${ndlaFrontendDomain}/podkast/${seriesId}`;
   const yearString = getYearDurationString(startYear, endYear, t);
@@ -219,7 +221,7 @@ export const podcastEpisodeApa7CopyString = (
   ndlaFrontendDomain: string | undefined,
   t: TranslationFunction,
 ) => {
-  const creators = getCreditString(copyright, false, true, t);
+  const creators = getCreditString(copyright, { withRole: true }, t);
   const titleString = getValueOrFallback(title, t('license.copyText.noTitle')) + ' ';
   const url = `${ndlaFrontendDomain}/podkast/${seriesId}#episode-${episodeId}`;
   const dateString = `(${getDateString(locale, date)}). `;

--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -48,7 +48,7 @@ export const getCreditString = (
       const [lastName, ...names] = creator.name.split(' ').reverse();
       const initials = names.length
         ? ', ' +
-          names
+          [...names]
             .reverse()
             .map((name) => name[0] + '.')
             .join(' ')

--- a/packages/ndla-ui/src/Article/Article.tsx
+++ b/packages/ndla-ui/src/Article/Article.tsx
@@ -184,7 +184,7 @@ export const Article = ({
   } = article;
 
   let authors = creators;
-  if (Array.isArray(authors) && authors.length === 0) {
+  if (Array.isArray(authors) && authors.length === 0 && !rightsholders.length) {
     authors = processors;
   }
   const suppliers = rightsholders.length ? rightsholders : undefined;
@@ -229,14 +229,12 @@ export const Article = ({
           {footNotes && footNotes.length > 0 && <ArticleFootNotes footNotes={footNotes} />}
           <ArticleByline
             copyPageUrlLink={copyPageUrlLink}
-            {...{
-              authors,
-              suppliers,
-              published,
-              license: licenseObj.license,
-              licenseBox,
-              printUrl,
-            }}
+            authors={authors}
+            suppliers={suppliers}
+            published={published}
+            license={licenseObj.license}
+            licenseBox={licenseBox}
+            printUrl={printUrl}
           />
         </LayoutItem>
         <LayoutItem layout="extend">{children}</LayoutItem>


### PR DESCRIPTION
Relatert til NDLANO/Issues#2947

Nye endringer på apa-funksjoner.

Det skal kun vises en rolletype av gangen i prioritert rekkefølge (creators -> rightsholders -> processors).

Creators og processors formateres til å vise etternavn og initialer. Rightsholders vises med fullt navn da dette gjerne er en organisasjon.


Endrer også Article slik at processors kun vises dersom verken creators eller rightsholders finnes.