### PR TITLE
Hotfix copystring pd license

### DIFF
--- a/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
+++ b/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
@@ -208,7 +208,7 @@ test('figureApa7CopyString return correct content when no license in param', () 
     'nb',
   );
 
-  expect(copyString).toEqual('Tittel, 2017, av Etternavn, A., Stor Bedrift. (https://test.ndla.no/path/123). ');
+  expect(copyString).toEqual('Tittel, 2017, av Etternavn, A., Stor Bedrift. (https://test.ndla.no/path/123).');
 });
 
 // function podcastSeriesApa7CopyString

--- a/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
+++ b/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
@@ -54,6 +54,11 @@ test('getLicenseString returns no content for PD license', () => {
   expect(creditString).toEqual('');
 });
 
+test('getLicenseString returns no content for N/A license', () => {
+  const creditString = getLicenseString('N/A', 'nb');
+  expect(creditString).toEqual('');
+});
+
 test('getLicenseString returns correct content for copyrighted license', () => {
   const creditString = getLicenseString('COPYRIGHTED', 'nb');
   expect(creditString).toEqual('COPYRIGHTED');

--- a/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
+++ b/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
@@ -17,6 +17,7 @@ import {
   getCreditString,
   getDateString,
   getYearDurationString,
+  getLicenseString,
 } from '../getCopyString';
 
 // Adding @ndla/ui to package.json would cause circular dependency.
@@ -24,7 +25,6 @@ import { i18nInstance } from '../../../ndla-ui';
 const tNB = i18nInstance.getFixedT('nb');
 const tEN = i18nInstance.getFixedT('en');
 
-// function getCreditString
 const roles = [
   { name: 'Anna Langt Etternavn', type: 'photographer' },
   { name: 'Bendik Person', type: 'artist' },
@@ -43,6 +43,28 @@ const copyright = {
   },
 };
 
+// function getLicenseString
+test('getLicenseString returns correct content for CC license', () => {
+  const creditString = getLicenseString(copyright.license.license, 'nb');
+  expect(creditString).toEqual('CC BY-SA 4.0');
+});
+
+test('getLicenseString returns no content for PD license', () => {
+  const creditString = getLicenseString('PD', 'nb');
+  expect(creditString).toEqual('');
+});
+
+test('getLicenseString returns correct content for copyrighted license', () => {
+  const creditString = getLicenseString('COPYRIGHTED', 'nb');
+  expect(creditString).toEqual('COPYRIGHTED');
+});
+
+test('getLicenseString returns no content for no license', () => {
+  const creditString = getLicenseString('', 'nb');
+  expect(creditString).toEqual('');
+});
+
+// function getCreditString
 test('getCreditString returns correct string for one person', () => {
   const creditString = getCreditString({ creators: [roles[0]] }, {}, tNB);
   expect(creditString).toEqual('Etternavn, A. L. ');
@@ -103,7 +125,7 @@ test('getCreditString uses correct role when processors is missing', () => {
   expect(creditStringWithoutProcessors).toEqual('Etternavn, A. ');
 });
 
-// getDateString
+// function getDateString
 const date = '2017-06-05T14:25:14Z';
 const invalidDate = '123abc';
 
@@ -150,13 +172,8 @@ test('getYearString return corrct string when start and end is identical', () =>
   expect(yearWithEqualStartAndEnd).toEqual('(2019). ');
 });
 
-// Get functions
+// function figureApa7CopyString
 test('figureApa7CopyString return correct content', () => {
-  const copyright = {
-    creators: [{ name: 'Anna Etternavn', type: 'photographer' }],
-    rightsholders: [{ name: 'Stor Bedrift', type: 'distributor' }],
-    processors: [{ name: 'Celine', type: 'writer' }],
-  };
   const date = '2017-06-05T14:25:14Z';
 
   const copyString = figureApa7CopyString(
@@ -176,6 +193,25 @@ test('figureApa7CopyString return correct content', () => {
   );
 });
 
+test('figureApa7CopyString return correct content when no license in param', () => {
+  const date = '2017-06-05T14:25:14Z';
+
+  const copyString = figureApa7CopyString(
+    'Tittel',
+    date,
+    undefined,
+    '/path/123',
+    copyright,
+    undefined,
+    'https://test.ndla.no',
+    tNB,
+    'nb',
+  );
+
+  expect(copyString).toEqual('Tittel, 2017, av Etternavn, A., Stor Bedrift. (https://test.ndla.no/path/123). ');
+});
+
+// function podcastSeriesApa7CopyString
 test('podcastSeriesApa7CopyString return correct with start and end date param', () => {
   const copyString = podcastSeriesApa7CopyString('Tittel', '2019', '2020', '5', copyright, 'https://test.ndla.no', tNB);
 
@@ -222,6 +258,7 @@ test('podcastSeriesApa7CopyString returns short year when start and end date is 
   );
 });
 
+// function podcastEpisodeApa7CopyString
 test('podcastEpisodeApa7CopyString return correct content', () => {
   const copyright = {
     license: {
@@ -252,6 +289,7 @@ test('podcastEpisodeApa7CopyString return correct content', () => {
   );
 });
 
+// function webpageReferenceApa7CopyString
 test('webpageReferenceApa7CopyString return correct content', () => {
   const copyright = {
     creators: [
@@ -292,6 +330,7 @@ test('webpageReferenceApa7CopyString return correct content', () => {
   );
 });
 
+// function getCopyString
 test('getCopyString returns correct content', () => {
   const copyright = {
     creators: [{ name: 'Person1', type: 'photographer' }],

--- a/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
+++ b/packages/ndla-licenses/src/__tests__/getCopyString-test.ts
@@ -38,6 +38,9 @@ const copyright = {
   creators,
   rightsholders,
   processors,
+  license: {
+    license: 'CC-BY-SA-4.0',
+  },
 };
 
 test('getCreditString returns correct string for one person', () => {
@@ -173,26 +176,16 @@ test('figureApa7CopyString return correct content', () => {
   );
 });
 
-test('podcastSeriesApa7CopyString return correct content', () => {
-  const copyright = {
-    license: {
-      license: 'CC-BY-SA-4.0',
-    },
-    creators: [{ name: 'Anna Etternavn', type: 'writer' }],
-    rightsholders: [{ name: 'Stor Bedrift', type: 'distributor' }],
-    processors: [{ name: 'Celine', type: 'writer' }],
-  };
+test('podcastSeriesApa7CopyString return correct with start and end date param', () => {
+  const copyString = podcastSeriesApa7CopyString('Tittel', '2019', '2020', '5', copyright, 'https://test.ndla.no', tNB);
 
-  const copyStringWithStartAndEnd = podcastSeriesApa7CopyString(
-    'Tittel',
-    '2019',
-    '2020',
-    '5',
-    copyright,
-    'https://test.ndla.no',
-    tNB,
+  expect(copyString).toEqual(
+    'Etternavn, A. (Fotograf), Stor Bedrift (Distributør). (2019-2020). Tittel [Audio podkast]. NDLA. https://test.ndla.no/podkast/5',
   );
-  const copyStringWithStart = podcastSeriesApa7CopyString(
+});
+
+test('podcastSeriesApa7CopyString returns correct content with start date param', () => {
+  const copyString = podcastSeriesApa7CopyString(
     'Tittel',
     '2019',
     undefined,
@@ -201,7 +194,13 @@ test('podcastSeriesApa7CopyString return correct content', () => {
     'https://test.ndla.no',
     tNB,
   );
-  const copyStringWithNoYear = podcastSeriesApa7CopyString(
+  expect(copyString).toEqual(
+    'Etternavn, A. (Fotograf), Stor Bedrift (Distributør). (2019-nå). Tittel [Audio podkast]. NDLA. https://test.ndla.no/podkast/5',
+  );
+});
+
+test('podcastSeriesApa7CopyString return nothing when no year param is used', () => {
+  const copyString = podcastSeriesApa7CopyString(
     'Tittel',
     undefined,
     undefined,
@@ -210,30 +209,16 @@ test('podcastSeriesApa7CopyString return correct content', () => {
     'https://test.ndla.no',
     tNB,
   );
-  const copyStringWithEqualYears = podcastSeriesApa7CopyString(
-    'Tittel',
-    '2019',
-    '2019',
-    '5',
-    copyright,
-    'https://test.ndla.no',
-    tNB,
+  expect(copyString).toEqual(
+    'Etternavn, A. (Fotograf), Stor Bedrift (Distributør). Tittel [Audio podkast]. NDLA. https://test.ndla.no/podkast/5',
   );
+});
 
-  expect(copyStringWithStartAndEnd).toEqual(
-    'Etternavn, A. (Forfatter), Stor Bedrift (Distributør). (2019-2020). Tittel [Audio podkast]. NDLA. https://test.ndla.no/podkast/5',
-  );
+test('podcastSeriesApa7CopyString returns short year when start and end date is equal', () => {
+  const copyString = podcastSeriesApa7CopyString('Tittel', '2019', '2019', '5', copyright, 'https://test.ndla.no', tNB);
 
-  expect(copyStringWithStart).toEqual(
-    'Etternavn, A. (Forfatter), Stor Bedrift (Distributør). (2019-nå). Tittel [Audio podkast]. NDLA. https://test.ndla.no/podkast/5',
-  );
-
-  expect(copyStringWithNoYear).toEqual(
-    'Etternavn, A. (Forfatter), Stor Bedrift (Distributør). Tittel [Audio podkast]. NDLA. https://test.ndla.no/podkast/5',
-  );
-
-  expect(copyStringWithEqualYears).toEqual(
-    'Etternavn, A. (Forfatter), Stor Bedrift (Distributør). (2019). Tittel [Audio podkast]. NDLA. https://test.ndla.no/podkast/5',
+  expect(copyString).toEqual(
+    'Etternavn, A. (Fotograf), Stor Bedrift (Distributør). (2019). Tittel [Audio podkast]. NDLA. https://test.ndla.no/podkast/5',
   );
 });
 

--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -161,6 +161,20 @@ export const getYearDurationString = (
   return `(${start}-${end}). `;
 };
 
+const getLicenseString = (license: string | undefined, locale: string) => {
+  if (license === 'PD') {
+    return;
+  }
+
+  const licenseAbbreviation = license && getLicenseByAbbreviation(license, locale).abbreviation;
+
+  if (licenseAbbreviation?.startsWith('CC ')) {
+    return `${licenseAbbreviation} 4.0`;
+  }
+
+  return licenseAbbreviation;
+};
+
 export const figureApa7CopyString = (
   title: string | undefined,
   date: string | undefined,
@@ -177,11 +191,8 @@ export const figureApa7CopyString = (
   const creators = getCreditString(copyright, { byPrefix: true, combineCreatorsAndRightsholders: true }, t);
   const url = `(${path ? ndlaFrontendDomain + path : src}). `;
 
-  const licenseAbbreviation = license && getLicenseByAbbreviation(license, locale).abbreviation;
-  const isCreativeCommonsLicense = licenseAbbreviation?.startsWith('CC ');
-  const licenseString =
-    licenseAbbreviation && isCreativeCommonsLicense ? licenseAbbreviation + ' 4.0' : licenseAbbreviation;
-  const punctuation = license ? '.' : '';
+  const licenseString = getLicenseString(license, locale);
+  const punctuation = licenseString ? '.' : '';
 
   // Ex: Tittel, 1914, av Nordmann, O. (https://ndla.no/urn:resource:123). CC BY-SA 4.0.
   return titleString + yearString + creators + url + licenseString + punctuation;

--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -162,7 +162,7 @@ export const getYearDurationString = (
 };
 
 export const getLicenseString = (license: string | undefined, locale: string) => {
-  if (license === 'PD') {
+  if (license === 'PD' || license === 'N/A') {
     return '';
   }
 

--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -189,13 +189,13 @@ export const figureApa7CopyString = (
   const titleString = getValueOrFallback(title, t('license.copyText.noTitle')) + ', ';
   const yearString = date ? getYearString(date) : '';
   const creators = getCreditString(copyright, { byPrefix: true, combineCreatorsAndRightsholders: true }, t);
-  const url = `(${path ? ndlaFrontendDomain + path : src}). `;
+  const url = `(${path ? ndlaFrontendDomain + path : src}).`;
 
-  const licenseString = getLicenseString(license, locale);
-  const punctuation = licenseString ? '.' : '';
+  const parsedLicense = getLicenseString(license, locale);
+  const licenseString = parsedLicense ? ` ${parsedLicense}.` : '';
 
   // Ex: Tittel, 1914, av Nordmann, O. (https://ndla.no/urn:resource:123). CC BY-SA 4.0.
-  return titleString + yearString + creators + url + licenseString + punctuation;
+  return titleString + yearString + creators + url + licenseString;
 };
 
 export const webpageReferenceApa7CopyString = (

--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -161,9 +161,9 @@ export const getYearDurationString = (
   return `(${start}-${end}). `;
 };
 
-const getLicenseString = (license: string | undefined, locale: string) => {
+export const getLicenseString = (license: string | undefined, locale: string) => {
   if (license === 'PD') {
-    return;
+    return '';
   }
 
   const licenseAbbreviation = license && getLicenseByAbbreviation(license, locale).abbreviation;
@@ -172,7 +172,7 @@ const getLicenseString = (license: string | undefined, locale: string) => {
     return `${licenseAbbreviation} 4.0`;
   }
 
-  return licenseAbbreviation;
+  return licenseAbbreviation ?? '';
 };
 
 export const figureApa7CopyString = (


### PR DESCRIPTION
Lisens i copystring for figur skal ikke vises når den er PD (markert for fri gjenbruk). Tilsvarende skal N/A-lisens også skjules.

Fikser samtidig en feil der lisens kunne bli "undefined" dersom lisens ikke finnes.