### PR TITLE
3016 concept block plugin

### DIFF
--- a/packages/designmanual/stories/molecules/NotionBlock.tsx
+++ b/packages/designmanual/stories/molecules/NotionBlock.tsx
@@ -16,7 +16,7 @@ import { uuid } from '@ndla/util';
 import { useRunOnlyOnce } from '../article/useRunOnlyOnce';
 
 type Props = {
-  type: 'image' | 'video' | 'H5P';
+  type: 'image' | 'video' | 'H5P' | 'iframe' | 'external';
 };
 
 const NotionBlock = ({ type }: Props) => {
@@ -109,16 +109,49 @@ const NotionBlock = ({ type }: Props) => {
         }}
       />
     );
+  } else if (type === 'external' || type === 'iframe') {
+    return (
+      <ConceptNotion
+        concept={{
+          id,
+          text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+          title: 'Tilfeldig embed',
+          image: {
+            src: 'https://api.test.ndla.no/image-api/raw/id/45298',
+            alt: 'Foto. Frokost.',
+          },
+          subjectNames: ['Elektro og data'],
+          copyright: {
+            license: {
+              license: 'CC-BY-SA-4.0',
+            },
+            creators: [
+              {
+                name: 'Fornavn Etternavn',
+                type: 'Writer',
+              },
+            ],
+            processors: [],
+            rightsholders: [],
+          },
+          visualElement: {
+            title: 'Velferdsteknologi gir frihet',
+            resource: 'external',
+            url: 'https://public.flourish.studio/visualisation/2152346/embed',
+          },
+        }}
+      />
+    );
   } else {
     return (
       <ConceptNotion
         concept={{
           id,
-          title: '6-akset robotarm',
-          text: 'En 6-akset robotarm betyr at den kan bevege seg i seks retninger. I akkurat denne konfigurasjonen eller løsningen kommer den sjette bevegelsesretningen av det robotarmen står på. I en slik løsning med transportband vil robotarmen ha større fleksibilitet og kan gjøre flere operasjoner raskere, for eksempel "pick and place" (plukk og plasser), som blir simulert her. Da kan man sortere ut varer eller enkeltprodukter på et samlebånd svært effektivt.',
+          title: 'Verdensrom og romskip',
+          text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
           image: {
-            src: 'https://api.test.ndla.no/image-api/raw/id/23425',
-            alt: 'Robotarmer i robotceller og på mobile enheter. Foto.',
+            src: 'https://api.test.ndla.no/image-api/raw/id/13816',
+            alt: 'Verdensrom. Foto.',
           },
           copyright: {
             license: {
@@ -126,32 +159,27 @@ const NotionBlock = ({ type }: Props) => {
             },
             creators: [
               {
-                name: 'Haldor Hove',
+                name: 'Fornavn Etternavn',
                 type: 'writer',
               },
             ],
             processors: [
               {
-                name: 'Totaltekst',
+                name: 'Et Byrå',
                 type: 'correction',
               },
             ],
             rightsholders: [],
           },
           visualElement: {
-            title: 'Viper 6-akset robot',
-            resource: 'brightcove',
-            url: 'https://players.brightcove.net/4806596774001/BkLm8fT_default/index.html?videoId=6268441758001',
+            resource: 'h5p',
+            title: 'En H5P',
+            url: 'https://h5p-test.ndla.no/resource/8ddd7f73-c570-44ab-9a8a-f5f4cc82a8aa?locale=nb-no&cssUrl=https://test.ndla.no/static/h5p-custom-css.css',
             copyright: {
-              license: {
-                license: 'CC-BY-NC-SA-4.0',
-              },
-              creators: [],
-              processors: [],
-              rightsholders: [
+              creators: [
                 {
-                  name: 'Omron Electronics Norway AS',
-                  type: 'supplier',
+                  name: 'Vilkårlig Person',
+                  type: 'Writer',
                 },
               ],
             },

--- a/packages/designmanual/stories/molecules/NotionBlock.tsx
+++ b/packages/designmanual/stories/molecules/NotionBlock.tsx
@@ -115,7 +115,7 @@ const NotionBlock = ({ type }: Props) => {
         concept={{
           id,
           text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-          title: 'Tilfeldig embed',
+          title: 'Statistikk om matvaner',
           image: {
             src: 'https://api.test.ndla.no/image-api/raw/id/45298',
             alt: 'Foto. Frokost.',
@@ -135,7 +135,7 @@ const NotionBlock = ({ type }: Props) => {
             rightsholders: [],
           },
           visualElement: {
-            title: 'Velferdsteknologi gir frihet',
+            title: 'Statistikk om matvaner',
             resource: 'external',
             url: 'https://public.flourish.studio/visualisation/2152346/embed',
           },

--- a/packages/designmanual/stories/organisms/NotionBlockExample.tsx
+++ b/packages/designmanual/stories/organisms/NotionBlockExample.tsx
@@ -49,6 +49,10 @@ class NotionBlockExample extends Component {
               <h2>Begrep med visuelt element h5p</h2>
             </ContentWrapper>
             <NotionBlock type="H5P" />
+            <ContentWrapper>
+              <h2>Begrep med visuelt element iframe/external</h2>
+            </ContentWrapper>
+            <NotionBlock type="external" />
           </OneColumn>
         }
         onSite={[<NotionSiteTabs></NotionSiteTabs>]}

--- a/packages/ndla-ui/src/Notion/FigureNotion.tsx
+++ b/packages/ndla-ui/src/Notion/FigureNotion.tsx
@@ -57,7 +57,6 @@ const FigureNotion = ({
               hideFigcaption={hideFigCaption}
               figureId={figureId}
               id={id}
-              caption={title}
               reuseLabel={t(`${type}.reuse`)}
               authors={contributors}
               licenseRights={license.rights}>

--- a/packages/ndla-ui/src/Notion/Notion.tsx
+++ b/packages/ndla-ui/src/Notion/Notion.tsx
@@ -16,6 +16,7 @@ import { animations, breakpoints, colors, fonts, mq, spacing } from '@ndla/core'
 import { CursorClick } from '@ndla/icons/action';
 import { Play, ArrowCollapse } from '@ndla/icons/common';
 import { ImageCrop, ImageFocalPoint, makeSrcQueryString } from '../Image';
+import { parseMarkdown } from '@ndla/util';
 
 const NotionContainer = styled.div``;
 
@@ -174,7 +175,6 @@ type VisualElementProps = {
 export type NotionProps = {
   id: string | number;
   labels?: string[];
-  renderMarkdown?: (text: string) => string;
   text: ReactNode;
   title: string;
   visualElement?: VisualElementProps;
@@ -182,16 +182,7 @@ export type NotionProps = {
   children?: ReactNode;
 };
 
-const Notion = ({
-  id,
-  labels = [],
-  renderMarkdown,
-  text,
-  title,
-  visualElement,
-  imageElement,
-  children,
-}: NotionProps) => {
+const Notion = ({ id, labels = [], text, title, visualElement, imageElement, children }: NotionProps) => {
   const { t } = useTranslation();
 
   return (
@@ -224,9 +215,7 @@ const Notion = ({
           </ImageWrapper>
         )}
         <TextWrapper hasVisualElement={!!(imageElement || visualElement?.metaImage)}>
-          {HTMLReactParser(
-            renderMarkdown ? renderMarkdown(`**${title}** \u2013 ${text}`) : `<b>${title}</b> \u2013 ${text}`,
-          )}
+          {parseMarkdown(`**${title}** \u2013 ${text}`)}
           {!!labels.length && (
             <LabelsContainer>
               {t('searchPage.resultType.notionLabels')}

--- a/packages/ndla-ui/src/Notion/Notion.tsx
+++ b/packages/ndla-ui/src/Notion/Notion.tsx
@@ -8,7 +8,7 @@
 
 import styled from '@emotion/styled';
 import { useTranslation } from 'react-i18next';
-import HTMLReactParser from 'html-react-parser';
+import { parseMarkdown } from '@ndla/util';
 import React, { Fragment, ReactNode } from 'react';
 import { keyframes } from '@emotion/core';
 import Button from '@ndla/button';
@@ -16,7 +16,6 @@ import { animations, breakpoints, colors, fonts, mq, spacing } from '@ndla/core'
 import { CursorClick } from '@ndla/icons/action';
 import { Play, ArrowCollapse } from '@ndla/icons/common';
 import { ImageCrop, ImageFocalPoint, makeSrcQueryString } from '../Image';
-import { parseMarkdown } from '@ndla/util';
 
 const NotionContainer = styled.div``;
 

--- a/packages/ndla-ui/src/Notion/NotionVisualElement.tsx
+++ b/packages/ndla-ui/src/Notion/NotionVisualElement.tsx
@@ -24,7 +24,7 @@ interface Props {
   visualElement: NotionVisualElementType;
 }
 
-const supportedEmbedTypes = ['brightcove', 'h5p'];
+const supportedEmbedTypes = ['brightcove', 'h5p', 'iframe', 'external'];
 const NotionVisualElement = ({ visualElement }: Props) => {
   const id = '1';
   const figureId = 'figure-1';


### PR DESCRIPTION
Et par oppdateringer på ConceptNotion:
- Fjerne `caption={title}` fra lisens. Dette førte i praksis til at tittelen ble vist to steder ganske nærme hverandre og var derfor unødvendig.
- Alltid rendre markdown.
- Støtte iframe og external embeds. Disse ble per nå ikke vist.