### PR TITLE
Add Concept and ConceptList howtos

### DIFF
--- a/packages/designmanual/stories/produksjonssystem/SlateBlockMenuExample.jsx
+++ b/packages/designmanual/stories/produksjonssystem/SlateBlockMenuExample.jsx
@@ -17,6 +17,7 @@ import {
   Keyhole,
   Code,
   Concept,
+  ListCircle,
 } from '@ndla/icons/editor';
 import { ArticleInModal } from '@ndla/howto';
 import { VolumeUp, Download, InformationOutline } from '@ndla/icons/common';
@@ -128,6 +129,12 @@ const actions = [
     label: 'Forklaring',
     icon: <Concept />,
     helpIcon: renderArticleInModal('Concept'),
+  },
+  {
+    data: { type: 'concept-list', object: 'conceptList' },
+    label: 'Forklaringsliste',
+    icon: <ListCircle />,
+    helpIcon: renderArticleInModal('ConceptList'),
   },
 ];
 

--- a/packages/designmanual/stories/produksjonssystem/SlateBlockMenuExample.jsx
+++ b/packages/designmanual/stories/produksjonssystem/SlateBlockMenuExample.jsx
@@ -16,6 +16,7 @@ import {
   RelatedArticle,
   Keyhole,
   Code,
+  Concept,
 } from '@ndla/icons/editor';
 import { ArticleInModal } from '@ndla/howto';
 import { VolumeUp, Download, InformationOutline } from '@ndla/icons/common';
@@ -121,6 +122,12 @@ const actions = [
     label: 'Kodeblokk',
     icon: <Code />,
     helpIcon: renderArticleInModal('CodeBlock'),
+  },
+  {
+    data: { type: 'concept', object: 'concept' },
+    label: 'Forklaring',
+    icon: <Concept />,
+    helpIcon: renderArticleInModal('Concept'),
   },
 ];
 

--- a/packages/ndla-howto/src/StaticInfoComponents/index.ts
+++ b/packages/ndla-howto/src/StaticInfoComponents/index.ts
@@ -287,7 +287,7 @@ export const stories: Record<string, Story> = {
     body: [
       {
         type: 'text',
-        content: 'Legg til en liste av forklaringer i artikkel. Velges basert på tags.',
+        content: 'Legg til en liste av forklaringer i artikkel.',
       },
     ],
   },

--- a/packages/ndla-howto/src/StaticInfoComponents/index.ts
+++ b/packages/ndla-howto/src/StaticInfoComponents/index.ts
@@ -271,4 +271,24 @@ export const stories: Record<string, Story> = {
       },
     ],
   },
+  Concept: {
+    title: 'Forklaring',
+    lead: 'Legg til forklaring.',
+    body: [
+      {
+        type: 'text',
+        content: 'Søk opp og legg til forklaring i artikkel.',
+      },
+    ],
+  },
+  ConceptList: {
+    title: 'Forklaringsliste',
+    lead: 'Legg til forklaringsliste.',
+    body: [
+      {
+        type: 'text',
+        content: 'Legg til en liste av forklaringer i artikkel. Velges basert på tags.',
+      },
+    ],
+  },
 };


### PR DESCRIPTION
Legger til howtos for forklaring og liste av forklaringer.

Disse kan testes i plussmeny på /?path=/story/produksjonssystem--how-to