### PR TITLE
3037 extended alert functionality

### DIFF
--- a/packages/ndla-howto/package.json
+++ b/packages/ndla-howto/package.json
@@ -32,7 +32,7 @@
     "@ndla/modal": "^1.2.3",
     "@ndla/tooltip": "^0.3.3",
     "@ndla/ui": "^6.2.1",
-    "remarkable": "^2.0.0"
+    "remarkable": "^2.0.1"
   },
   "peerDependencies": {
     "@emotion/core": "^10.0.9",

--- a/packages/ndla-ui/package.json
+++ b/packages/ndla-ui/package.json
@@ -73,7 +73,6 @@
     "@types/reach__dialog": "^0.1.0",
     "@types/react-sticky-el": "^1.0.2",
     "@types/react-transition-group": "^4.4.2",
-    "@types/remarkable": "^2.0.3",
     "css-loader": "^2.1.0",
     "mini-css-extract-plugin": "^0.5.0",
     "sass-loader": "^7.1.0",

--- a/packages/ndla-ui/package.json
+++ b/packages/ndla-ui/package.json
@@ -57,7 +57,8 @@
     "react-sticky-el": "^2.0.6",
     "react-swipeable": "^6.2.0",
     "react-transition-group": "^2.5.3",
-    "shave": "^2.5.10"
+    "shave": "^2.5.10",
+    "remarkable": "^2.0.1"
   },
   "peerDependencies": {
     "@emotion/core": "^10.0.9",
@@ -72,6 +73,7 @@
     "@types/reach__dialog": "^0.1.0",
     "@types/react-sticky-el": "^1.0.2",
     "@types/react-transition-group": "^4.4.2",
+    "@types/remarkable": "^2.0.3",
     "css-loader": "^2.1.0",
     "mini-css-extract-plugin": "^0.5.0",
     "sass-loader": "^7.1.0",

--- a/packages/ndla-ui/src/Masthead/Masthead.tsx
+++ b/packages/ndla-ui/src/Masthead/Masthead.tsx
@@ -9,6 +9,7 @@
 import React, { ReactNode, useEffect, useRef } from 'react';
 import BEMHelper from 'react-bem-helper';
 import { WithTranslation, withTranslation } from 'react-i18next';
+import { Remarkable } from 'remarkable';
 import { DisplayOnPageYOffset } from '../Animation';
 import { MessageBox, MessageBoxType } from '../MessageBox';
 
@@ -56,6 +57,10 @@ interface Props {
   onCloseAlert?: (id: number) => void;
 }
 
+const markdown = new Remarkable({ breaks: true });
+markdown.inline.ruler.enable(['sub', 'sup']);
+markdown.block.ruler.disable(['list', 'table']);
+
 export const Masthead = ({
   children,
   fixed,
@@ -98,7 +103,8 @@ export const Masthead = ({
           <MessageBox
             type={MessageBoxType.masthead}
             showCloseButton={message.closable}
-            onClose={() => onCloseAlert && onCloseAlert(message.number)}>
+            onClose={() => onCloseAlert && onCloseAlert(message.number)}
+            renderMarkdown={(content) => markdown.render(content)}>
             {message.content}
           </MessageBox>
         ))}

--- a/packages/ndla-ui/src/Masthead/Masthead.tsx
+++ b/packages/ndla-ui/src/Masthead/Masthead.tsx
@@ -43,6 +43,7 @@ const MastheadInfo = ({ children }: MastheadInfoProps) => (
 interface Alert {
   content: string;
   closable?: boolean;
+  number: number;
 }
 
 interface Props {
@@ -52,6 +53,7 @@ interface Props {
   ndlaFilm?: boolean;
   skipToMainContentId?: string;
   messages?: Alert[];
+  onCloseAlert?: (id: number) => void;
 }
 
 export const Masthead = ({
@@ -61,6 +63,7 @@ export const Masthead = ({
   ndlaFilm,
   skipToMainContentId,
   messages,
+  onCloseAlert,
   t,
 }: Props & WithTranslation) => {
   const mastheadRef = useRef<HTMLDivElement>(null);
@@ -92,7 +95,10 @@ export const Masthead = ({
       )}
       <div id="masthead" {...classes('', { fixed: !!fixed, infoContent: !!infoContent, ndlaFilm: !!ndlaFilm })}>
         {messages?.map((message) => (
-          <MessageBox type={MessageBoxType.masthead} showCloseButton={message.closable}>
+          <MessageBox
+            type={MessageBoxType.masthead}
+            showCloseButton={message.closable}
+            onClose={() => onCloseAlert && onCloseAlert(message.number)}>
             {message.content}
           </MessageBox>
         ))}

--- a/packages/ndla-ui/src/Masthead/Masthead.tsx
+++ b/packages/ndla-ui/src/Masthead/Masthead.tsx
@@ -40,13 +40,18 @@ const MastheadInfo = ({ children }: MastheadInfoProps) => (
   </div>
 );
 
+interface Alert {
+  content: string;
+  closable?: boolean;
+}
+
 interface Props {
   children?: ReactNode;
   fixed?: boolean;
   infoContent?: ReactNode;
   ndlaFilm?: boolean;
   skipToMainContentId?: string;
-  messages?: string[];
+  messages?: Alert[];
 }
 
 export const Masthead = ({
@@ -87,7 +92,9 @@ export const Masthead = ({
       )}
       <div id="masthead" {...classes('', { fixed: !!fixed, infoContent: !!infoContent, ndlaFilm: !!ndlaFilm })}>
         {messages?.map((message) => (
-          <MessageBox type={MessageBoxType.masthead}>{message}</MessageBox>
+          <MessageBox type={MessageBoxType.masthead} showCloseButton={message.closable}>
+            {message.content}
+          </MessageBox>
         ))}
         {infoContent && (
           <DisplayOnPageYOffset yOffsetMin={0} yOffsetMax={90}>

--- a/packages/ndla-ui/src/Masthead/Masthead.tsx
+++ b/packages/ndla-ui/src/Masthead/Masthead.tsx
@@ -9,7 +9,6 @@
 import React, { ReactNode, useEffect, useRef } from 'react';
 import BEMHelper from 'react-bem-helper';
 import { WithTranslation, withTranslation } from 'react-i18next';
-import { Remarkable } from 'remarkable';
 import { DisplayOnPageYOffset } from '../Animation';
 import { MessageBox, MessageBoxType } from '../MessageBox';
 
@@ -57,10 +56,6 @@ interface Props {
   onCloseAlert?: (id: number) => void;
 }
 
-const markdown = new Remarkable({ breaks: true });
-markdown.inline.ruler.enable(['sub', 'sup']);
-markdown.block.ruler.disable(['list', 'table']);
-
 export const Masthead = ({
   children,
   fixed,
@@ -104,7 +99,7 @@ export const Masthead = ({
             type={MessageBoxType.masthead}
             showCloseButton={message.closable}
             onClose={() => onCloseAlert && onCloseAlert(message.number)}
-            renderMarkdown={(content) => markdown.render(content)}>
+            renderMarkdown={true}>
             {message.content}
           </MessageBox>
         ))}

--- a/packages/ndla-ui/src/Masthead/Masthead.tsx
+++ b/packages/ndla-ui/src/Masthead/Masthead.tsx
@@ -98,8 +98,7 @@ export const Masthead = ({
           <MessageBox
             type={MessageBoxType.masthead}
             showCloseButton={message.closable}
-            onClose={() => onCloseAlert && onCloseAlert(message.number)}
-            renderMarkdown={true}>
+            onClose={() => onCloseAlert?.(message.number)}>
             {message.content}
           </MessageBox>
         ))}

--- a/packages/ndla-ui/src/MessageBox/MessageBox.tsx
+++ b/packages/ndla-ui/src/MessageBox/MessageBox.tsx
@@ -152,12 +152,24 @@ type Props = {
   children?: string;
   links?: LinkProps[];
   showCloseButton?: boolean;
+  onClose?: () => void;
 };
 
-export const MessageBox = ({ type, sticky = false, children, links, t, showCloseButton }: Props & WithTranslation) => {
+export const MessageBox = ({
+  type,
+  sticky = false,
+  children,
+  links,
+  t,
+  showCloseButton,
+  onClose,
+}: Props & WithTranslation) => {
   const [hideMessageBox, setHideMessageBox] = useState(false);
   const onCloseMessageBox = () => {
     setHideMessageBox(true);
+    if (onClose) {
+      onClose();
+    }
   };
   const Icon = type === 'ghost' ? HumanMaleBoard : InformationOutline;
   return (

--- a/packages/ndla-ui/src/MessageBox/MessageBox.tsx
+++ b/packages/ndla-ui/src/MessageBox/MessageBox.tsx
@@ -102,6 +102,9 @@ const TextWrapper = styled.div<WrapperProps>`
     line-height: 24px;
     font-size: 16px;
   }
+  & p {
+    margin: 0;
+  }
 `;
 
 const IconWrapper = styled.div<WrapperProps>`
@@ -153,16 +156,18 @@ type Props = {
   links?: LinkProps[];
   showCloseButton?: boolean;
   onClose?: () => void;
+  renderMarkdown?: (text: string) => string;
 };
 
 export const MessageBox = ({
   type,
   sticky = false,
-  children,
+  children = '',
   links,
   t,
   showCloseButton,
   onClose,
+  renderMarkdown,
 }: Props & WithTranslation) => {
   const [hideMessageBox, setHideMessageBox] = useState(false);
   const onCloseMessageBox = () => {
@@ -180,7 +185,8 @@ export const MessageBox = ({
           <IconWrapper boxType={type}>
             <Icon style={{ width: '24px', height: '24px' }} />
           </IconWrapper>
-          <TextWrapper>{children}</TextWrapper>
+          <TextWrapper
+            dangerouslySetInnerHTML={{ __html: renderMarkdown ? renderMarkdown(children) : children }}></TextWrapper>
         </InfoWrapper>
         {showCloseButton && (
           <CloseButtonWrapper>

--- a/packages/ndla-ui/src/MessageBox/MessageBox.tsx
+++ b/packages/ndla-ui/src/MessageBox/MessageBox.tsx
@@ -12,6 +12,9 @@ import Sticky from 'react-sticky-el';
 import { breakpoints, fonts, mq, spacing } from '@ndla/core';
 import { InformationOutline, HumanMaleBoard } from '@ndla/icons/common';
 import { WithTranslation, withTranslation } from 'react-i18next';
+
+// @ts-ignore
+import { Remarkable } from 'remarkable';
 import { CloseButton } from '../CloseButton';
 
 export enum MessageBoxType {
@@ -45,6 +48,7 @@ const StyleByType = (type: WrapperProps['boxType']) => {
       styles.width = '100vw';
       styles.position = 'relative';
       styles.left = '50%';
+      styles.padding = '0';
       styles.transform = 'translateX(-50%)';
       break;
     case 'medium':
@@ -156,15 +160,18 @@ type Props = {
   links?: LinkProps[];
   showCloseButton?: boolean;
   onClose?: () => void;
-  renderMarkdown?: (text: string) => string;
+  renderMarkdown?: boolean;
 };
+
+const markdown = new Remarkable({ breaks: true });
+markdown.inline.ruler.enable(['sub', 'sup']);
+markdown.block.ruler.disable(['list', 'table']);
 
 export const MessageBox = ({
   type,
   sticky = false,
   children = '',
   links,
-  t,
   showCloseButton,
   onClose,
   renderMarkdown,
@@ -186,7 +193,7 @@ export const MessageBox = ({
             <Icon style={{ width: '24px', height: '24px' }} />
           </IconWrapper>
           <TextWrapper
-            dangerouslySetInnerHTML={{ __html: renderMarkdown ? renderMarkdown(children) : children }}></TextWrapper>
+            dangerouslySetInnerHTML={{ __html: renderMarkdown ? markdown.render(children) : children }}></TextWrapper>
         </InfoWrapper>
         {showCloseButton && (
           <CloseButtonWrapper>

--- a/packages/ndla-ui/src/MessageBox/MessageBox.tsx
+++ b/packages/ndla-ui/src/MessageBox/MessageBox.tsx
@@ -160,7 +160,6 @@ type Props = {
   links?: LinkProps[];
   showCloseButton?: boolean;
   onClose?: () => void;
-  renderMarkdown?: boolean;
 };
 
 const markdown = new Remarkable({ breaks: true });
@@ -174,14 +173,11 @@ export const MessageBox = ({
   links,
   showCloseButton,
   onClose,
-  renderMarkdown,
 }: Props & WithTranslation) => {
   const [hideMessageBox, setHideMessageBox] = useState(false);
   const onCloseMessageBox = () => {
     setHideMessageBox(true);
-    if (onClose) {
-      onClose();
-    }
+    onClose?.();
   };
   const Icon = type === 'ghost' ? HumanMaleBoard : InformationOutline;
   return (
@@ -192,8 +188,7 @@ export const MessageBox = ({
           <IconWrapper boxType={type}>
             <Icon style={{ width: '24px', height: '24px' }} />
           </IconWrapper>
-          <TextWrapper
-            dangerouslySetInnerHTML={{ __html: renderMarkdown ? markdown.render(children) : children }}></TextWrapper>
+          <TextWrapper dangerouslySetInnerHTML={{ __html: markdown.render(children) }}></TextWrapper>
         </InfoWrapper>
         {showCloseButton && (
           <CloseButtonWrapper>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4629,11 +4629,6 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/highlight.js@^9.7.0":
-  version "9.12.4"
-  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.4.tgz#8c3496bd1b50cc04aeefd691140aa571d4dbfa34"
-  integrity sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==
-
 "@types/history@*":
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.7.tgz#613957d900fab9ff84c8dfb24fa3eef0c2a40896"
@@ -4924,14 +4919,6 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
-
-"@types/remarkable@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@types/remarkable/-/remarkable-2.0.3.tgz#ba2e5edada8f0fe64c658beb2127e06ac0b9c1c8"
-  integrity sha512-QQUBeYApuHCNl9Br6ZoI3PlKmwZ69JHrlJktJXnjxobia9liZgsI70fm8PnCqVFAcefYK+9PGzR5L/hzCslNYQ==
-  dependencies:
-    "@types/highlight.js" "^9.7.0"
-    highlight.js "^9.7.0"
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -10688,11 +10675,6 @@ highlight.js@^10.4.1, highlight.js@~10.7.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
-highlight.js@^9.7.0:
-  version "9.18.5"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.5.tgz#d18a359867f378c138d6819edfc2a8acd5f29825"
-  integrity sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==
-
 history@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/history/-/history-5.0.0.tgz#0cabbb6c4bbf835addb874f8259f6d25101efd08"
@@ -15962,7 +15944,7 @@ remark-squeeze-paragraphs@4.0.0:
   dependencies:
     mdast-squeeze-paragraphs "^4.0.0"
 
-remarkable@^2.0.0, remarkable@^2.0.1:
+remarkable@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/remarkable/-/remarkable-2.0.1.tgz#280ae6627384dfb13d98ee3995627ca550a12f31"
   integrity sha512-YJyMcOH5lrR+kZdmB0aJJ4+93bEojRZ1HGDn9Eagu6ibg7aVZhc3OWbbShRid+Q5eAfsEqWxpe+g5W5nYNfNiA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4629,6 +4629,11 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/highlight.js@^9.7.0":
+  version "9.12.4"
+  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.4.tgz#8c3496bd1b50cc04aeefd691140aa571d4dbfa34"
+  integrity sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==
+
 "@types/history@*":
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.7.tgz#613957d900fab9ff84c8dfb24fa3eef0c2a40896"
@@ -4919,6 +4924,14 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
+
+"@types/remarkable@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/remarkable/-/remarkable-2.0.3.tgz#ba2e5edada8f0fe64c658beb2127e06ac0b9c1c8"
+  integrity sha512-QQUBeYApuHCNl9Br6ZoI3PlKmwZ69JHrlJktJXnjxobia9liZgsI70fm8PnCqVFAcefYK+9PGzR5L/hzCslNYQ==
+  dependencies:
+    "@types/highlight.js" "^9.7.0"
+    highlight.js "^9.7.0"
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -10674,6 +10687,11 @@ highlight.js@^10.4.1, highlight.js@~10.7.0:
   version "10.7.3"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
+
+highlight.js@^9.7.0:
+  version "9.18.5"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.5.tgz#d18a359867f378c138d6819edfc2a8acd5f29825"
+  integrity sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==
 
 history@5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Relatert til NDLANO/Issues#3037

Gjør endringer på Masthead og Messageboxes for å støtte:
- Rendering av markdown i messageboxes (hovedsakelig for lenker)
- Lukking av messageboxes.
- Ikke vise messageboxes som allerede er lukket av bruker. (Logikken håndteres i ndla-frontend, men har lagt inn mulighet for å sende inn funksjon onCloseAlert som legger issue-nummer i localStorage)