### PR TITLE
Removed facepaint dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,8 +28,6 @@
     "types"
   ],
   "dependencies": {
-    "@types/facepaint": "^1.2.1",
-    "facepaint": "^1.2.1",
     "inuitcss": "6.0.0",
     "polished": "^4.1.3",
     "sass-mq": "^5.0.1"

--- a/packages/core/src/mq.ts
+++ b/packages/core/src/mq.ts
@@ -1,10 +1,4 @@
-import facepaint from 'facepaint';
-import breakpoints from './breakpoints';
-
 const mq = {
-  tablet: facepaint([`@media (min-width: ${breakpoints.tablet})`]),
-  desktop: facepaint([`@media (min-width: ${breakpoints.desktop})`]),
-  mobile: facepaint([`@media (min-width: ${breakpoints.mobile})`]),
   range: ({ from, until }: { from?: string; until?: string }) =>
     `${from ? `@media (min-width: ${from})` : ''}${from && until ? ' and ' : ''}${!from && until ? '@media ' : ''}${
       until ? `(max-width: ${until})` : ''

--- a/packages/ndla-ui/src/ErrorMessage/ErrorMessage.tsx
+++ b/packages/ndla-ui/src/ErrorMessage/ErrorMessage.tsx
@@ -6,11 +6,10 @@
  *
  */
 
-import * as React from 'react';
+import React, { ReactNode } from 'react';
 import styled from '@emotion/styled';
-import { colors, spacing, mq } from '@ndla/core';
+import { colors, spacing, breakpoints } from '@ndla/core';
 import SafeLink from '@ndla/safelink';
-import { ReactNode } from 'react';
 
 const StyledErrorMessage = styled.article`
   text-align: center;
@@ -23,18 +22,19 @@ const StyledErrorMessage = styled.article`
   }
 `;
 
-const IllustrationWrapper = styled('div')(
-  mq.tablet({
-    marginBottom: spacing.normal,
-    marginTop: [null, spacing.large],
-  }),
-);
+const IllustrationWrapper = styled('div')`
+  margin-bottom: ${spacing.normal};
+  @media (min-width: ${breakpoints.tablet}) {
+    margin-top: ${spacing.large};
+  }
+`;
 
-const Description = styled('p')(
-  mq.tablet({
-    marginBottom: [spacing.normal, spacing.large],
-  }),
-);
+const Description = styled('p')`
+  margin-bottom: ${spacing.normal};
+  @media (min-width: ${breakpoints.tablet}) {
+    margin-bottom: ${spacing.large};
+  }
+`;
 
 const CustomElementWrapper = styled.div`
   margin: ${spacing.large} 0;


### PR DESCRIPTION
Ble bare brukt i ErrorMessage, og kunne fint byttes ut med en vanlig mediaquery.

Kan testes ved å sjekke ut den genererte CSS'en på Feilmelding i design-manualen i forskjellige størrelser.