### PR TITLE
changed children prop from function to ReactElement

### DIFF
--- a/packages/button/src/MultiButton.tsx
+++ b/packages/button/src/MultiButton.tsx
@@ -149,7 +149,7 @@ type Props = {
   disabled?: boolean;
   large?: boolean;
   menuPosition?: 'top' | 'bottom';
-  children?: () => ReactElement;
+  children?: ReactElement;
 };
 
 export const MultiButton = ({


### PR DESCRIPTION
Løser følgende type problem:
Siden `children` proppen er definert som `() => ReactElement` må vi sende children på følgende måten:
```tsx
<Multibutton>
  {() => <h1> hei </h1>}
</MultiButton>
```
Istedenfor å bruke den vanlige skrivemåten:
```tsx
<Multibutton>
  <h1> hei </h1>
</MultiButton>
```

Endringen jeg innfører tillater oss å sende `children` på vanlig måte.