### PR TITLE
Support messageboxes in masthead.

### DIFF
--- a/packages/core/scss/global/objects/objects.content.scss
+++ b/packages/core/scss/global/objects/objects.content.scss
@@ -2,8 +2,6 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-
   &--background {
     background-color: $brand-grey--lightest;
   }

--- a/packages/core/scss/global/utilities/utilities.shame.scss
+++ b/packages/core/scss/global/utilities/utilities.shame.scss
@@ -6,7 +6,7 @@
 *
 */
 body {
-  overflow-x: hidden;
+  contain: paint;
   -webkit-overflow-scrolling: touch;
   input {
     appearance: none !important;

--- a/packages/core/scss/global/utilities/utilities.shame.scss
+++ b/packages/core/scss/global/utilities/utilities.shame.scss
@@ -6,8 +6,6 @@
 *
 */
 body {
-  contain: paint;
-  -webkit-overflow-scrolling: touch;
   input {
     appearance: none !important;
     -webkit-appearance: none !important;

--- a/packages/designmanual/stories/collated-components.jsx
+++ b/packages/designmanual/stories/collated-components.jsx
@@ -384,7 +384,7 @@ storiesOf('Sammensatte moduler', module)
   ))
   .add('Hovedhode med meldingsboks', () => (
     <div>
-      <MastheadWithTopicMenu showInfoboxes={true} />
+      <MastheadWithTopicMenu showMessageboxes={true} />
     </div>
   ))
   .add('Lisensikoner', () => (

--- a/packages/designmanual/stories/collated-components.jsx
+++ b/packages/designmanual/stories/collated-components.jsx
@@ -382,6 +382,11 @@ storiesOf('Sammensatte moduler', module)
       <MastheadWithTopicMenu />
     </div>
   ))
+  .add('Hovedhode med meldingsboks', () => (
+    <div>
+      <MastheadWithTopicMenu showInfoboxes={true} />
+    </div>
+  ))
   .add('Lisensikoner', () => (
     <Center>
       <LayoutItem layout="center">

--- a/packages/designmanual/stories/molecules/MessageBoxTabs.jsx
+++ b/packages/designmanual/stories/molecules/MessageBoxTabs.jsx
@@ -147,9 +147,8 @@ const MessageBoxTabs = () => {
             title: 'Fagforside',
             content: (
               <Wrapper>
+                <MastheadWithTopicMenu />
                 <Content>
-                  <MastheadWithTopicMenu />
-
                   <SubjectPage
                     topics={topics}
                     messagebox={'Dette emnet hører til et fag som ikke er oppdatert etter gjeldende læreplan.'} //pass this prop to display a messagebox

--- a/packages/designmanual/stories/molecules/mastheads.jsx
+++ b/packages/designmanual/stories/molecules/mastheads.jsx
@@ -25,6 +25,9 @@ import {
   SearchFieldForm,
   BreadcrumbBlock,
   MastheadAuthModal,
+  messagesNB,
+  MessageBox,
+  MessageBoxType,
 } from '@ndla/ui';
 import Modal from '@ndla/modal';
 import SafeLink from '@ndla/safelink';
@@ -39,6 +42,14 @@ export const MastheadWithLogo = ({ skipToMainContentId }) => (
     </MastheadItem>
   </Masthead>
 );
+
+const InfoBoxes = () => {
+  return (
+    <MessageBox type={MessageBoxType.fullpage} showCloseButton>
+      {messagesNB.messageBoxInfo.updateBrowser}
+    </MessageBox>
+  );
+};
 
 class MastheadWithTopicMenu extends Component {
   constructor(props) {
@@ -129,6 +140,7 @@ class MastheadWithTopicMenu extends Component {
       breadcrumbItems,
       isAuthed,
       menuProps,
+      showInfoboxes,
       t,
       i18n,
     } = this.props;
@@ -171,7 +183,8 @@ class MastheadWithTopicMenu extends Component {
         fixed
         skipToMainContentId={skipToMainContentId}
         ndlaFilm={ndlaFilm}
-        infoContent={beta && betaInfoContent}>
+        infoContent={beta && betaInfoContent}
+        infoBoxes={showInfoboxes && <InfoBoxes />}>
         <MastheadItem left>
           {!hideMenuButton && (
             <Modal
@@ -292,6 +305,7 @@ MastheadWithTopicMenu.propTypes = {
     hideSubject: PropTypes.bool,
     hideCurrentProgramme: PropTypes.bool,
   }),
+  showInfoboxes: PropTypes.bool,
 };
 
 MastheadWithTopicMenu.defaultProps = {

--- a/packages/designmanual/stories/molecules/mastheads.jsx
+++ b/packages/designmanual/stories/molecules/mastheads.jsx
@@ -45,7 +45,7 @@ export const MastheadWithLogo = ({ skipToMainContentId }) => (
 
 const Messageboxes = () => {
   return (
-    <MessageBox type={MessageBoxType.fullpage} showCloseButton>
+    <MessageBox type={MessageBoxType.masthead} showCloseButton>
       {messagesNB.messageBoxInfo.updateBrowser}
     </MessageBox>
   );

--- a/packages/designmanual/stories/molecules/mastheads.jsx
+++ b/packages/designmanual/stories/molecules/mastheads.jsx
@@ -43,7 +43,7 @@ export const MastheadWithLogo = ({ skipToMainContentId }) => (
   </Masthead>
 );
 
-const InfoBoxes = () => {
+const Messageboxes = () => {
   return (
     <MessageBox type={MessageBoxType.fullpage} showCloseButton>
       {messagesNB.messageBoxInfo.updateBrowser}
@@ -140,7 +140,7 @@ class MastheadWithTopicMenu extends Component {
       breadcrumbItems,
       isAuthed,
       menuProps,
-      showInfoboxes,
+      showMessageboxes,
       t,
       i18n,
     } = this.props;
@@ -184,7 +184,7 @@ class MastheadWithTopicMenu extends Component {
         skipToMainContentId={skipToMainContentId}
         ndlaFilm={ndlaFilm}
         infoContent={beta && betaInfoContent}
-        infoBoxes={showInfoboxes && <InfoBoxes />}>
+        messageboxes={showMessageboxes && <Messageboxes />}>
         <MastheadItem left>
           {!hideMenuButton && (
             <Modal
@@ -305,7 +305,7 @@ MastheadWithTopicMenu.propTypes = {
     hideSubject: PropTypes.bool,
     hideCurrentProgramme: PropTypes.bool,
   }),
-  showInfoboxes: PropTypes.bool,
+  showMEssageboxes: PropTypes.bool,
 };
 
 MastheadWithTopicMenu.defaultProps = {

--- a/packages/designmanual/stories/molecules/mastheads.jsx
+++ b/packages/designmanual/stories/molecules/mastheads.jsx
@@ -305,7 +305,7 @@ MastheadWithTopicMenu.propTypes = {
     hideSubject: PropTypes.bool,
     hideCurrentProgramme: PropTypes.bool,
   }),
-  showMEssageboxes: PropTypes.bool,
+  showMessageboxes: PropTypes.bool,
 };
 
 MastheadWithTopicMenu.defaultProps = {

--- a/packages/ndla-ui/src/Masthead/Masthead.tsx
+++ b/packages/ndla-ui/src/Masthead/Masthead.tsx
@@ -46,7 +46,7 @@ interface Props {
   infoContent?: ReactNode;
   ndlaFilm?: boolean;
   skipToMainContentId?: string;
-  infoBoxes?: ReactNode;
+  messageBoxes?: ReactNode;
 }
 
 export const Masthead = ({
@@ -56,7 +56,7 @@ export const Masthead = ({
   showLoaderWhenNeeded = true,
   ndlaFilm,
   skipToMainContentId,
-  infoBoxes,
+  messageBoxes,
   t,
 }: Props & WithTranslation) => (
   <>
@@ -74,7 +74,7 @@ export const Masthead = ({
         </DisplayOnPageYOffset>
       )}
       <div className={`u-1/1 ${classes('content').className}`}>{children}</div>
-      {infoBoxes}
+      {messageBoxes}
     </div>
   </>
 );

--- a/packages/ndla-ui/src/Masthead/Masthead.tsx
+++ b/packages/ndla-ui/src/Masthead/Masthead.tsx
@@ -46,7 +46,7 @@ interface Props {
   infoContent?: ReactNode;
   ndlaFilm?: boolean;
   skipToMainContentId?: string;
-  messageBoxes?: ReactNode;
+  messageboxes?: ReactNode;
 }
 
 export const Masthead = ({
@@ -56,7 +56,7 @@ export const Masthead = ({
   showLoaderWhenNeeded = true,
   ndlaFilm,
   skipToMainContentId,
-  messageBoxes,
+  messageboxes,
   t,
 }: Props & WithTranslation) => (
   <>
@@ -74,7 +74,7 @@ export const Masthead = ({
         </DisplayOnPageYOffset>
       )}
       <div className={`u-1/1 ${classes('content').className}`}>{children}</div>
-      {messageBoxes}
+      {messageboxes}
     </div>
   </>
 );

--- a/packages/ndla-ui/src/Masthead/Masthead.tsx
+++ b/packages/ndla-ui/src/Masthead/Masthead.tsx
@@ -46,6 +46,7 @@ interface Props {
   infoContent?: ReactNode;
   ndlaFilm?: boolean;
   skipToMainContentId?: string;
+  infoBoxes?: ReactNode;
 }
 
 export const Masthead = ({
@@ -55,6 +56,7 @@ export const Masthead = ({
   showLoaderWhenNeeded = true,
   ndlaFilm,
   skipToMainContentId,
+  infoBoxes,
   t,
 }: Props & WithTranslation) => (
   <>
@@ -63,14 +65,16 @@ export const Masthead = ({
         {t('masthead.skipToContent')}
       </a>
     )}
-    <div {...classes('placeholder', { infoContent: !!infoContent })} />
-    <div {...classes('', { fixed: !!fixed, infoContent: !!infoContent, showLoaderWhenNeeded, ndlaFilm: !!ndlaFilm })}>
+    <div
+      id="masthead"
+      {...classes('', { fixed: !!fixed, infoContent: !!infoContent, showLoaderWhenNeeded, ndlaFilm: !!ndlaFilm })}>
       {infoContent && (
         <DisplayOnPageYOffset yOffsetMin={0} yOffsetMax={90}>
           <MastheadInfo>{infoContent}</MastheadInfo>
         </DisplayOnPageYOffset>
       )}
       <div className={`u-1/1 ${classes('content').className}`}>{children}</div>
+      {infoBoxes}
     </div>
   </>
 );

--- a/packages/ndla-ui/src/Masthead/Masthead.tsx
+++ b/packages/ndla-ui/src/Masthead/Masthead.tsx
@@ -67,7 +67,12 @@ export const Masthead = ({
     )}
     <div
       id="masthead"
-      {...classes('', { fixed: !!fixed, infoContent: !!infoContent, showLoaderWhenNeeded, ndlaFilm: !!ndlaFilm })}>
+      {...classes('', {
+        fixed: !!fixed,
+        infoContent: !!infoContent,
+        showLoaderWhenNeeded,
+        ndlaFilm: !!ndlaFilm,
+      })}>
       {infoContent && (
         <DisplayOnPageYOffset yOffsetMin={0} yOffsetMax={90}>
           <MastheadInfo>{infoContent}</MastheadInfo>

--- a/packages/ndla-ui/src/Masthead/component.masthead.scss
+++ b/packages/ndla-ui/src/Masthead/component.masthead.scss
@@ -50,16 +50,17 @@
       &:after {
         content: '';
         display: block;
-        height: 100vh;
-        width: 100vw;
+        height: calc(100vh - 84px);
+        width: 100%;
         background-color: #f9f9f9;
       }
       &:before {
         content: '';
         position: absolute;
+        padding-top: $masthead-height;
         display: block;
-        height: 100vh;
-        width: 100vw;
+        height: calc(100vh - 84px);
+        width: 100%;
         background-position-x: center;
         background-position-y: 65px;
         background-repeat: no-repeat;

--- a/packages/ndla-ui/src/Masthead/component.masthead.scss
+++ b/packages/ndla-ui/src/Masthead/component.masthead.scss
@@ -16,7 +16,8 @@
     height: 1px;
     overflow: hidden;
     z-index: -999;
-    &:focus, &:active {
+    &:focus,
+    &:active {
       color: #fff;
       background: $brand-color;
       left: auto;
@@ -38,9 +39,7 @@
 
   &--fixed {
     top: 0;
-    left: 0;
-    right: 0;
-    position: fixed;
+    position: sticky;
     @media print {
       position: relative;
     }
@@ -107,14 +106,6 @@
     .c-breadcrumb-block__item span,
     .c-breadcrumb-block__item .c-icon {
       color: #fff;
-    }
-  }
-
-  &__placeholder {
-    min-height: $masthead-height;
-    width: 100%;
-    @media print {
-      min-height: revert;
     }
   }
 

--- a/packages/ndla-ui/src/Masthead/index.ts
+++ b/packages/ndla-ui/src/Masthead/index.ts
@@ -7,7 +7,8 @@
  */
 
 import Masthead, { MastheadItem } from './Masthead';
+import { getMastheadHeight } from './utils';
 
-export { MastheadItem };
+export { MastheadItem, getMastheadHeight };
 
 export default Masthead;

--- a/packages/ndla-ui/src/Masthead/utils.ts
+++ b/packages/ndla-ui/src/Masthead/utils.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export const getMastheadHeight = (): number | undefined => {
+  const masthead = document.getElementById('masthead');
+  return masthead?.getBoundingClientRect().height;
+};

--- a/packages/ndla-ui/src/MessageBox/MessageBox.tsx
+++ b/packages/ndla-ui/src/MessageBox/MessageBox.tsx
@@ -18,6 +18,7 @@ export enum MessageBoxType {
   ghost = 'ghost',
   fullpage = 'fullpage',
   medium = 'medium',
+  masthead = 'masthead',
 }
 type WrapperProps = {
   boxType?: MessageBoxType;
@@ -51,7 +52,9 @@ const StyleByType = (type: WrapperProps['boxType']) => {
       styles.backgroundColor = 'transparent';
       styles.border = '1px solid #D1D6DB';
       styles.color = '#444444';
-
+      break;
+    case 'masthead':
+      styles.display = 'none';
       break;
   }
   return styles;

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -32,7 +32,7 @@ export { createUniversalPortal } from './utils/createUniversalPortal';
 
 export { default as NoContentBox } from './NoContentBox';
 
-export { default as Masthead, MastheadItem } from './Masthead';
+export { default as Masthead, MastheadItem, getMastheadHeight } from './Masthead';
 
 export { default as Portrait } from './Portrait';
 


### PR DESCRIPTION
Relatert til NDLANO/Issues#3023

Har gjort følgende endringer:
- Lagt til støtte for infoBoxes i Masthead.
- Skrevet om Masthead til å være sticky framfor fixed. Da trenger vi ikke lenger et placeholder-element bak masthead for å dytte sideinnholdet ned.
- Lagt til en enkel util-funksjon for å regne ut høyde på masthead.
- Nytt eksempel i designmanual: Hovedhoved med meldingsboks.

Omskriving til sticky skapte noen problemer, spesielt relatert til `overflow: hidden` som var brukt flere steder og var nødvendig for at siden ikke fikk hvit marg på høyre side i visse tilfeller. Dessverre brekker `overflow: hidden` bruk av sticky elementer. Løsningen ble den nyoppdagede `contain: paint` som gjør mye av det samme, uten sideeffektene til overflow og den effektiviserer rendering også.