### PR TITLE
Render concept notion markdown as body

### DIFF
--- a/packages/ndla-ui/src/Notion/Notion.tsx
+++ b/packages/ndla-ui/src/Notion/Notion.tsx
@@ -214,7 +214,7 @@ const Notion = ({ id, labels = [], text, title, visualElement, imageElement, chi
           </ImageWrapper>
         )}
         <TextWrapper hasVisualElement={!!(imageElement || visualElement?.metaImage)}>
-          {parseMarkdown(`**${title}** \u2013 ${text}`)}
+          {parseMarkdown(`**${title}** \u2013 ${text}`, 'body')}
           {!!labels.length && (
             <LabelsContainer>
               {t('searchPage.resultType.notionLabels')}


### PR DESCRIPTION
Markdown i ConceptNotion skulle vært rendret som body i utgangspunktet. Lokalt på maskinen min fungerer rendering av markdown i article-converter riktig nå. Men det gjør det forsåvidt uten at 'body' er satt også.