### PR TITLE
Hotfix article text apa

### DIFF
--- a/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
+++ b/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
@@ -77,7 +77,7 @@ test('getCreditString returns correct content when using rightsholders', () => {
     {},
     tNB,
   );
-  expect(creditString).toEqual('Stor Bedrift, Liten Bedrift & Organisasjon. ');
+  expect(creditString).toEqual('Stor Bedrift, Liten Bedrift, Organisasjon. ');
 });
 
 test('getCreditString uses correct role when all are present', () => {
@@ -165,9 +165,10 @@ test('figureApa7CopyString return correct content', () => {
     'CC-BY-SA-4.0',
     'https://test.ndla.no',
     tNB,
+    'nb',
   );
 
-  expect(copyString).toEqual('Tittel, 2017, av Etternavn, A. NDLA. (https://test.ndla.no/path/123). CC-BY-SA-4.0.');
+  expect(copyString).toEqual('Tittel, 2017, av Etternavn, A. (https://test.ndla.no/path/123). CC BY-SA 4.0.');
 });
 
 test('podcastSeriesApa7CopyString return correct content', () => {

--- a/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
+++ b/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
@@ -47,22 +47,22 @@ test('getCreditString returns correct string for one person', () => {
 
 test('getCreditString returns correct string for two people', () => {
   const creditString = getCreditString({ creators: roles.slice(0, 2) }, {}, tNB);
-  expect(creditString).toEqual('Etternavn, A. L. & Person, B. ');
+  expect(creditString).toEqual('Etternavn, A. L., Person, B. ');
 });
 
 test('getCreditString returns correct string for three people', () => {
   const creditString = getCreditString({ creators: roles }, {}, tNB);
-  expect(creditString).toEqual('Etternavn, A. L., Person, B. & Test, B. ');
+  expect(creditString).toEqual('Etternavn, A. L., Person, B., Test, B. ');
 });
 
 test('getCreditString returns correct content with withRoles param', () => {
   const creditString = getCreditString({ creators: roles.slice(0, 2) }, { withRole: true }, tNB);
-  expect(creditString).toEqual('Etternavn, A. L. (Fotograf) & Person, B. (Kunstner). ');
+  expect(creditString).toEqual('Etternavn, A. L. (Fotograf), Person, B. (Kunstner). ');
 });
 
 test('getCreditString returns correct content with byPrefix param', () => {
   const creditString = getCreditString({ creators: roles.slice(0, 2) }, { byPrefix: true }, tNB);
-  expect(creditString).toEqual('av Etternavn, A. L. & Person, B. ');
+  expect(creditString).toEqual('av Etternavn, A. L., Person, B. ');
 });
 
 test('getCreditString returns correct content when using rightsholders', () => {
@@ -151,7 +151,7 @@ test('getYearString return corrct string when start and end is identical', () =>
 test('figureApa7CopyString return correct content', () => {
   const copyright = {
     creators: [{ name: 'Anna Etternavn', type: 'photographer' }],
-    rightsholders: [{ name: 'Bendik Person', type: 'artist' }],
+    rightsholders: [{ name: 'Stor Bedrift', type: 'distributor' }],
     processors: [{ name: 'Celine', type: 'writer' }],
   };
   const date = '2017-06-05T14:25:14Z';
@@ -168,7 +168,9 @@ test('figureApa7CopyString return correct content', () => {
     'nb',
   );
 
-  expect(copyString).toEqual('Tittel, 2017, av Etternavn, A. (https://test.ndla.no/path/123). CC BY-SA 4.0.');
+  expect(copyString).toEqual(
+    'Tittel, 2017, av Etternavn, A., Stor Bedrift. (https://test.ndla.no/path/123). CC BY-SA 4.0.',
+  );
 });
 
 test('podcastSeriesApa7CopyString return correct content', () => {
@@ -177,7 +179,7 @@ test('podcastSeriesApa7CopyString return correct content', () => {
       license: 'CC-BY-SA-4.0',
     },
     creators: [{ name: 'Anna Etternavn', type: 'writer' }],
-    rightsholders: [{ name: 'Bendik Person', type: 'artist' }],
+    rightsholders: [{ name: 'Stor Bedrift', type: 'distributor' }],
     processors: [{ name: 'Celine', type: 'writer' }],
   };
 
@@ -219,19 +221,19 @@ test('podcastSeriesApa7CopyString return correct content', () => {
   );
 
   expect(copyStringWithStartAndEnd).toEqual(
-    'Etternavn, A. (Forfatter). (2019-2020). Tittel [Audio podkast]. NDLA. https://test.ndla.no/podkast/5',
+    'Etternavn, A. (Forfatter), Stor Bedrift (Distributør). (2019-2020). Tittel [Audio podkast]. NDLA. https://test.ndla.no/podkast/5',
   );
 
   expect(copyStringWithStart).toEqual(
-    'Etternavn, A. (Forfatter). (2019-nå). Tittel [Audio podkast]. NDLA. https://test.ndla.no/podkast/5',
+    'Etternavn, A. (Forfatter), Stor Bedrift (Distributør). (2019-nå). Tittel [Audio podkast]. NDLA. https://test.ndla.no/podkast/5',
   );
 
   expect(copyStringWithNoYear).toEqual(
-    'Etternavn, A. (Forfatter). Tittel [Audio podkast]. NDLA. https://test.ndla.no/podkast/5',
+    'Etternavn, A. (Forfatter), Stor Bedrift (Distributør). Tittel [Audio podkast]. NDLA. https://test.ndla.no/podkast/5',
   );
 
   expect(copyStringWithEqualYears).toEqual(
-    'Etternavn, A. (Forfatter). (2019). Tittel [Audio podkast]. NDLA. https://test.ndla.no/podkast/5',
+    'Etternavn, A. (Forfatter), Stor Bedrift (Distributør). (2019). Tittel [Audio podkast]. NDLA. https://test.ndla.no/podkast/5',
   );
 });
 
@@ -245,7 +247,7 @@ test('podcastEpisodeApa7CopyString return correct content', () => {
       { name: 'Bendik Person', type: 'artist' },
       { name: 'Lars Nordmann', type: 'artist' },
     ],
-    rightsholders: [{ name: 'Bendik Test', type: 'artist' }],
+    rightsholders: [{ name: 'Stor Bedrift', type: 'distributor' }],
     processors: [{ name: 'Celine', type: 'writer' }],
   };
 
@@ -261,7 +263,7 @@ test('podcastEpisodeApa7CopyString return correct content', () => {
   );
 
   expect(copyString).toEqual(
-    'Etternavn, A. (Forfatter), Person, B. (Kunstner) & Nordmann, L. (Kunstner). (2017, 5. juni). Tittel [Audio podkast episode]. NDLA. https://test.ndla.no/podkast/10#episode-2',
+    'Etternavn, A. (Forfatter), Person, B. (Kunstner), Nordmann, L. (Kunstner), Stor Bedrift (Distributør). (2017, 5. juni). Tittel [Audio podkast episode]. NDLA. https://test.ndla.no/podkast/10#episode-2',
   );
 });
 
@@ -271,7 +273,7 @@ test('webpageReferenceApa7CopyString return correct content', () => {
       { name: 'Anna Etternavn', type: 'photographer' },
       { name: 'Bendik Person', type: 'artist' },
     ],
-    rightsholders: [{ name: 'Bendik Person', type: 'artist' }],
+    rightsholders: [{ name: 'Stor Bedrift', type: 'distributor' }],
     processors: [{ name: 'Celine', type: 'writer' }],
   };
 
@@ -298,10 +300,10 @@ test('webpageReferenceApa7CopyString return correct content', () => {
   );
 
   expect(englishCopyString).toEqual(
-    'Etternavn, A. & Person, B. (2017, June 5). Title. NDLA. https://test.ndla.no/path/123',
+    'Etternavn, A., Person, B., Stor Bedrift. (2017, June 5). Title. NDLA. https://test.ndla.no/path/123',
   );
   expect(norwegianCopyString).toEqual(
-    'Etternavn, A. & Person, B. (2017, 5. juni). Tittel. NDLA. https://test.ndla.no/path/123',
+    'Etternavn, A., Person, B., Stor Bedrift. (2017, 5. juni). Tittel. NDLA. https://test.ndla.no/path/123',
   );
 });
 

--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -1,3 +1,4 @@
+import { getLicenseByAbbreviation } from './licenses';
 import { Contributor, CopyrightType } from './contributorTypes';
 
 export const getLicenseCredits = (copyright?: {
@@ -37,9 +38,10 @@ export const getCreditString = (
   t: TranslationFunction,
 ) => {
   const formatNames = (credits: string[], forcePunctuation?: boolean) => {
+    const lastSeparator = !copyright?.creators?.length && copyright?.rightsholders?.length ? ', ' : ' & ';
     const lastCredit = credits.pop();
 
-    const formattedCredits = credits.length ? credits.join(', ') + ' & ' + lastCredit : lastCredit;
+    const formattedCredits = credits.length ? credits.join(', ') + lastSeparator + lastCredit : lastCredit;
 
     const prefix = config.byPrefix ? t('license.copyText.by') + ' ' : '';
     const punctuation = forcePunctuation || config.withRole ? '.' : '';
@@ -162,15 +164,16 @@ export const figureApa7CopyString = (
   license: string | undefined,
   ndlaFrontendDomain: string | undefined,
   t: TranslationFunction,
+  locale: string,
 ): string => {
   const titleString = getValueOrFallback(title, t('license.copyText.noTitle')) + ', ';
   const yearString = date ? getYearString(date) : '';
   const creators = getCreditString(copyright, { byPrefix: true }, t);
   const url = `(${path ? ndlaFrontendDomain + path : src}). `;
-  const licenseString = license ? license + '.' : '';
+  const licenseString = license ? getLicenseByAbbreviation(license, locale).abbreviation + '.' : '';
 
-  // Ex: Tittel, 1914, av Nordmann, O. NDLA. (https://ndla.no/urn:resource:123). CC-BY-SA-4.0.
-  return titleString + yearString + creators + 'NDLA. ' + url + licenseString;
+  // Ex: Tittel, 1914, av Nordmann, O. (https://ndla.no/urn:resource:123). CC BY-SA 4.0.
+  return titleString + yearString + creators + url + licenseString;
 };
 
 export const webpageReferenceApa7CopyString = (

--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -178,7 +178,7 @@ export const figureApa7CopyString = (
   const url = `(${path ? ndlaFrontendDomain + path : src}). `;
 
   const licenseAbbreviation = license && getLicenseByAbbreviation(license, locale).abbreviation;
-  const isCreativeCommonsLicense = licenseAbbreviation && licenseAbbreviation.slice(0, 3) === 'CC ';
+  const isCreativeCommonsLicense = licenseAbbreviation?.startsWith('CC ');
   const licenseString =
     licenseAbbreviation && isCreativeCommonsLicense ? licenseAbbreviation + ' 4.0' : licenseAbbreviation;
   const punctuation = license ? '.' : '';

--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -1,4 +1,4 @@
-import { getLicenseByAbbreviation } from './licenses';
+import { getLicenseByAbbreviation } from '.';
 import { Contributor, CopyrightType } from './contributorTypes';
 
 export const getLicenseCredits = (copyright?: {
@@ -176,10 +176,15 @@ export const figureApa7CopyString = (
   const yearString = date ? getYearString(date) : '';
   const creators = getCreditString(copyright, { byPrefix: true, combineCreatorsAndRightsholders: true }, t);
   const url = `(${path ? ndlaFrontendDomain + path : src}). `;
-  const licenseString = license ? getLicenseByAbbreviation(license, locale).abbreviation + '.' : '';
+
+  const licenseAbbreviation = license && getLicenseByAbbreviation(license, locale).abbreviation;
+  const isCreativeCommonsLicense = licenseAbbreviation && licenseAbbreviation.slice(0, 3) === 'CC ';
+  const licenseString =
+    licenseAbbreviation && isCreativeCommonsLicense ? licenseAbbreviation + ' 4.0' : licenseAbbreviation;
+  const punctuation = license ? '.' : '';
 
   // Ex: Tittel, 1914, av Nordmann, O. (https://ndla.no/urn:resource:123). CC BY-SA 4.0.
-  return titleString + yearString + creators + url + licenseString;
+  return titleString + yearString + creators + url + licenseString + punctuation;
 };
 
 export const webpageReferenceApa7CopyString = (

--- a/packages/ndla-licenses/src/licenses.ts
+++ b/packages/ndla-licenses/src/licenses.ts
@@ -57,7 +57,7 @@ const byncnd: LicenseType = {
       'This license is the most restrictive of our six main licenses, only allowing others to download your works and share them with others as long as they credit you, but they can’t change them in any way or use them commercially.',
   },
   rights: [CC, BY, NC, ND],
-  abbreviation: `${CC} ${BY}-${NC}-${ND}`.toUpperCase(),
+  abbreviation: `${CC} ${BY}-${NC}-${ND} 4.0`.toUpperCase(),
 };
 
 const byncsa: LicenseType = {
@@ -90,7 +90,7 @@ const byncsa: LicenseType = {
       'This license lets others remix, tweak, and build upon your work non-commercially, as long as they credit you and license their new creations under the identical terms.',
   },
   rights: [CC, BY, NC, SA],
-  abbreviation: `${CC} ${BY}-${NC}-${SA}`.toUpperCase(),
+  abbreviation: `${CC} ${BY}-${NC}-${SA} 4.0`.toUpperCase(),
 };
 
 const bync: LicenseType = {
@@ -123,7 +123,7 @@ const bync: LicenseType = {
       'This license lets others remix, tweak, and build upon your work non-commercially, and although their new works must also acknowledge you and be non-commercial, they don’t have to license their derivative works on the same terms.',
   },
   rights: [CC, BY, NC],
-  abbreviation: `${CC} ${BY}-${NC}`.toUpperCase(),
+  abbreviation: `${CC} ${BY}-${NC} 4.0`.toUpperCase(),
 };
 
 const bynd: LicenseType = {
@@ -156,7 +156,7 @@ const bynd: LicenseType = {
       'This license allows for redistribution, commercial and non-commercial, as long as it is passed along unchanged and in whole, with credit to you.',
   },
   rights: [CC, BY, ND],
-  abbreviation: `${CC} ${BY}-${ND}`.toUpperCase(),
+  abbreviation: `${CC} ${BY}-${ND} 4.0`.toUpperCase(),
 };
 
 const bysa: LicenseType = {
@@ -189,7 +189,7 @@ const bysa: LicenseType = {
       'This license lets others remix, tweak, and build upon your work even for commercial purposes, as long as they credit you and license their new creations under the identical terms. This license is often compared to “copyleft” free and open source software licenses. All new works based on yours will carry the same license, so any derivatives will also allow commercial use. This is the license used by Wikipedia, and is recommended for materials that would benefit from incorporating content from Wikipedia and similarly licensed projects.',
   },
   rights: [CC, BY, SA],
-  abbreviation: `${CC} ${BY}-${SA}`.toUpperCase(),
+  abbreviation: `${CC} ${BY}-${SA} 4.0`.toUpperCase(),
 };
 
 const by: LicenseType = {
@@ -222,7 +222,7 @@ const by: LicenseType = {
       'This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of licenses offered. Recommended for maximum dissemination and use of licensed materials.',
   },
   rights: [CC, BY],
-  abbreviation: `${CC} ${BY}`.toUpperCase(),
+  abbreviation: `${CC} ${BY} 4.0`.toUpperCase(),
 };
 
 const pd: LicenseType = {

--- a/packages/ndla-licenses/src/licenses.ts
+++ b/packages/ndla-licenses/src/licenses.ts
@@ -57,7 +57,7 @@ const byncnd: LicenseType = {
       'This license is the most restrictive of our six main licenses, only allowing others to download your works and share them with others as long as they credit you, but they can’t change them in any way or use them commercially.',
   },
   rights: [CC, BY, NC, ND],
-  abbreviation: `${CC} ${BY}-${NC}-${ND} 4.0`.toUpperCase(),
+  abbreviation: `${CC} ${BY}-${NC}-${ND}`.toUpperCase(),
 };
 
 const byncsa: LicenseType = {
@@ -90,7 +90,7 @@ const byncsa: LicenseType = {
       'This license lets others remix, tweak, and build upon your work non-commercially, as long as they credit you and license their new creations under the identical terms.',
   },
   rights: [CC, BY, NC, SA],
-  abbreviation: `${CC} ${BY}-${NC}-${SA} 4.0`.toUpperCase(),
+  abbreviation: `${CC} ${BY}-${NC}-${SA}`.toUpperCase(),
 };
 
 const bync: LicenseType = {
@@ -123,7 +123,7 @@ const bync: LicenseType = {
       'This license lets others remix, tweak, and build upon your work non-commercially, and although their new works must also acknowledge you and be non-commercial, they don’t have to license their derivative works on the same terms.',
   },
   rights: [CC, BY, NC],
-  abbreviation: `${CC} ${BY}-${NC} 4.0`.toUpperCase(),
+  abbreviation: `${CC} ${BY}-${NC}`.toUpperCase(),
 };
 
 const bynd: LicenseType = {
@@ -156,7 +156,7 @@ const bynd: LicenseType = {
       'This license allows for redistribution, commercial and non-commercial, as long as it is passed along unchanged and in whole, with credit to you.',
   },
   rights: [CC, BY, ND],
-  abbreviation: `${CC} ${BY}-${ND} 4.0`.toUpperCase(),
+  abbreviation: `${CC} ${BY}-${ND}`.toUpperCase(),
 };
 
 const bysa: LicenseType = {
@@ -189,7 +189,7 @@ const bysa: LicenseType = {
       'This license lets others remix, tweak, and build upon your work even for commercial purposes, as long as they credit you and license their new creations under the identical terms. This license is often compared to “copyleft” free and open source software licenses. All new works based on yours will carry the same license, so any derivatives will also allow commercial use. This is the license used by Wikipedia, and is recommended for materials that would benefit from incorporating content from Wikipedia and similarly licensed projects.',
   },
   rights: [CC, BY, SA],
-  abbreviation: `${CC} ${BY}-${SA} 4.0`.toUpperCase(),
+  abbreviation: `${CC} ${BY}-${SA}`.toUpperCase(),
 };
 
 const by: LicenseType = {
@@ -222,7 +222,7 @@ const by: LicenseType = {
       'This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of licenses offered. Recommended for maximum dissemination and use of licensed materials.',
   },
   rights: [CC, BY],
-  abbreviation: `${CC} ${BY} 4.0`.toUpperCase(),
+  abbreviation: `${CC} ${BY}`.toUpperCase(),
 };
 
 const pd: LicenseType = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7050,11 +7050,6 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-can-use-dom@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/can-use-dom/-/can-use-dom-0.1.0.tgz#22cc4a34a0abc43950f42c6411024a3f6366b45a"
-  integrity sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=
-
 caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001181:
   version "1.0.30001241"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz"
@@ -15276,15 +15271,6 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
-react-facebook@^6.0.15:
-  version "6.0.15"
-  resolved "https://registry.yarnpkg.com/react-facebook/-/react-facebook-6.0.15.tgz#24914e13ab4f49c8ab73d638535ec97bd78daff5"
-  integrity sha512-WRL20POc5XdzLv6FP4ys9VZ9C7Cc2GVEVeGDq/0mshG7c7g917tLt5OWEIw97Gkhcbdn9HSaZ81TS8pFWgwSZA==
-  dependencies:
-    babel-runtime "^6.26.0"
-    can-use-dom "^0.1.0"
-    react-spinner-children "^1.0.8"
-
 react-fast-compare@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
@@ -15478,14 +15464,6 @@ react-sizeme@^3.0.1:
     invariant "^2.2.4"
     shallowequal "^1.1.0"
     throttle-debounce "^3.0.1"
-
-react-spinner-children@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/react-spinner-children/-/react-spinner-children-1.0.8.tgz#6fdd6a89593c5f233bb56f4deccb812382e6ca74"
-  integrity sha1-b91qiVk8XyM7tW9N7MuBI4LmynQ=
-  dependencies:
-    prop-types "^15.6.0"
-    spin.js "^2.3.2"
 
 react-sticky-el@^2.0.6:
   version "2.0.6"
@@ -16867,11 +16845,6 @@ spdx-license-ids@^3.0.0:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
-
-spin.js@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/spin.js/-/spin.js-2.3.2.tgz#6caa56d520673450fd5cfbc6971e6d0772c37a1a"
-  integrity sha1-bKpW1SBnNFD9XPvGlx5tB3LDeho=
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"


### PR DESCRIPTION
En liste over endringer:
- Opphavspersoner og rettighetshavere skal listes opp sammen.
- Krediterte personer/organisasjoner skal separeres med komma (ikke &-tegn).
- "NDLA" skal fjernes fra figureApa7CopyString
- Lisenser skal skrives som uten bindestrek i starten og før versjonsnummer. Riktig: _CC BY-SA 4.0_. Feil: _CC-BY-SA-4.0_