### PR TITLE
Create useMastheadHeight hook. Add variable height to Breadcrumblist

### DIFF
--- a/packages/ndla-ui/src/Breadcrumblist/Breadcrumblist.tsx
+++ b/packages/ndla-ui/src/Breadcrumblist/Breadcrumblist.tsx
@@ -19,12 +19,14 @@ import {
 import SafeLink from '@ndla/safelink';
 import { useTranslation } from 'react-i18next';
 import MessageBoxTag from '../MessageBox/MessageBoxTag';
+import { useMastheadHeight } from '../Masthead';
 
 type WrapperProps = {
   startOffset?: number;
   isVisible?: boolean;
   leftAlign?: boolean;
   hideOnNarrow?: boolean;
+  mastheadHeight?: number;
 };
 
 type InvertItProps = {
@@ -46,11 +48,11 @@ const Wrapper = styled.div<WrapperProps>`
     width: 240px;
     position: fixed;
     left: 22px;
-    top: 85px;
+    top: ${(props) => props.mastheadHeight || 85}px;
     ${(props) =>
       props.startOffset &&
       `
-        top: calc(${props.startOffset}px + 85px); 
+        top: calc(${props.startOffset}px + ${props.mastheadHeight || 85}px); 
     `}
   }
   ${mq.range({ from: breakpoints.wide })} {
@@ -230,6 +232,8 @@ const Breadcrumblist = ({
   const [wrapperOffset, setWrapperOffset] = useState(startOffset);
   const [useScrollEvent, setUseScrollEvent] = useState(false);
 
+  const { height: mastheadHeight } = useMastheadHeight();
+
   useEffect(() => {
     const handleScroll = () => {
       let position = 0;
@@ -270,7 +274,12 @@ const Breadcrumblist = ({
 
   return (
     <>
-      <Wrapper leftAlign={leftAlign} startOffset={wrapperOffset} hideOnNarrow={hideOnNarrow} isVisible={isVisible}>
+      <Wrapper
+        leftAlign={leftAlign}
+        startOffset={wrapperOffset}
+        hideOnNarrow={hideOnNarrow}
+        isVisible={isVisible}
+        mastheadHeight={mastheadHeight}>
         {items.length > 0 && (
           <>
             <Heading invertedStyle={invertedStyle}>{t('breadcrumb.youAreHere')}</Heading>

--- a/packages/ndla-ui/src/Masthead/index.ts
+++ b/packages/ndla-ui/src/Masthead/index.ts
@@ -8,8 +8,8 @@
 
 import Masthead, { MastheadItem } from './Masthead';
 
-import { getMastheadHeight } from './utils';
+import { getMastheadHeight, useMastheadHeight } from './utils';
 
-export { MastheadItem, getMastheadHeight };
+export { MastheadItem, getMastheadHeight, useMastheadHeight };
 
 export default Masthead;

--- a/packages/ndla-ui/src/Masthead/utils.ts
+++ b/packages/ndla-ui/src/Masthead/utils.ts
@@ -6,7 +6,28 @@
  *
  */
 
+import { useState } from 'react';
+import { resizeObserver } from '@ndla/util';
+
 export const getMastheadHeight = (): number | undefined => {
   const masthead = document.getElementById('masthead');
   return masthead?.getBoundingClientRect().height;
+};
+
+export const useMastheadHeight = () => {
+  const [height, setHeight] = useState<number>();
+  const masthead = document.getElementById('masthead');
+
+  const handleHeightChange = (el: HTMLElement) => {
+    const newHeight = el.getBoundingClientRect().height;
+    setHeight(newHeight);
+  };
+
+  if (masthead) {
+    resizeObserver(masthead, handleHeightChange);
+  }
+
+  return {
+    height,
+  };
 };

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -32,7 +32,7 @@ export { createUniversalPortal } from './utils/createUniversalPortal';
 
 export { default as NoContentBox } from './NoContentBox';
 
-export { default as Masthead, MastheadItem, getMastheadHeight } from './Masthead';
+export { default as Masthead, MastheadItem, getMastheadHeight, useMastheadHeight } from './Masthead';
 
 export { default as Portrait } from './Portrait';
 

--- a/packages/util/src/resizeObserver.ts
+++ b/packages/util/src/resizeObserver.ts
@@ -33,12 +33,12 @@ function fallbackResizeObserver(element: HTMLElement, handler: (el: HTMLElement)
 
 function resizeObserverWrapper(element: HTMLElement, handler: (el: HTMLElement) => void): () => void {
   // @ts-ignore ResizeObserver
-  let resizeObserver = new ResizeObserver(() => {
+  let resizeObserver: ResizeObserver | null = new ResizeObserver(() => {
     handler(element);
   });
   resizeObserver.observe(element);
   return () => {
-    resizeObserver.disconnect(element);
+    resizeObserver?.disconnect();
     resizeObserver = null;
   };
 }


### PR DESCRIPTION
Breadcrumblist ble plassert med en statisk avstand på 85px fra top for å kompensere for masthead. Nå som Masthead har variabel høyde har jeg implementert en hook som returnerer høyden på masthead og oppdateres hver gang den endrer seg.

Hvordan teste:
1. Kjør opp ndla-frontend med ndla-ui linket inn. `ndla link ndla-frontend -l ndla-ui`
2. Gå inn på feks http://localhost:3000/subject:1:19dae192-699d-488f-8218-d81535ce3ae3/topic:2:55163 og sjekk at Breadcrumblist plasseres riktig både med og uten banner.