### PR TITLE
Resourcebox styling updates

### DIFF
--- a/packages/designmanual/stories/pages/ResourceBoxExample.jsx
+++ b/packages/designmanual/stories/pages/ResourceBoxExample.jsx
@@ -9,7 +9,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { BY, NC, ND } from '@ndla/licenses';
-import { Article, OneColumn, TasksAndActivitiesBadge, constants, ResourceBox } from '@ndla/ui';
+import { Article, OneColumn, TasksAndActivitiesBadge, constants, ResourceBox, Figure } from '@ndla/ui';
 import LicenseBox from '../article/LicenseBox';
 import { CompetenceGoalListExample } from '../organisms/CompetenceGoalsExample';
 import NotionExample from '../molecules/NotionExample';
@@ -38,12 +38,14 @@ const ReferenceBoxExample = () => {
                   av noen få minutter skal du få andre til å <a href="#test">tenne på idéen din og se potensialet</a> i
                   den.
                 </p>
-                <ResourceBox
-                  licenseRights={[BY, NC, ND]}
-                  title="Mediehistorie"
-                  caption="I dette interaktive oppslagsverket kan du lære om medieutviklingen, kan du lære om medieutviklingen, kan du lære om medieutviklingen. kan du lære om medieutviklingen. "
-                  image="https://media.snl.no/media/27960/standard_Schaarwa_chter_Henrik_Ibsen_cropped.jpg"
-                  url="https://www.ndla.no"></ResourceBox>
+                <Figure type={'full'}>
+                  <ResourceBox
+                    licenseRights={[BY, NC, ND]}
+                    title="Mediehistorie"
+                    caption="I dette interaktive oppslagsverket kan du lære om medieutviklingen, kan du lære om medieutviklingen, kan du lære om medieutviklingen. kan du lære om medieutviklingen. "
+                    image="https://media.snl.no/media/27960/standard_Schaarwa_chter_Henrik_Ibsen_cropped.jpg"
+                    url="https://www.ndla.no"></ResourceBox>
+                </Figure>
 
                 <p>
                   En pitch er en kortvarig framføring av en idé for en potensiell samarbeidspartner eller kunde. I løpet

--- a/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
+++ b/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
@@ -21,8 +21,6 @@ const BoxWrapper = styled.div`
   border-radius: 5px;
   border: 1px solid ${colors.brand.light};
   position: relative;
-  align-items: stretch;
-  margin-bottom: 24px;
   font-family: ${fonts.sans};
   box-shadow: 0px 20px 35px -15px rgba(32, 88, 143, 0.15);
   gap: 40px;
@@ -39,10 +37,6 @@ const Title = styled.h3`
   font-weight: ${fonts.weight.bold};
   font-size: ${fonts.sizes(18)};
   margin-top: 0;
-  ${mq.range({ until: breakpoints.desktop })} {
-    text-align: center;
-    width: 100%;
-  }
 `;
 
 const Caption = styled.p`
@@ -53,14 +47,21 @@ const Caption = styled.p`
   }
 `;
 
+const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  ${mq.range({ until: breakpoints.desktop })} {
+    align-items: center;
+    padding-top: 10px;
+  }
+`;
+
 const StyledButton = styled(SafeLinkButton)`
   border: 1px solid ${colors.brand.tertiary};
   :hover {
     background-color: ${colors.brand.primary};
     color: white;
-  }
-  ${mq.range({ until: breakpoints.desktop })} {
-    width: 210px;
   }
 `;
 
@@ -70,40 +71,26 @@ const StyledLaunchIcon = styled(Launch)`
   width: 15px;
 `;
 
-const StyledImage = styled(Image)`
-  object-fit: cover;
-  width: 134px;
-  height: 134px;
-  border-radius: 5px;
-
-  ${mq.range({ until: breakpoints.desktop })} {
-    width: 200px;
-    height: 200px;
-  }
-`;
-
 const ImageWrapper = styled.div`
   align-items: flex-start;
   display: flex;
   justify-content: center;
+
+  img {
+    object-fit: cover;
+    width: 134px;
+    height: 134px;
+    border-radius: 5px;
+
+    ${mq.range({ until: breakpoints.desktop })} {
+      width: 200px;
+      height: 200px;
+    }
+  }
 `;
 
 const CaptionWrapper = styled.div`
   max-width: 600px;
-  ${mq.range({ until: breakpoints.desktop })} {
-    margin: 0 auto;
-  }
-`;
-
-const TitleWrapper = styled.div`
-  display: flex;
-  justify-content: space-between;
-  ${mq.range({ until: breakpoints.desktop })} {
-    text-align: center;
-    padding-top: 10px;
-    max-width: 200px;
-    margin: 0 auto;
-  }
 `;
 
 const LincenseWrapper = styled.div`
@@ -136,13 +123,11 @@ export const ResourceBox = ({ image, title, caption, licenseRights, locale, auth
         </LicenseByline>
       </LincenseWrapper>
       <ImageWrapper>
-        <StyledImage alt={title} src={image} sizes="25, 25" />
+        <Image alt={title} src={image} sizes="25, 25" />
       </ImageWrapper>
-      <div>
+      <TextWrapper>
+        <Title>{title}</Title>
         <CaptionWrapper>
-          <TitleWrapper>
-            <Title>{title}</Title>
-          </TitleWrapper>
           <Caption>{caption}</Caption>
         </CaptionWrapper>
 
@@ -150,7 +135,7 @@ export const ResourceBox = ({ image, title, caption, licenseRights, locale, auth
           {t('license.other.itemImage.ariaLabel')}
           <StyledLaunchIcon aria-hidden />
         </StyledButton>
-      </div>
+      </TextWrapper>
     </BoxWrapper>
   );
 };

--- a/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
+++ b/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
@@ -30,14 +30,12 @@ const BoxWrapper = styled.div`
   ${mq.range({ until: breakpoints.desktop })} {
     gap: 0;
     flex-direction: column;
-    padding-left: 24px;
-    padding-right: 24px;
-    padding-bottom: 0;
+    padding-top: 30px;
     text-align: center;
   }
 `;
 
-const Boxtitle = styled.h3`
+const Title = styled.h3`
   font-weight: ${fonts.weight.bold};
   font-size: ${fonts.sizes(18)};
   margin-top: 0;
@@ -47,7 +45,7 @@ const Boxtitle = styled.h3`
   }
 `;
 
-const Boxcaption = styled.p`
+const Caption = styled.p`
   font-size: ${fonts.sizes(14)};
 
   ${mq.range({ until: breakpoints.desktop })} {
@@ -55,14 +53,7 @@ const Boxcaption = styled.p`
   }
 `;
 
-const StyledButtonDiv = styled.div`
-  align-items: flex-start;
-  ${mq.range({ until: breakpoints.desktop })} {
-    padding-bottom: 10px;
-    margin: 0 auto;
-  }
-`;
-const ResourceBoxStyledButton = styled(SafeLinkButton)`
+const StyledButton = styled(SafeLinkButton)`
   border: 1px solid ${colors.brand.tertiary};
   :hover {
     background-color: ${colors.brand.primary};
@@ -72,13 +63,14 @@ const ResourceBoxStyledButton = styled(SafeLinkButton)`
     width: 210px;
   }
 `;
-const ResourceBoxLaunchIcon = styled(Launch)`
+
+const StyledLaunchIcon = styled(Launch)`
   margin-left: 8px;
   height: 15px;
   width: 15px;
 `;
 
-const BoxImage = styled(Image)`
+const StyledImage = styled(Image)`
   object-fit: cover;
   width: 134px;
   height: 134px;
@@ -89,34 +81,21 @@ const BoxImage = styled(Image)`
     height: 200px;
   }
 `;
-const ImageSectionWrapper = styled.div`
+
+const ImageWrapper = styled.div`
   align-items: flex-start;
   display: flex;
   justify-content: center;
-  ${mq.range({ until: breakpoints.desktop })} {
-    margin: 0 auto;
-    padding-top: 10px;
-  }
 `;
 
-const CaptionSectionWrapper = styled.div`
+const CaptionWrapper = styled.div`
   max-width: 600px;
   ${mq.range({ until: breakpoints.desktop })} {
     margin: 0 auto;
   }
 `;
 
-const CenterItems = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  flex-flow: column;
-  ${mq.range({ until: breakpoints.desktop })} {
-    width: 100%;
-  }
-`;
-
-const TitleAndLicence = styled.div`
+const TitleWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   ${mq.range({ until: breakpoints.desktop })} {
@@ -149,31 +128,29 @@ export const ResourceBox = ({ image, title, caption, licenseRights, locale, auth
   const { t } = useTranslation();
   return (
     <BoxWrapper>
-      <ImageSectionWrapper>
-        <BoxImage alt={title} src={image} sizes="25, 25" />
-      </ImageSectionWrapper>
-      <CenterItems>
-        <CaptionSectionWrapper>
-          <TitleAndLicence>
-            <Boxtitle>{title}</Boxtitle>
-            <LincenseWrapper>
-              <LicenseByline licenseRights={licenseRights} locale={locale} marginRight color={colors.brand.tertiary}>
-                <div className="c-figure__byline-author-buttons">
-                  <span className="c-figure__byline-authors">{authors?.map((author) => author.name).join(' ')}</span>
-                </div>
-              </LicenseByline>
-            </LincenseWrapper>
-          </TitleAndLicence>
-          <Boxcaption>{caption}</Boxcaption>
-        </CaptionSectionWrapper>
+      <LincenseWrapper>
+        <LicenseByline licenseRights={licenseRights} locale={locale} marginRight color={colors.brand.tertiary}>
+          <div className="c-figure__byline-author-buttons">
+            <span className="c-figure__byline-authors">{authors?.map((author) => author.name).join(' ')}</span>
+          </div>
+        </LicenseByline>
+      </LincenseWrapper>
+      <ImageWrapper>
+        <StyledImage alt={title} src={image} sizes="25, 25" />
+      </ImageWrapper>
+      <div>
+        <CaptionWrapper>
+          <TitleWrapper>
+            <Title>{title}</Title>
+          </TitleWrapper>
+          <Caption>{caption}</Caption>
+        </CaptionWrapper>
 
-        <StyledButtonDiv>
-          <ResourceBoxStyledButton to={url} target="_blank" outline borderShape="rounded">
-            {t('license.other.itemImage.ariaLabel')}
-            <ResourceBoxLaunchIcon aria-hidden />
-          </ResourceBoxStyledButton>
-        </StyledButtonDiv>
-      </CenterItems>
+        <StyledButton to={url} target="_blank" outline borderShape="rounded">
+          {t('license.other.itemImage.ariaLabel')}
+          <StyledLaunchIcon aria-hidden />
+        </StyledButton>
+      </div>
     </BoxWrapper>
   );
 };

--- a/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
+++ b/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
@@ -17,13 +17,10 @@ import Image from '../Image';
 
 const BoxWrapper = styled.div`
   display: flex;
-  padding-top: 20px;
-  padding-bottom: 20px;
+  padding: 20px;
   border-radius: 5px;
   border: 1px solid ${colors.brand.light};
   position: relative;
-  left: -16.6666666667%;
-  width: 133.3333333333%;
   align-items: stretch;
   margin-bottom: 24px;
   font-family: ${fonts.sans};
@@ -31,16 +28,11 @@ const BoxWrapper = styled.div`
   gap: 40px;
 
   ${mq.range({ until: breakpoints.desktop })} {
-    gap: 1px;
+    gap: 0;
     flex-direction: column;
-    margin: 0 auto;
-    width: 80%;
-    left: 0;
     padding-left: 24px;
     padding-right: 24px;
     padding-bottom: 0;
-    margin-bottom: 24px;
-    height: auto;
     text-align: center;
   }
 `;
@@ -101,7 +93,6 @@ const ImageSectionWrapper = styled.div`
   align-items: flex-start;
   display: flex;
   justify-content: center;
-  margin-left: 20px;
   ${mq.range({ until: breakpoints.desktop })} {
     margin: 0 auto;
     padding-top: 10px;

--- a/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
+++ b/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
@@ -15,7 +15,7 @@ import { SafeLinkButton } from '@ndla/safelink';
 import styled from '@emotion/styled';
 import Image from '../Image';
 
-const BoxWrapper = styled.div`
+const ResourceBoxContainer = styled.div`
   display: flex;
   padding: 20px;
   border-radius: 5px;
@@ -41,6 +41,7 @@ const Title = styled.h3`
 
 const Caption = styled.p`
   font-size: ${fonts.sizes(14)};
+  max-width: 600px;
 
   ${mq.range({ until: breakpoints.desktop })} {
     line-height: 22px;
@@ -61,6 +62,7 @@ const StyledButton = styled(SafeLinkButton)`
   border: 1px solid ${colors.brand.tertiary};
   :hover {
     background-color: ${colors.brand.primary};
+    border: 1px solid ${colors.brand.primary};
     color: white;
   }
 `;
@@ -72,10 +74,6 @@ const StyledLaunchIcon = styled(Launch)`
 `;
 
 const ImageWrapper = styled.div`
-  align-items: flex-start;
-  display: flex;
-  justify-content: center;
-
   img {
     object-fit: cover;
     width: 134px;
@@ -87,10 +85,6 @@ const ImageWrapper = styled.div`
       height: 200px;
     }
   }
-`;
-
-const CaptionWrapper = styled.div`
-  max-width: 600px;
 `;
 
 const LincenseWrapper = styled.div`
@@ -114,7 +108,7 @@ type Props = {
 export const ResourceBox = ({ image, title, caption, licenseRights, locale, authors, url }: Props) => {
   const { t } = useTranslation();
   return (
-    <BoxWrapper>
+    <ResourceBoxContainer>
       <LincenseWrapper>
         <LicenseByline licenseRights={licenseRights} locale={locale} marginRight color={colors.brand.tertiary}>
           <div className="c-figure__byline-author-buttons">
@@ -123,20 +117,18 @@ export const ResourceBox = ({ image, title, caption, licenseRights, locale, auth
         </LicenseByline>
       </LincenseWrapper>
       <ImageWrapper>
-        <Image alt={title} src={image} sizes="25, 25" />
+        <Image alt={title} src={image} />
       </ImageWrapper>
       <TextWrapper>
         <Title>{title}</Title>
-        <CaptionWrapper>
-          <Caption>{caption}</Caption>
-        </CaptionWrapper>
+        <Caption>{caption}</Caption>
 
         <StyledButton to={url} target="_blank" outline borderShape="rounded">
           {t('license.other.itemImage.ariaLabel')}
           <StyledLaunchIcon aria-hidden />
         </StyledButton>
       </TextWrapper>
-    </BoxWrapper>
+    </ResourceBoxContainer>
   );
 };
 


### PR DESCRIPTION
Relatert til NDLANO/Issues#3002

133% width på ResourceBox settes nå ved hjelp av Figure som har dette innebygd. Dette var nødvendig for enkel bruk av komponenten i Slate. Har samtidig forenklet stylingen.

Hvordan teste:
- Åpne ?path=/story/sammensatte-moduler--ressurs-fra-lenke
- Styling skal se likt ut som før bortsett fra noen små endringer i marginer/padding. Sjekk responsitivitet for alle skjermbredder.