### PR TITLE
Show rightsholders on same line as icons when only rightsholders are present

### DIFF
--- a/packages/ndla-ui/src/Article/Article.tsx
+++ b/packages/ndla-ui/src/Article/Article.tsx
@@ -183,11 +183,8 @@ export const Article = ({
     copyright: { license: licenseObj, creators, rightsholders, processors },
   } = article;
 
-  let authors = creators;
-  if (Array.isArray(authors) && authors.length === 0 && rightsholders.length === 0) {
-    authors = processors;
-  }
-  const suppliers = rightsholders.length ? rightsholders : undefined;
+  const authors = creators || rightsholders || processors;
+  const suppliers = creators.length ? rightsholders : undefined;
 
   return (
     <div ref={wrapperRef}>


### PR DESCRIPTION
Fikser feil nevnt i trello. Var en såpass liten fiks at det er like greit å ta med nå.

Dersom kun rettighetshaver finnes i artikkel vises dette per nå under lisensikonene. Med denne oppdateringen skal det nå vises på samme linje. Om opphavsperson finnes legges rettighetshaver fortsatt på linjen under.