### PR TITLE
Removed polished in favor of regular css

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -6,7 +6,6 @@ module.exports = {
     '@emotion/babel-preset-css-prop',
   ],
   plugins: [
-    'polished',
     '@babel/plugin-proposal-object-rest-spread',
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-syntax-dynamic-import',

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.1.0",
     "babel-plugin-emotion": "^10.0.33",
-    "babel-plugin-polished": "^1.1.0",
     "babel-preset-es2015": "6.24.1",
     "camelcase": "^5.0.0",
     "chalk": "^2.4.2",

--- a/packages/carousel/src/CarouselAutosize.tsx
+++ b/packages/carousel/src/CarouselAutosize.tsx
@@ -7,7 +7,6 @@
  */
 
 import React, { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
-import em from 'polished/lib/helpers/em';
 import { breakpoints as breakpointFromCore } from '@ndla/core';
 import { Breakpoint } from '@ndla/core/types';
 import { CalculatedProps as CalculatedCarouselProps } from './Carousel';
@@ -37,7 +36,7 @@ export const CarouselAutosize = ({ breakpoints: propsBreakpoints, children, cent
   // Update sizes when window resize changes
   const updateSizes = useCallback(() => {
     const node = autosizeRef.current!;
-    const wrapperWidthInEm = parseFloat(em(node.offsetWidth));
+    const wrapperWidthInEm = parseFloat(`${node.offsetWidth / 16}em`);
     const breakpoints: CaruselBreakpoint[] = propsBreakpoints;
 
     const useBreakpoint = breakpoints

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,6 @@
   ],
   "dependencies": {
     "inuitcss": "6.0.0",
-    "polished": "^4.1.3",
     "sass-mq": "^5.0.1"
   },
   "publishConfig": {

--- a/packages/core/src/breakpoints.ts
+++ b/packages/core/src/breakpoints.ts
@@ -1,14 +1,13 @@
-import em from 'polished/lib/helpers/em';
 import { Breakpoints } from '../types';
 
 const breakpoints: Breakpoints = {
-  mobile: em('320px'),
-  mobileWide: em('476px'),
-  tablet: em('601px'),
-  tabletWide: em('768px'),
-  desktop: em('981px'),
-  wide: em('1301px'),
-  ultraWide: em('1601px'),
+  mobile: '20em',
+  mobileWide: '29.75em',
+  tablet: '37.5625em',
+  tabletWide: '48em',
+  desktop: '61.3125em',
+  wide: '81.3125em',
+  ultraWide: '100.0625em',
 };
 
 export default breakpoints;

--- a/packages/core/src/colors.ts
+++ b/packages/core/src/colors.ts
@@ -1,6 +1,3 @@
-import darken from 'polished/lib/color/darken';
-import rgba from 'polished/lib/color/rgba';
-
 const brandLight = '#ceddea';
 const brandLightest = '#F0F6FB';
 const brandDark = '#184673';
@@ -56,41 +53,41 @@ const colors = {
   subjectMaterial: {
     light: '#dde9d0',
     dark: '#5c6a4f',
-    additional: rgba('#dde9d0', 0.4),
+    additional: 'rgba(221,233,208,0.4)',
   },
 
   externalLearningResource: {
     background: '#d0e8de',
     light: '#e6f3ed',
     dark: '#4f7d76',
-    additional: rgba('#d0e8de', 0.4),
+    additional: 'rgba(208,232,222,0.4)',
   },
 
   sourceMaterial: {
     light: '#dce5e0',
     dark: '#636e68',
-    additional: rgba('#dce5e0', 0.4),
+    additional: 'rgba(220,229,224,0.4)',
   },
 
   tasksAndActivities: {
     background: '#f8e0c4',
     light: '#fbeddc',
     dark: '#d98229',
-    additional: rgba('#fbeddc', 0.4),
+    additional: 'rgba(251,237,220,0.4)',
   },
 
   assessmentResource: {
     background: '#efd5d5',
     light: '#f5e7e5',
     dark: '#c0676f',
-    additional: rgba('#f5e7e5', 0.4),
+    additional: 'rgba(245,231,229,0.4)',
   },
 
   learningPath: {
     background: '#f2efef',
     light: '#e8e3e3',
     dark: '#797979',
-    backgroundAdditional: rgba('#e8e3e3', 0.4),
+    backgroundAdditional: 'rgba(232,227,227,0.4)',
   },
 
   /**
@@ -105,11 +102,11 @@ const colors = {
   markColor: '#da788d',
   support: {
     red: '#d1372e',
-    redLight: rgba('#d1372e', 0.3),
+    redLight: 'rgba(209,55,46,0.3)',
     green: '#5cbc80',
-    greenLight: rgba('#5cbc80', 0.3),
+    greenLight: 'rgba(92,188,128,0.3)',
     yellow: '#ead854',
-    yellowLight: rgba('#ead854', 0.3),
+    yellowLight: 'rgba(234,216,84,0.3)',
   },
   tableBg: '#f9fafb',
   favoriteColor: '#fcba03',
@@ -127,8 +124,8 @@ const colors = {
    * */
   background: {
     default: '#ffffff' /* old: EFF0F2 (gray) */,
-    dark: darken(0.1, '#ffffff'),
-    darker: darken(0.2, '#ffffff'),
+    dark: '#e6e6e6',
+    darker: '#ccc',
     backgroundGray: brandGreyLightest,
     grayDark: '#e4e4e4',
   },

--- a/packages/ndla-modal/src/Modal.tsx
+++ b/packages/ndla-modal/src/Modal.tsx
@@ -7,8 +7,6 @@
  */
 
 import React, { ReactElement, ReactNode, useState, MouseEvent, cloneElement } from 'react';
-import em from 'polished/lib/helpers/em';
-
 import { spacing, colors, mq, breakpoints, fonts } from '@ndla/core';
 import { DialogContent } from '@reach/dialog';
 import css from '@emotion/css';
@@ -240,11 +238,11 @@ const animationContainer = css`
     box-shadow: 0 0 30px rgba(0, 0, 0, 0.2);
   }
   &.large {
-    max-width: ${em('970px')};
-    width: ${em('970px')};
+    max-width: '60.625em';
+    width: '60.625em';
     max-height: 85vh;
     box-shadow: 0 0 30px rgba(0, 0, 0, 0.2);
-    ${mq.range({ until: em('970px') })} {
+    ${mq.range({ until: '60.625em' })} {
       box-shadow: none;
       width: 100vw;
       height: 100vw;
@@ -253,11 +251,11 @@ const animationContainer = css`
     }
   }
   &.medium {
-    max-width: ${em('790px')};
-    width: ${em('790px')};
+    max-width: '49.375em';
+    width: '49.375em';
     max-height: 85vh;
     box-shadow: 0 0 30px rgba(0, 0, 0, 0.2);
-    ${mq.range({ until: em('790px') })} {
+    ${mq.range({ until: '49.375em' })} {
       box-shadow: none;
       height: 100vh;
       width: 100vw;
@@ -273,8 +271,8 @@ const animationContainer = css`
       box-shadow: 0 0 30px rgba(0, 0, 0, 0.2);
       width: 90%;
       max-height: 85vh;
-      max-width: ${em('613px')};
-      min-width: ${em('613px')};
+      max-width: '38.3125em';
+      min-width: '38.3125em';
     }
   }
   &.medium,

--- a/packages/ndla-pager/src/Pager.tsx
+++ b/packages/ndla-pager/src/Pager.tsx
@@ -10,7 +10,6 @@ import React, { ElementType, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
-import rgba from 'polished/lib/color/rgba';
 import { colors } from '@ndla/core';
 import SafeLink from '@ndla/safelink';
 import { stepNumbers } from './pagerHelpers';
@@ -23,7 +22,7 @@ const createQueryString = (obj: Query) =>
 
 const pageItemActiveStyle = css`
   border-top: 3px solid ${colors.brand.primary};
-  background-color: ${rgba(colors.brand.lighter, 0.5)};
+  background-color: 'rgba(222,235,246,0.5)';
 `;
 
 const pageItemStyle = css`

--- a/yarn.lock
+++ b/yarn.lock
@@ -2131,13 +2131,6 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.14.0":
-  version "7.15.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
-  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@babel/template@^7.10.4", "@babel/template@^7.4.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -6193,13 +6186,6 @@ babel-plugin-named-asset-import@^0.3.1:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.6.tgz#c9750a1b38d85112c9e166bf3ef7c5dbc605f4be"
   integrity sha512-1aGDUfL1qOOIoqk9QKGIo2lANk+C7ko/fqH0uIyC71x3PEGz0uVP8ISgfEsFuG+FKmjHTvFK/nNM8dowpmUxLA==
-
-babel-plugin-polished@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polished/-/babel-plugin-polished-1.1.0.tgz#7f6902ab8e9c20fc14cb53d596dd858880e357d3"
-  integrity sha1-f2kCq46cIPwUy1PVlt2FiIDjV9M=
-  dependencies:
-    polished "^1.0.0"
 
 babel-plugin-polyfill-corejs2@^0.1.4:
   version "0.1.10"
@@ -14522,24 +14508,12 @@ pnp-webpack-plugin@1.6.4:
   dependencies:
     ts-pnp "^1.1.6"
 
-polished@^1.0.0:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/polished/-/polished-1.9.3.tgz#d61b8a0c4624efe31e2583ff24a358932b6b75e1"
-  integrity sha512-4NmSD7fMFlM8roNxs7YXPv7UFRbYzb0gufR5zBxJLRzY54+zFsavxBo6zsQzP9ep6Hh3pC2pTyrpSTBEaB6IkQ==
-
 polished@^4.0.5:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/polished/-/polished-4.1.1.tgz#40442cc973348e466f2918cdf647531bb6c29bfb"
   integrity sha512-4MZTrfPMPRLD7ac8b+2JZxei58zw6N1hFkdBDERif5Tlj19y3vPoPusrLG+mJIlPTGnUlKw3+yWz0BazvMx1vg==
   dependencies:
     "@babel/runtime" "^7.12.5"
-
-polished@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/polished/-/polished-4.1.3.tgz#7a3abf2972364e7d97770b827eec9a9e64002cfc"
-  integrity sha512-ocPAcVBUOryJEKe0z2KLd1l9EBa1r5mSwlKpExmrLzsnIzJo4axsoU9O2BjOTkDGDT4mZ0WFE5XKTlR3nLnZOA==
-  dependencies:
-    "@babel/runtime" "^7.14.0"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
Så på noe urelatert og kom frem til at polished kunne fjernes, så hvorfor ikke? Nesten all css er hentet ut fra de ferdig-genererte filene, utenom `em`-kalkulasjonen i `CarouselAutoSize`. Der prøvde jeg meg på et regnestykke. `polished` bruker 16 som default-størrelse på `em` hvis man ikke passerer inn noe annet.