### PR TITLE
Set ConceptNotion text width to 100% if no visual element or image

### DIFF
--- a/packages/ndla-ui/src/Notion/Notion.tsx
+++ b/packages/ndla-ui/src/Notion/Notion.tsx
@@ -42,8 +42,8 @@ const ContentWrapper = styled.div`
     }
   }
 `;
-const TextWrapper = styled.div`
-  width: 75%;
+const TextWrapper = styled.div<{ hasVisualElement: boolean }>`
+  width: ${(props) => (props.hasVisualElement ? '75%' : '100%')};
   ${mq.range({ until: breakpoints.tabletWide })} {
     width: 100%;
   }
@@ -223,7 +223,7 @@ const Notion = ({
             </ExpandVisualElementButton>
           </ImageWrapper>
         )}
-        <TextWrapper>
+        <TextWrapper hasVisualElement={!!(imageElement || visualElement?.metaImage)}>
           {HTMLReactParser(
             renderMarkdown ? renderMarkdown(`**${title}** \u2013 ${text}`) : `<b>${title}</b> \u2013 ${text}`,
           )}


### PR DESCRIPTION
En feil som Gunnar påpekte. Teksten i ConceptNotion burde dekke hele bredden av boksen dersom det ikke finnes noe visuelt element.