### PR TITLE
Add incremental flag to tsconfig.build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 storybook-static/
 .DS_Store
 *.iml
+packages/*/tsconfig.build.tsbuildinfo
 /.idea
 *.iml
 .eslintcache

--- a/packages/button/tsconfig.build.json
+++ b/packages/button/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/carousel/tsconfig.build.json
+++ b/packages/carousel/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src", "./types"]
 }

--- a/packages/hooks/tsconfig.build.json
+++ b/packages/hooks/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/ndla-accordion/tsconfig.build.json
+++ b/packages/ndla-accordion/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src", "./types"]
 }

--- a/packages/ndla-audio-search/tsconfig.build.json
+++ b/packages/ndla-audio-search/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/ndla-code/tsconfig.build.json
+++ b/packages/ndla-code/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/ndla-editor/tsconfig.build.json
+++ b/packages/ndla-editor/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/ndla-forms/tsconfig.build.json
+++ b/packages/ndla-forms/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/ndla-howto/tsconfig.build.json
+++ b/packages/ndla-howto/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/ndla-icons/tsconfig.build.json
+++ b/packages/ndla-icons/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/ndla-image-search/tsconfig.build.json
+++ b/packages/ndla-image-search/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/ndla-licenses/tsconfig.build.json
+++ b/packages/ndla-licenses/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/ndla-listview/tsconfig.build.json
+++ b/packages/ndla-listview/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/ndla-modal/tsconfig.build.json
+++ b/packages/ndla-modal/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/ndla-notion/tsconfig.build.json
+++ b/packages/ndla-notion/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/ndla-pager/tsconfig.build.json
+++ b/packages/ndla-pager/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/ndla-tabs/tsconfig.build.json
+++ b/packages/ndla-tabs/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/ndla-tracker/tsconfig.build.json
+++ b/packages/ndla-tracker/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/ndla-ui/tsconfig.build.json
+++ b/packages/ndla-ui/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/ndla-zendesk/tsconfig.build.json
+++ b/packages/ndla-zendesk/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/safelink/tsconfig.build.json
+++ b/packages/safelink/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/switch/tsconfig.build.json
+++ b/packages/switch/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/tooltip/tsconfig.build.json
+++ b/packages/tooltip/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "declarationDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "incremental": true
   },
   "include": ["./src"]
 }

--- a/packages/util/tsconfig.build.json
+++ b/packages/util/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "declarationDir": "./lib",
     "rootDir": "./src",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "incremental": true
   },
   "include": ["./src", "./types"]
 }


### PR DESCRIPTION
Er dette noe vi har prøvd oss på før? Under lett testing har jeg ikke klart å finne noen umiddelbare ulemper med det. Å legge til `incremental`-flagget i build-filene tok `bootstrap`-tiden min fra 86 sekunder til 40 sekunder. Ser at vi kjører `tsc -b` i frontendene, som er i samme gate.