### PR TITLE
Better handle empty contributor lists when rendering article byline

### DIFF
--- a/packages/ndla-ui/src/Article/Article.tsx
+++ b/packages/ndla-ui/src/Article/Article.tsx
@@ -183,8 +183,7 @@ export const Article = ({
     copyright: { license: licenseObj, creators, rightsholders, processors },
   } = article;
 
-  const authors = creators || rightsholders || processors;
-  const suppliers = creators.length ? rightsholders : undefined;
+  const authors = creators.length || rightsholders.length ? creators : processors;
 
   return (
     <div ref={wrapperRef}>
@@ -227,7 +226,7 @@ export const Article = ({
           <ArticleByline
             copyPageUrlLink={copyPageUrlLink}
             authors={authors}
-            suppliers={suppliers}
+            suppliers={rightsholders}
             published={published}
             license={licenseObj.license}
             licenseBox={licenseBox}

--- a/packages/ndla-ui/src/Article/ArticleByline.tsx
+++ b/packages/ndla-ui/src/Article/ArticleByline.tsx
@@ -64,15 +64,9 @@ type Props = {
 
 const renderContributors = (contributors: SupplierProps[] | AuthorProps[], t: TFunction) => {
   const contributorsArray = contributors.map((contributor, index) => {
-    let separator = '';
-    if (index > 0) {
-      if (index === contributors.length - 1) {
-        separator = ` ${t('article.conjunction')} `;
-      } else {
-        separator = ', ';
-      }
-    }
-    return `${separator}${contributor.name}`;
+    if (index < 1) return contributor.name;
+    const sep = index === contributors.length - 1 ? ` ${t('article.conjunction')} ` : ', ';
+    return `${sep}${contributor.name}`;
   });
   return contributorsArray.join('');
 };


### PR DESCRIPTION
Bedre håndtering av ArticlebyLine. Rettighetshaver skal alltid vises dersom det eksisterer. Plasseres på nederste linje dersom opphavsperson finnes, ellers plasseres det øverst.