### PR TITLE
3023 masthead fixes

### DIFF
--- a/packages/core/scss/global/utilities/utilities.shame.scss
+++ b/packages/core/scss/global/utilities/utilities.shame.scss
@@ -13,6 +13,11 @@ body {
   }
 }
 
+// Overflow hidden from reach/dialog and react-remove-scroll causes issues with sticky masthead
+html body {
+  overflow: visible !important;
+}
+
 /* IE-10+ fix for footer */
 html.ie #root {
   height: 100%;

--- a/packages/ndla-ui/src/MessageBox/MessageBox.tsx
+++ b/packages/ndla-ui/src/MessageBox/MessageBox.tsx
@@ -33,6 +33,7 @@ const StyleByType = (type: WrapperProps['boxType']) => {
     display: 'flex',
     padding: '10px',
     width: 'auto',
+    borderRadius: '5px',
     position: 'relative',
     transform: 'auto',
     left: 'auto',
@@ -58,6 +59,7 @@ const StyleByType = (type: WrapperProps['boxType']) => {
       styles.margin = '0 auto';
       styles.display = 'none';
       styles.padding = '0';
+      styles.borderRadius = '0';
       break;
   }
   return styles;
@@ -73,7 +75,7 @@ const Wrapper = styled.div<WrapperProps>`
   padding: ${spacing.small};
   position: ${(props) => StyleByType(props.boxType).position};
   border: ${(props) => StyleByType(props.boxType).border};
-  border-radius: 5px;
+  border-radius: ${(props) => StyleByType(props.boxType).borderRadius};
   transform: ${(props) => StyleByType(props.boxType).transform};
   left: ${(props) => StyleByType(props.boxType).left};
   z-index: 10;

--- a/packages/ndla-ui/src/MessageBox/MessageBox.tsx
+++ b/packages/ndla-ui/src/MessageBox/MessageBox.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { useState } from 'react';
+import React, { HTMLAttributes, useState } from 'react';
 import styled from '@emotion/styled';
 import Sticky from 'react-sticky-el';
 import { breakpoints, fonts, mq, spacing } from '@ndla/core';
@@ -25,12 +25,13 @@ type WrapperProps = {
 };
 
 const StyleByType = (type: WrapperProps['boxType']) => {
-  const styles = {
+  const styles: HTMLAttributes<HTMLElement>['style'] = {
     margin: '1px',
     color: '#444444',
     backgroundColor: '#f9f4c8',
     border: 'none',
     display: 'flex',
+    padding: '10px',
     width: 'auto',
     position: 'relative',
     transform: 'auto',
@@ -56,6 +57,7 @@ const StyleByType = (type: WrapperProps['boxType']) => {
     case 'masthead':
       styles.margin = '0 auto';
       styles.display = 'none';
+      styles.padding = '0';
       break;
   }
   return styles;
@@ -80,7 +82,7 @@ const Wrapper = styled.div<WrapperProps>`
 
 const InfoWrapper = styled.div<WrapperProps>`
   margin: ${(props) => StyleByType(props.boxType).margin};
-  padding: 10px;
+  padding: ${(props) => StyleByType(props.boxType).padding};
   display: flex;
   ${mq.range({ until: breakpoints.tabletWide })} {
     padding: 0 90px 0 0;

--- a/packages/ndla-ui/src/TopicMenu/TopicMenu.jsx
+++ b/packages/ndla-ui/src/TopicMenu/TopicMenu.jsx
@@ -28,6 +28,7 @@ import Logo from '../Logo';
 import FrontpageAllSubjects from '../Frontpage/FrontpageAllSubjects';
 import NavigationBox from '../Navigation/NavigationBox';
 import { ProgrammeSubjects } from '../Programme';
+import { MessageBox, MessageBoxType } from '../MessageBox';
 
 const classes = new BEMHelper({
   name: 'topic-menu',
@@ -72,6 +73,7 @@ export const TopicMenu = ({
   programmes,
   currentProgramme,
   initialSelectedMenu,
+  messages,
 }) => {
   const { t } = useTranslation();
   const [isNarrowScreen, setIsNarrowScreen] = useState(false);
@@ -148,6 +150,9 @@ export const TopicMenu = ({
 
   return (
     <nav>
+      {messages?.map((message) => (
+        <MessageBox type={MessageBoxType.masthead}>{message}</MessageBox>
+      ))}
       <ModalHeader modifier={['white', 'menu']}>
         <div {...classes('masthead-left')}>
           <button type="button" {...classes('close-button')} onClick={closeMenu}>


### PR DESCRIPTION
Fikser litt diverse på masthead:
- Dialog skapte noen problemer da den innfører scroll-lock på body ved åpning av modal. Det førte til at sticky posisjonering av masthead ikke fungerte og det medførte igjen til lite jevn animasjon ut og inn av menyen. Gjør derfor en overstyring av overflow på body som løser problemet. Har ikke sett noen andre sideeffekter av dette så langt.
- Messagebox i masthead er nå uten border-radius og padding.
- Har lagt til støtte for messageboxes i TopicMenu (nødvendig for at meldingsbokser skal vises der også)