### PR TITLE
Umiddelbare forbedringer etter presentasjon om Uu-analyse av ndla.no

### DIFF
--- a/packages/ndla-ui/src/RelatedArticleList/RelatedArticleList.tsx
+++ b/packages/ndla-ui/src/RelatedArticleList/RelatedArticleList.tsx
@@ -31,14 +31,14 @@ export const RelatedArticle = ({
   const iconWithClass = cloneElement(icon, { className: 'c-icon--medium' });
   return (
     <article {...classes('item', modifier)}>
-      <h1 {...classes('title')}>
+      <h3 {...classes('title')}>
         {iconWithClass}
         <span {...classes('link-wrapper')}>
           <SafeLink to={to} {...classes('link')} target={target} rel={linkInfo ? 'noopener noreferrer' : undefined}>
             {title}
           </SafeLink>
         </span>
-      </h1>
+      </h3>
       <p {...classes('description')} dangerouslySetInnerHTML={{ __html: introduction }} />
       {linkInfo && <p {...classes('link-info')}>{linkInfo}</p>}
     </article>

--- a/packages/ndla-ui/src/SearchTypeResult/SearchFieldHeader.tsx
+++ b/packages/ndla-ui/src/SearchTypeResult/SearchFieldHeader.tsx
@@ -73,6 +73,11 @@ const SearchInput = styled.input`
   margin-left: 3px;
 `;
 
+const iconStyle = {
+  width: '24px',
+  height: '24px',
+};
+
 type Props = {
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   value?: string;
@@ -135,11 +140,11 @@ const SearchFieldHeader = ({ value, onSubmit, onChange, filters, activeFilters }
               inputRef.current.focus();
             }
           }}>
-          <CrossIcon style={{ width: '24px', height: '24px' }} />
+          <CrossIcon style={iconStyle} title={t<string>('welcomePage.resetSearch')}/>
         </ClearButton>
       )}
       <SearchButton type="submit" value={t<string>('searchPage.search')}>
-        <SearchIcon style={{ width: '24px', height: '24px' }} />
+        <SearchIcon style={iconStyle} title={t<string>('searchPage.search')} />
       </SearchButton>
     </StyledForm>
   );

--- a/packages/ndla-ui/src/SectionHeading/SectionHeading.tsx
+++ b/packages/ndla-ui/src/SectionHeading/SectionHeading.tsx
@@ -9,9 +9,8 @@ interface Props {
   large?: boolean;
   className?: string;
 }
-const SectionHeading = ({ children, large = false, className }: Props) => (
-  <h1 {...classes('', { large }, className)}>{children}</h1>
-);
+const SectionHeading = ({ children, large = false, className }: Props) =>
+  large ? <h1 {...classes('', { large }, className)}>{children}</h1> : <h2 {...classes('', className)}>{children}</h2>;
 
 export default SectionHeading;
 


### PR DESCRIPTION
Gjør om fra h1 til h3 for relaterte artikler, samt h2 for header for relaterte artikler.
Legger på title på svg-ikon i søk for å gjøre disse synlige for skjermlesere.