### PR TITLE
Removed overflow: hidden in order to show focus border when navigating with tab

### DIFF
--- a/packages/ndla-ui/src/SearchTypeResult/SearchItem.tsx
+++ b/packages/ndla-ui/src/SearchTypeResult/SearchItem.tsx
@@ -56,7 +56,6 @@ const Container = styled.div`
 
 const ItemWrapper = styled.div`
   flex-direction: column;
-  overflow: hidden;
   display: flex;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
Kan testes ved å navigere eksempelet med tab-knappen og sjekke at alt fokuseres riktig.