### PR TITLE
Markdown list rendering

### DIFF
--- a/packages/designmanual/stories/molecules/NotionBlock.tsx
+++ b/packages/designmanual/stories/molecules/NotionBlock.tsx
@@ -145,9 +145,6 @@ const conceptData = {
       alt: 'Robotarmer i robotceller og på mobile enheter. Foto.',
     },
     copyright: {
-      license: {
-        license: 'CC-BY-SA-4.0',
-      },
       creators: [
         {
           name: 'Haldor Hove',
@@ -194,12 +191,12 @@ const getType = (type: string) => {
 
 type Props = {
   type: 'image' | 'video' | 'h5p' | 'iframe' | 'external';
-
   hideIconsAndAuthors?: boolean;
+  data?: 'image' | 'video' | 'h5p' | 'iframe' | 'external' | 'other';
   adjustSizeToFitWiderPage?: boolean;
 };
 
-const NotionBlock = ({ type, hideIconsAndAuthors, adjustSizeToFitWiderPage }: Props) => {
+const NotionBlock = ({ type, hideIconsAndAuthors, adjustSizeToFitWiderPage, data }: Props) => {
   const id = useRunOnlyOnce(uuid(), () => {
     initArticleScripts();
   });
@@ -210,7 +207,7 @@ const NotionBlock = ({ type, hideIconsAndAuthors, adjustSizeToFitWiderPage }: Pr
         <ConceptNotion
           hideIconsAndAuthors={hideIconsAndAuthors}
           type={type}
-          concept={{ ...conceptData[getType(type)], id }}
+          concept={{ ...conceptData[getType(data || type)], id }}
         />
       </Figure>
     );

--- a/packages/designmanual/stories/molecules/NotionBlock.tsx
+++ b/packages/designmanual/stories/molecules/NotionBlock.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { ConceptNotion, Figure } from '@ndla/ui';
+import { ConceptNotion } from '@ndla/ui';
 // @ts-ignore
 import { initArticleScripts } from '@ndla/article-scripts';
 import { uuid } from '@ndla/util';
@@ -178,10 +178,53 @@ const conceptData = {
       },
     },
   },
+  richtext: {
+    authors: [],
+    title: '6-akset robotarm',
+    source: 'https://www.snl.no',
+    text: 'En 6-akset **robotarm** betyr at den kan bevege seg i seks `retninger`. I akkurat _denne_ konfigurasjonen eller løsningen kommer den ^sjette^ ~bevegelsesretningen~ av det robotarmen står på.\n1. I en slik løsning med transportband vil robotarmen ha større fleksibilitet og kan gjøre flere operasjoner raskere, for eksempel "pick and place" (plukk og plasser), som blir simulert her.\n2. Da kan man sortere ut varer eller enkeltprodukter på et samlebånd svært effektivt.',
+    image: {
+      src: 'https://api.test.ndla.no/image-api/raw/id/23425',
+      alt: 'Robotarmer i robotceller og på mobile enheter. Foto.',
+    },
+    copyright: {
+      creators: [
+        {
+          name: 'Haldor Hove',
+          type: 'writer',
+        },
+      ],
+      processors: [
+        {
+          name: 'Totaltekst',
+          type: 'correction',
+        },
+      ],
+      rightsholders: [],
+    },
+    visualElement: {
+      title: 'Viper 6-akset robot',
+      resource: 'h5p',
+      url: 'https://players.brightcove.net/4806596774001/BkLm8fT_default/index.html?videoId=6268441758001',
+      copyright: {
+        license: {
+          license: 'CC-BY-NC-SA-4.0',
+        },
+        creators: [],
+        processors: [],
+        rightsholders: [
+          {
+            name: 'Omron Electronics Norway AS',
+            type: 'supplier',
+          },
+        ],
+      },
+    },
+  },
 };
 
 const getType = (type: string) => {
-  if (type === 'image' || type === 'video') {
+  if (type === 'image' || type === 'video' || type === 'richtext') {
     return type;
   } else if (['iframe', 'h5p', 'external'].includes(type)) {
     return 'h5p';
@@ -192,32 +235,19 @@ const getType = (type: string) => {
 type Props = {
   type: 'image' | 'video' | 'h5p' | 'iframe' | 'external';
   hideIconsAndAuthors?: boolean;
-  data?: 'image' | 'video' | 'h5p' | 'iframe' | 'external' | 'other';
-  adjustSizeToFitWiderPage?: boolean;
+  data?: 'image' | 'video' | 'h5p' | 'iframe' | 'external' | 'other' | 'richtext';
 };
 
-const NotionBlock = ({ type, hideIconsAndAuthors, adjustSizeToFitWiderPage, data }: Props) => {
+const NotionBlock = ({ type, hideIconsAndAuthors, data }: Props) => {
   const id = useRunOnlyOnce(uuid(), () => {
     initArticleScripts();
   });
-
-  if (adjustSizeToFitWiderPage) {
-    return (
-      <Figure type="full">
-        <ConceptNotion
-          hideIconsAndAuthors={hideIconsAndAuthors}
-          type={type}
-          concept={{ ...conceptData[getType(data || type)], id }}
-        />
-      </Figure>
-    );
-  }
 
   return (
     <ConceptNotion
       hideIconsAndAuthors={hideIconsAndAuthors}
       type={type}
-      concept={{ ...conceptData[getType(type)], id }}
+      concept={{ ...conceptData[getType(data || type)], id }}
     />
   );
 };

--- a/packages/designmanual/stories/molecules/NotionBlock.tsx
+++ b/packages/designmanual/stories/molecules/NotionBlock.tsx
@@ -7,12 +7,190 @@
  */
 
 import React from 'react';
-import { ConceptNotion } from '@ndla/ui';
+import { ConceptNotion, Figure } from '@ndla/ui';
 // @ts-ignore
 import { initArticleScripts } from '@ndla/article-scripts';
 import { uuid } from '@ndla/util';
 //@ts-ignore
 import { useRunOnlyOnce } from '../article/useRunOnlyOnce';
+
+const conceptData = {
+  image: {
+    authors: [],
+    title: 'And',
+    source: 'https://www.snl.no',
+    text: 'Ender tilhører andefamilien. I Norge har det vært vanlig å dele endene inn i tre grupper etter levevis: Gressender som spiser planter på grunt vann, dykkender som dykker etter virvelløse dyr, og fiskeender som spiser fisk. Ender ble husdyr i middelhavslandene kort tid før Kristi fødsel. Hos hannen, andriken, er de fire midtre halefjærene bøyd oppover. Som ofte ellers i fugleriket har hannen finere farger enn hunnen. Det finnes en rekke raser og krysninger. På bildet ser vi tamme ender, pekinand.',
+    subjectNames: ['Naturbruk Vg1', 'Naturbruk Vg2'],
+    copyright: {
+      license: {
+        license: 'CC-BY-NC-SA-4.0',
+      },
+      creators: [{ name: 'En skaper', type: 'Writer' }],
+      processors: [{ name: 'Totaltekst', type: 'Correction' }],
+      rightsholders: [],
+    },
+    visualElement: {
+      copyright: {
+        license: {
+          license: 'CC-BY-NC-SA-4.0',
+        },
+        creators: [],
+        processors: [],
+        rightsholders: [{ name: 'NTB Scanpix', type: 'Supplier' }],
+        origin: 'http://www.scanpix.no',
+      },
+      resource: 'image',
+      image: {
+        src: 'https://api.staging.ndla.no/image-api/raw/20081209-095942-ag_0.jpg',
+        alt: 'Stokkand. Foto.',
+      },
+    },
+    image: {
+      src: 'https://api.test.ndla.no/image-api/raw/id/40164',
+      alt: 'Stokkand. Foto.',
+    },
+  },
+  video: {
+    authors: [],
+    text: 'I videoen kan du se en introduksjon til hva vi for eksempel mener når vi prater om «velferdsteknologi».',
+    title: 'Velferdsteknologi',
+    source: 'https://www.snl.no',
+    image: {
+      src: 'https://api.test.ndla.no/image-api/raw/id/52535',
+      alt: 'Foto. Klasseromsrobot som gjør det mulig å være på skolen uten å være fysisk til stede.',
+    },
+    subjectNames: ['Elektro og data'],
+    copyright: {
+      license: {
+        license: 'CC-BY-SA-4.0',
+      },
+      creators: [
+        {
+          name: 'Bjørnar Mortensen Vik',
+          type: 'Writer',
+        },
+      ],
+      processors: [],
+      rightsholders: [],
+    },
+    visualElement: {
+      title: 'Velferdsteknologi gir frihet',
+      resource: 'brightcove',
+      url: 'https://players.brightcove.net/4806596774001/BkLm8fT_default/index.html?videoId=6154610667001',
+      copyright: {
+        license: {
+          license: 'CC-BY-NC-SA-4.0',
+        },
+        creators: [],
+        processors: [],
+        rightsholders: [
+          {
+            name: 'film_konsulentene',
+            type: 'supplier',
+          },
+        ],
+      },
+    },
+  },
+  h5p: {
+    authors: [],
+    title: 'Verdensrom og romskip',
+    text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    image: {
+      src: 'https://api.test.ndla.no/image-api/raw/id/13816',
+      alt: 'Verdensrom. Foto.',
+    },
+    copyright: {
+      license: {
+        license: 'CC-BY-SA-4.0',
+      },
+      creators: [
+        {
+          name: 'Fornavn Etternavn',
+          type: 'writer',
+        },
+      ],
+      processors: [
+        {
+          name: 'Et Byrå',
+          type: 'correction',
+        },
+      ],
+      rightsholders: [],
+    },
+    visualElement: {
+      resource: 'h5p',
+      title: 'En H5P',
+      url: 'https://h5p-test.ndla.no/resource/8ddd7f73-c570-44ab-9a8a-f5f4cc82a8aa?locale=nb-no&cssUrl=https://test.ndla.no/static/h5p-custom-css.css',
+      copyright: {
+        license: {
+          license: 'CC-BY-NC-SA-4.0',
+        },
+        creators: [
+          {
+            name: 'Vilkårlig Person',
+            type: 'Writer',
+          },
+        ],
+      },
+    },
+  },
+  other: {
+    authors: [],
+    title: '6-akset robotarm',
+    source: 'https://www.snl.no',
+    text: 'En 6-akset robotarm betyr at den kan bevege seg i seks retninger. I akkurat denne konfigurasjonen eller løsningen kommer den sjette bevegelsesretningen av det robotarmen står på. I en slik løsning med transportband vil robotarmen ha større fleksibilitet og kan gjøre flere operasjoner raskere, for eksempel "pick and place" (plukk og plasser), som blir simulert her. Da kan man sortere ut varer eller enkeltprodukter på et samlebånd svært effektivt.',
+    image: {
+      src: 'https://api.test.ndla.no/image-api/raw/id/23425',
+      alt: 'Robotarmer i robotceller og på mobile enheter. Foto.',
+    },
+    copyright: {
+      license: {
+        license: 'CC-BY-SA-4.0',
+      },
+      creators: [
+        {
+          name: 'Haldor Hove',
+          type: 'writer',
+        },
+      ],
+      processors: [
+        {
+          name: 'Totaltekst',
+          type: 'correction',
+        },
+      ],
+      rightsholders: [],
+    },
+    visualElement: {
+      title: 'Viper 6-akset robot',
+      resource: 'h5p',
+      url: 'https://players.brightcove.net/4806596774001/BkLm8fT_default/index.html?videoId=6268441758001',
+      copyright: {
+        license: {
+          license: 'CC-BY-NC-SA-4.0',
+        },
+        creators: [],
+        processors: [],
+        rightsholders: [
+          {
+            name: 'Omron Electronics Norway AS',
+            type: 'supplier',
+          },
+        ],
+      },
+    },
+  },
+};
+
+const getType = (type: string) => {
+  if (type === 'image' || type === 'video') {
+    return type;
+  } else if (['iframe', 'h5p', 'external'].includes(type)) {
+    return 'h5p';
+  }
+  return 'other';
+};
 
 type Props = {
   type: 'image' | 'video' | 'h5p' | 'iframe' | 'external';
@@ -26,208 +204,25 @@ const NotionBlock = ({ type, hideIconsAndAuthors, adjustSizeToFitWiderPage }: Pr
     initArticleScripts();
   });
 
-  if (type === 'image') {
+  if (adjustSizeToFitWiderPage) {
     return (
-      <ConceptNotion
-        adjustSizeToFitWiderPage={adjustSizeToFitWiderPage}
-        hideIconsAndAuthors={hideIconsAndAuthors}
-        type={type}
-        concept={{
-          id,
-          authors: [],
-          title: 'And',
-          source: 'https://www.snl.no',
-          text: 'Ender tilhører andefamilien. I Norge har det vært vanlig å dele endene inn i tre grupper etter levevis: Gressender som spiser planter på grunt vann, dykkender som dykker etter virvelløse dyr, og fiskeender som spiser fisk. Ender ble husdyr i middelhavslandene kort tid før Kristi fødsel. Hos hannen, andriken, er de fire midtre halefjærene bøyd oppover. Som ofte ellers i fugleriket har hannen finere farger enn hunnen. Det finnes en rekke raser og krysninger. På bildet ser vi tamme ender, pekinand.',
-          subjectNames: ['Naturbruk Vg1', 'Naturbruk Vg2'],
-          copyright: {
-            license: {
-              license: 'CC-BY-NC-SA-4.0',
-            },
-            creators: [{ name: 'En skaper', type: 'Writer' }],
-            processors: [{ name: 'Totaltekst', type: 'Correction' }],
-            rightsholders: [],
-          },
-          visualElement: {
-            copyright: {
-              license: {
-                license: 'CC-BY-NC-SA-4.0',
-              },
-              creators: [],
-              processors: [],
-              rightsholders: [{ name: 'NTB Scanpix', type: 'Supplier' }],
-              origin: 'http://www.scanpix.no',
-            },
-            resource: 'image',
-            image: {
-              src: 'https://api.staging.ndla.no/image-api/raw/20081209-095942-ag_0.jpg',
-              alt: 'Stokkand. Foto.',
-            },
-          },
-          image: {
-            src: 'https://api.test.ndla.no/image-api/raw/id/40164',
-            alt: 'Stokkand. Foto.',
-          },
-        }}
-      />
-    );
-  } else if (type === 'video') {
-    return (
-      <ConceptNotion
-        adjustSizeToFitWiderPage={adjustSizeToFitWiderPage}
-        hideIconsAndAuthors={hideIconsAndAuthors}
-        type={type}
-        concept={{
-          id,
-          authors: [],
-          text: 'I videoen kan du se en introduksjon til hva vi for eksempel mener når vi prater om «velferdsteknologi».',
-          title: 'Velferdsteknologi',
-          source: 'https://www.snl.no',
-          image: {
-            src: 'https://api.test.ndla.no/image-api/raw/id/52535',
-            alt: 'Foto. Klasseromsrobot som gjør det mulig å være på skolen uten å være fysisk til stede.',
-          },
-          subjectNames: ['Elektro og data'],
-          copyright: {
-            license: {
-              license: 'CC-BY-SA-4.0',
-            },
-            creators: [
-              {
-                name: 'Bjørnar Mortensen Vik',
-                type: 'Writer',
-              },
-            ],
-            processors: [],
-            rightsholders: [],
-          },
-          visualElement: {
-            title: 'Velferdsteknologi gir frihet',
-            resource: 'brightcove',
-            url: 'https://players.brightcove.net/4806596774001/BkLm8fT_default/index.html?videoId=6154610667001',
-            copyright: {
-              license: {
-                license: 'CC-BY-NC-SA-4.0',
-              },
-              creators: [],
-              processors: [],
-              rightsholders: [
-                {
-                  name: 'film_konsulentene',
-                  type: 'supplier',
-                },
-              ],
-            },
-          },
-        }}
-      />
-    );
-  } else if (type === 'external' || type === 'iframe' || type === 'h5p') {
-    return (
-      <ConceptNotion
-        adjustSizeToFitWiderPage={adjustSizeToFitWiderPage}
-        hideIconsAndAuthors={hideIconsAndAuthors}
-        type={type}
-        concept={{
-          id,
-          authors: [],
-          title: 'Verdensrom og romskip',
-          text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-          image: {
-            src: 'https://api.test.ndla.no/image-api/raw/id/13816',
-            alt: 'Verdensrom. Foto.',
-          },
-          copyright: {
-            license: {
-              license: 'CC-BY-SA-4.0',
-            },
-            creators: [
-              {
-                name: 'Fornavn Etternavn',
-                type: 'writer',
-              },
-            ],
-            processors: [
-              {
-                name: 'Et Byrå',
-                type: 'correction',
-              },
-            ],
-            rightsholders: [],
-          },
-          visualElement: {
-            resource: 'h5p',
-            title: 'En H5P',
-            url: 'https://h5p-test.ndla.no/resource/8ddd7f73-c570-44ab-9a8a-f5f4cc82a8aa?locale=nb-no&cssUrl=https://test.ndla.no/static/h5p-custom-css.css',
-            copyright: {
-              license: {
-                license: 'CC-BY-NC-SA-4.0',
-              },
-              creators: [
-                {
-                  name: 'Vilkårlig Person',
-                  type: 'Writer',
-                },
-              ],
-            },
-          },
-        }}
-      />
-    );
-  } else {
-    return (
-      <ConceptNotion
-        adjustSizeToFitWiderPage={adjustSizeToFitWiderPage}
-        hideIconsAndAuthors={hideIconsAndAuthors}
-        type={type}
-        concept={{
-          id,
-          authors: [],
-          title: '6-akset robotarm',
-          source: 'https://www.snl.no',
-          text: 'En 6-akset robotarm betyr at den kan bevege seg i seks retninger. I akkurat denne konfigurasjonen eller løsningen kommer den sjette bevegelsesretningen av det robotarmen står på. I en slik løsning med transportband vil robotarmen ha større fleksibilitet og kan gjøre flere operasjoner raskere, for eksempel "pick and place" (plukk og plasser), som blir simulert her. Da kan man sortere ut varer eller enkeltprodukter på et samlebånd svært effektivt.',
-          image: {
-            src: 'https://api.test.ndla.no/image-api/raw/id/23425',
-            alt: 'Robotarmer i robotceller og på mobile enheter. Foto.',
-          },
-          copyright: {
-            license: {
-              license: 'CC-BY-SA-4.0',
-            },
-            creators: [
-              {
-                name: 'Haldor Hove',
-                type: 'writer',
-              },
-            ],
-            processors: [
-              {
-                name: 'Totaltekst',
-                type: 'correction',
-              },
-            ],
-            rightsholders: [],
-          },
-          visualElement: {
-            title: 'Viper 6-akset robot',
-            resource: 'h5p',
-            url: 'https://players.brightcove.net/4806596774001/BkLm8fT_default/index.html?videoId=6268441758001',
-            copyright: {
-              license: {
-                license: 'CC-BY-NC-SA-4.0',
-              },
-              creators: [],
-              processors: [],
-              rightsholders: [
-                {
-                  name: 'Omron Electronics Norway AS',
-                  type: 'supplier',
-                },
-              ],
-            },
-          },
-        }}
-      />
+      <Figure type="full">
+        <ConceptNotion
+          hideIconsAndAuthors={hideIconsAndAuthors}
+          type={type}
+          concept={{ ...conceptData[getType(type)], id }}
+        />
+      </Figure>
     );
   }
+
+  return (
+    <ConceptNotion
+      hideIconsAndAuthors={hideIconsAndAuthors}
+      type={type}
+      concept={{ ...conceptData[getType(type)], id }}
+    />
+  );
 };
+
 export default NotionBlock;

--- a/packages/designmanual/stories/molecules/NotionList.tsx
+++ b/packages/designmanual/stories/molecules/NotionList.tsx
@@ -6,24 +6,11 @@
  *
  */
 
-import React, { ReactNode } from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
-import { breakpoints, mq, fonts } from '@ndla/core';
+import { fonts } from '@ndla/core';
 import NotionBlock from '../molecules/NotionBlock';
 
-const NotionListTitleWrapper = styled.div`
-  margin: 48px 0 48px;
-  position: relative !important;
-  right: auto !important;
-  left: -16.6666666667%;
-  width: 133.3333333333% !important;
-  padding-left: 24px;
-  padding-right: 24px;
-  ${mq.range({ until: breakpoints.tabletWide })} {
-    width: 100%;
-    left: -4%;
-  }
-`;
 const NotionListTitle = styled.h2`
   font-size: 24px;
   color: #444444;
@@ -31,36 +18,34 @@ const NotionListTitle = styled.h2`
   margin: 0;
 `;
 
-const NotionList = styled.ul`
+const StyledList = styled.ul`
   list-style: none;
 `;
 type Notions = {
   type: 'image' | 'video' | 'h5p';
 };
 type Props = {
-  children: Notions[];
-  title: ReactNode;
+  notions: Notions[];
+  title: string;
 };
 
-const NotionListExample = ({ title, children }: Props) => {
+const NotionList = ({ title, notions }: Props) => {
   return (
     <>
-      {children && (
+      {notions && (
         <>
-          <NotionListTitleWrapper>
-            <NotionListTitle>{title}</NotionListTitle>
-          </NotionListTitleWrapper>
-          <NotionList>
-            {children.map((child) => (
+          <NotionListTitle>{title}</NotionListTitle>
+          <StyledList>
+            {notions.map((notion) => (
               <li>
-                <NotionBlock type={child.type} hideIconsAndAuthors></NotionBlock>
+                <NotionBlock type={notion.type} hideIconsAndAuthors></NotionBlock>
               </li>
             ))}
-          </NotionList>
+          </StyledList>
         </>
       )}
     </>
   );
 };
 
-export default NotionListExample;
+export default NotionList;

--- a/packages/designmanual/stories/molecules/NotionSiteTabs.jsx
+++ b/packages/designmanual/stories/molecules/NotionSiteTabs.jsx
@@ -6,7 +6,7 @@
  *
  */
 import React, { Fragment } from 'react';
-import { Article, OneColumn, TasksAndActivitiesBadge, constants } from '@ndla/ui';
+import { Article, OneColumn, TasksAndActivitiesBadge, constants, Figure } from '@ndla/ui';
 import Tabs from '@ndla/tabs';
 import styled from '@emotion/styled';
 //@ts-ignore
@@ -72,7 +72,9 @@ const NotionSiteTabs = () => {
                             eventuelt jobber sammen med i klassen.
                           </p>
                           <FigureImage alt="" src="https://api.staging.ndla.no/image-api/raw/42-45210905.jpg" />
-                          <NotionBlock type="image" hideIconsAndAuthors></NotionBlock>
+                          <Figure type="full">
+                            <NotionBlock type="image" hideIconsAndAuthors></NotionBlock>
+                          </Figure>
                           <p>
                             En pitch er en kortvarig framføring av en idé for en potensiell samarbeidspartner eller
                             kunde. I løpet av noen få minutter skal du få andre til å tenne på idéen din og se
@@ -152,9 +154,12 @@ const NotionSiteTabs = () => {
                             eventuelt jobber sammen med i klassen.
                           </p>
                           <FigureImage alt="" src="https://api.staging.ndla.no/image-api/raw/42-45210905.jpg" />
-                          <NotionList
-                            title="Liste med forklaringer"
-                            children={[{ type: 'image' }, { type: 'h5p' }, { type: 'video' }]}></NotionList>
+
+                          <Figure type="full">
+                            <NotionList
+                              title="Liste med forklaringer"
+                              notions={[{ type: 'image' }, { type: 'h5p' }, { type: 'video' }]}></NotionList>
+                          </Figure>
                           <p>
                             En pitch er en kortvarig framføring av en idé for en potensiell samarbeidspartner eller
                             kunde. I løpet av noend få minutter skal du få andre til å tenne på idéen din og se

--- a/packages/designmanual/stories/organisms/NotionBlockExample.tsx
+++ b/packages/designmanual/stories/organisms/NotionBlockExample.tsx
@@ -33,21 +33,23 @@ class NotionBlockExample extends Component {
           components={
             <OneColumn>
               <h2 className="u-heading">Begrep med visuelt element bilde</h2>
-              <NotionBlock type="image" hideIconsAndAuthors adjustSizeToFitWiderPage />
+              <NotionBlock type="image" hideIconsAndAuthors />
               <h2 className="u-heading">Begrep med visuelt element video</h2>
-              <NotionBlock type="video" hideIconsAndAuthors adjustSizeToFitWiderPage />
+              <NotionBlock type="video" hideIconsAndAuthors />
               <h2 className="u-heading">Begrep med visuelt element h5p</h2>
-              <NotionBlock type="h5p" hideIconsAndAuthors adjustSizeToFitWiderPage />
+              <NotionBlock type="h5p" hideIconsAndAuthors />
               <h2 className="u-heading">Begrep med forfatter og lisensikoner</h2>
-              <NotionBlock type="image" adjustSizeToFitWiderPage />
+              <NotionBlock type="image" />
               <h2 className="u-heading">Begrep med manglende lisens</h2>
-              <NotionBlock type="image" data="other" adjustSizeToFitWiderPage />
+              <NotionBlock type="image" data="other" />
+              <h2 className="u-heading">Begrep med markdown-innhold</h2>
+              <NotionBlock type="image" data="richtext" />
             </OneColumn>
           }
           onSite={[<NotionSiteTabs></NotionSiteTabs>]}
           reactCode={`
   //Enkel forklaringsblokk
-  <NotionBlock type="H5P" hideIconsAndAuthors adjustSizeToFitWiderPage></NotionBlock>
+  <NotionBlock type="H5P" hideIconsAndAuthors></NotionBlock>
   //Liste med forklaringsblokker
   <NotionListExample
   title="Liste med forklaringer"

--- a/packages/designmanual/stories/organisms/NotionBlockExample.tsx
+++ b/packages/designmanual/stories/organisms/NotionBlockExample.tsx
@@ -50,19 +50,19 @@ class NotionBlockExample extends Component {
               <ContentWrapper>
                 <h2>Begrep med visuelt element bilde</h2>
               </ContentWrapper>
-              <NotionBlock type="image" hideIconsAndAuthors />
+              <NotionBlock type="image" hideIconsAndAuthors adjustSizeToFitWiderPage />
               <ContentWrapper>
                 <h2>Begrep med visuelt element video</h2>
               </ContentWrapper>
-              <NotionBlock type="video" hideIconsAndAuthors />
+              <NotionBlock type="video" hideIconsAndAuthors adjustSizeToFitWiderPage />
               <ContentWrapper>
                 <h2>Begrep med visuelt element h5p</h2>
               </ContentWrapper>
-              <NotionBlock type="h5p" hideIconsAndAuthors />
+              <NotionBlock type="h5p" hideIconsAndAuthors adjustSizeToFitWiderPage />
               <ContentWrapper>
                 <h2>Begrep med forfatter og lisensikoner</h2>
               </ContentWrapper>
-              <NotionBlock type="image" />
+              <NotionBlock type="image" adjustSizeToFitWiderPage />
             </OneColumn>
           }
           onSite={[<NotionSiteTabs></NotionSiteTabs>]}

--- a/packages/designmanual/stories/organisms/NotionBlockExample.tsx
+++ b/packages/designmanual/stories/organisms/NotionBlockExample.tsx
@@ -6,31 +6,16 @@
  *
  */
 
-import styled from '@emotion/styled';
 import React, { Component } from 'react';
 //@ts-ignore
 import { addShowConceptDefinitionClickListeners } from '@ndla/article-scripts';
 import { OneColumn } from '@ndla/ui';
 import Helmet from 'react-helmet';
-import { breakpoints, mq } from '@ndla/core';
 import NotionBlock from '../molecules/NotionBlock';
 //@ts-ignore
 import ComponentInfo from '../ComponentInfo';
 //@ts-ignore
 import NotionSiteTabs from '../molecules/NotionSiteTabs';
-
-const ContentWrapper = styled.div`
-  position: relative !important;
-  right: auto !important;
-  left: -16.6666666667%;
-  width: 133.3333333333% !important;
-  padding-left: 24px;
-  padding-right: 24px;
-  ${mq.range({ until: breakpoints.tabletWide })} {
-    width: 100% !important;
-    left: 0 !important;
-  }
-`;
 
 class NotionBlockExample extends Component {
   componentDidMount() {
@@ -47,22 +32,16 @@ class NotionBlockExample extends Component {
           status={3}
           components={
             <OneColumn>
-              <ContentWrapper>
-                <h2>Begrep med visuelt element bilde</h2>
-              </ContentWrapper>
+              <h2 className="u-heading">Begrep med visuelt element bilde</h2>
               <NotionBlock type="image" hideIconsAndAuthors adjustSizeToFitWiderPage />
-              <ContentWrapper>
-                <h2>Begrep med visuelt element video</h2>
-              </ContentWrapper>
+              <h2 className="u-heading">Begrep med visuelt element video</h2>
               <NotionBlock type="video" hideIconsAndAuthors adjustSizeToFitWiderPage />
-              <ContentWrapper>
-                <h2>Begrep med visuelt element h5p</h2>
-              </ContentWrapper>
+              <h2 className="u-heading">Begrep med visuelt element h5p</h2>
               <NotionBlock type="h5p" hideIconsAndAuthors adjustSizeToFitWiderPage />
-              <ContentWrapper>
-                <h2>Begrep med forfatter og lisensikoner</h2>
-              </ContentWrapper>
+              <h2 className="u-heading">Begrep med forfatter og lisensikoner</h2>
               <NotionBlock type="image" adjustSizeToFitWiderPage />
+              <h2 className="u-heading">Begrep med manglende lisens</h2>
+              <NotionBlock type="image" data="other" adjustSizeToFitWiderPage />
             </OneColumn>
           }
           onSite={[<NotionSiteTabs></NotionSiteTabs>]}

--- a/packages/designmanual/stories/pages/SearchResult.jsx
+++ b/packages/designmanual/stories/pages/SearchResult.jsx
@@ -431,9 +431,9 @@ const SearchResult = ({ showCompetenceGoals }) => {
           onRemove={() => {
             setHideNotionsResult(true);
           }}>
-          <NotionBlock type="image" adjustSizeToFitWiderPage />
-          <NotionBlock type="video" adjustSizeToFitWiderPage />
-          <NotionBlock type="H5P" adjustSizeToFitWiderPage />
+          <NotionBlock type="image" />
+          <NotionBlock type="video" />
+          <NotionBlock type="H5P" />
         </SearchNotionsResult>
       )}
       {!showCompetenceGoals && <SearchSubjectResult id="search-result-content" items={subjectItems} />}

--- a/packages/ndla-ui/src/Notion/ConceptNotion.tsx
+++ b/packages/ndla-ui/src/Notion/ConceptNotion.tsx
@@ -18,20 +18,6 @@ import NotionVisualElement, { NotionVisualElementType } from './NotionVisualElem
 import FigureNotion from './FigureNotion';
 import { Copyright } from '../types';
 
-const ContentWrapper = styled.div<{ adjustSizeToFitWiderPage?: boolean }>`
-  position: relative;
-  right: auto;
-  left: ${(props) => (props.adjustSizeToFitWiderPage ? '0%' : '-16.6666666667%')};
-  width: ${(props) => (props.adjustSizeToFitWiderPage ? '100%' : '133.3333333333%')};
-  padding-left: 24px;
-  padding-right: 24px;
-
-  ${mq.range({ until: breakpoints.tabletWide })} {
-    width: 100%;
-    left: 0;
-  }
-`;
-
 const ImageWrapper = styled.div`
   float: right;
   padding-left: ${spacing.normal};
@@ -62,10 +48,9 @@ interface Props {
   concept: ConceptNotionType;
   disableScripts?: boolean;
   hideIconsAndAuthors?: boolean;
-  adjustSizeToFitWiderPage?: boolean;
 }
 
-const ConceptNotion = ({ concept, disableScripts, type, hideIconsAndAuthors, adjustSizeToFitWiderPage }: Props) => {
+const ConceptNotion = ({ concept, disableScripts, type, hideIconsAndAuthors }: Props) => {
   const notionId = `notion-${concept.id}`;
   const figureId = `notion-figure-${concept.id}`;
   const visualElementId = `visual-element-${concept.id}`;
@@ -78,104 +63,88 @@ const ConceptNotion = ({ concept, disableScripts, type, hideIconsAndAuthors, adj
   }, [disableScripts]);
 
   return (
-    <ContentWrapper adjustSizeToFitWiderPage={adjustSizeToFitWiderPage}>
-      <FigureNotion
-        resizeIframe
-        id={figureId}
-        figureId={visualElementId}
-        copyright={concept.copyright}
-        licenseString={concept.copyright?.license?.license ?? ''}
-        type="concept"
-        hideIconsAndAuthors={hideIconsAndAuthors}>
-        <UINotion
-          id={notionId}
-          title={concept.title}
-          text={concept.text}
-          imageElement={
-            concept.visualElement?.resource === 'image' && concept.visualElement.image ? (
-              <ImageWrapper>
-                <Notion
-                  id={notionId}
-                  ariaLabel={t('factbox.open')}
-                  title={concept.title}
-                  subTitle={t('searchPage.resultType.notionsHeading')}
-                  hideBaselineIcon
-                  content={
-                    <>
-                      <NotionDialogContent>
-                        {concept.visualElement?.resource === 'image' && concept.visualElement.image ? (
-                          <NotionVisualElement
-                            visualElement={concept.visualElement}
-                            id={notionId}
-                            figureId={figureId}
-                          />
-                        ) : undefined}
-                        <NotionDialogText>{concept.text}</NotionDialogText>
-                      </NotionDialogContent>
-                      <NotionDialogLicenses
-                        license={concept.copyright?.license?.license ?? ''}
-                        source={concept.source}
-                      />
-                    </>
-                  }>
-                  {concept.visualElement.image && (
-                    <NotionImage
-                      type={type}
-                      id={visualElementId}
-                      src={concept.visualElement.image.src}
-                      alt={concept.visualElement.image.alt ?? ''}
-                      imageCopyright={concept.visualElement.copyright}
-                    />
-                  )}
-                </Notion>
-              </ImageWrapper>
-            ) : undefined
-          }
-          visualElement={
-            concept.visualElement && concept.visualElement.resource !== 'image' && concept.visualElement.url ? (
-              <ImageWrapper>
-                <Notion
-                  id={notionId}
-                  ariaLabel={t('factbox.open')}
-                  title={concept.title}
-                  hideBaselineIcon
-                  subTitle={t('searchPage.resultType.notionsHeading')}
-                  content={
-                    <>
-                      <NotionDialogContent>
-                        {concept.visualElement &&
-                        concept.visualElement?.resource !== 'image' &&
-                        concept.visualElement.url ? (
-                          <NotionVisualElement
-                            visualElement={concept.visualElement}
-                            id={notionId}
-                            figureId={figureId}
-                          />
-                        ) : undefined}
+    <FigureNotion
+      resizeIframe
+      id={figureId}
+      figureId={visualElementId}
+      copyright={concept.copyright}
+      licenseString={concept.copyright?.license?.license ?? ''}
+      type="concept"
+      hideIconsAndAuthors={hideIconsAndAuthors}>
+      <UINotion
+        id={notionId}
+        title={concept.title}
+        text={concept.text}
+        imageElement={
+          concept.visualElement?.resource === 'image' && concept.visualElement.image ? (
+            <ImageWrapper>
+              <Notion
+                id={notionId}
+                ariaLabel={t('factbox.open')}
+                title={concept.title}
+                subTitle={t('searchPage.resultType.notionsHeading')}
+                hideBaselineIcon
+                content={
+                  <>
+                    <NotionDialogContent>
+                      {concept.visualElement?.resource === 'image' && concept.visualElement.image ? (
+                        <NotionVisualElement visualElement={concept.visualElement} id={notionId} figureId={figureId} />
+                      ) : undefined}
+                      <NotionDialogText>{concept.text}</NotionDialogText>
+                    </NotionDialogContent>
+                    <NotionDialogLicenses license={concept.copyright?.license?.license ?? ''} source={concept.source} />
+                  </>
+                }>
+                {concept.visualElement.image && (
+                  <NotionImage
+                    type={type}
+                    id={visualElementId}
+                    src={concept.visualElement.image.src}
+                    alt={concept.visualElement.image.alt ?? ''}
+                    imageCopyright={concept.visualElement.copyright}
+                  />
+                )}
+              </Notion>
+            </ImageWrapper>
+          ) : undefined
+        }
+        visualElement={
+          concept.visualElement && concept.visualElement.resource !== 'image' && concept.visualElement.url ? (
+            <ImageWrapper>
+              <Notion
+                id={notionId}
+                ariaLabel={t('factbox.open')}
+                title={concept.title}
+                hideBaselineIcon
+                subTitle={t('searchPage.resultType.notionsHeading')}
+                content={
+                  <>
+                    <NotionDialogContent>
+                      {concept.visualElement &&
+                      concept.visualElement?.resource !== 'image' &&
+                      concept.visualElement.url ? (
+                        <NotionVisualElement visualElement={concept.visualElement} id={notionId} figureId={figureId} />
+                      ) : undefined}
 
-                        <NotionDialogText>{concept.text}</NotionDialogText>
-                      </NotionDialogContent>
-                      <NotionDialogLicenses
-                        license={concept.copyright?.license?.license ?? ''}
-                        source={concept.source}
-                      />
-                    </>
-                  }>
-                  {concept.image && (
-                    <NotionImage
-                      type={type}
-                      id={visualElementId}
-                      src={concept.image?.src}
-                      alt={concept.image?.alt ?? ''}
-                      imageCopyright={concept.visualElement.copyright}
-                    />
-                  )}
-                </Notion>
-              </ImageWrapper>
-            ) : undefined
-          }></UINotion>
-      </FigureNotion>
-    </ContentWrapper>
+                      <NotionDialogText>{concept.text}</NotionDialogText>
+                    </NotionDialogContent>
+                    <NotionDialogLicenses license={concept.copyright?.license?.license ?? ''} source={concept.source} />
+                  </>
+                }>
+                {concept.image && (
+                  <NotionImage
+                    type={type}
+                    id={visualElementId}
+                    src={concept.image?.src}
+                    alt={concept.image?.alt ?? ''}
+                    imageCopyright={concept.visualElement.copyright}
+                  />
+                )}
+              </Notion>
+            </ImageWrapper>
+          ) : undefined
+        }></UINotion>
+    </FigureNotion>
   );
 };
 

--- a/packages/ndla-ui/src/Notion/ConceptNotion.tsx
+++ b/packages/ndla-ui/src/Notion/ConceptNotion.tsx
@@ -34,9 +34,7 @@ export interface ConceptNotionType {
   copyright?: Partial<Copyright>;
   title: string;
   text: string;
-  subjectNames?: string[];
   visualElement?: NotionVisualElementType;
-  authors: string[];
   source?: string;
   image?: {
     src: string;

--- a/packages/ndla-ui/src/Notion/FigureNotion.tsx
+++ b/packages/ndla-ui/src/Notion/FigureNotion.tsx
@@ -5,11 +5,18 @@
  * LICENSE file in the root directory of this source tree. *
  */
 
+import styled from '@emotion/styled';
+import { colors, spacing } from '@ndla/core';
 import { getGroupedContributorDescriptionList, getLicenseByAbbreviation } from '@ndla/licenses';
 import React, { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Figure, FigureCaption, FigureLicenseDialog } from '../Figure';
 import { Copyright } from '../types';
+
+const BottomBorder = styled.div`
+  margin-top: ${spacing.normal};
+  border-bottom: 1px solid ${colors.brand.greyLight};
+`;
 
 interface Props {
   resizeIframe?: boolean;
@@ -53,7 +60,7 @@ const FigureNotion = ({
       {({ typeClass }) => (
         <>
           {typeof children === 'function' ? children({ typeClass }) : children}
-          {copyright?.license?.license && (
+          {copyright?.license?.license ? (
             <FigureCaption
               hideFigcaption={hideFigCaption}
               figureId={figureId}
@@ -77,6 +84,8 @@ const FigureNotion = ({
                   title: t('title'),
                 }}></FigureLicenseDialog>
             </FigureCaption>
+          ) : (
+            <BottomBorder />
           )}
         </>
       )}

--- a/packages/ndla-ui/src/Notion/Notion.tsx
+++ b/packages/ndla-ui/src/Notion/Notion.tsx
@@ -43,6 +43,16 @@ const TextWrapper = styled.div<{ hasVisualElement: boolean }>`
   ${ContentWrapper} .c-figure.expanded + & {
     width: 100%;
   }
+  ${mq.range({ from: breakpoints.desktop })} {
+    ul,
+    ol {
+      margin: 12px 0;
+      padding: 0 1rem 0 2rem;
+    }
+    ol > li {
+      margin-left: 24px;
+    }
+  }
 `;
 
 const ClearWrapper = styled.div`

--- a/packages/util/src/__tests__/__snapshots__/markdownHelpers-test.ts.snap
+++ b/packages/util/src/__tests__/__snapshots__/markdownHelpers-test.ts.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parseMarkdown does not render richText when type=caption. 1`] = `
+Array [
+  <p>
+    ### Header
+ 
+    <strong>
+      bold
+    </strong>
+     
+
+    <em>
+      italic
+    </em>
+     
+\`code\` 
+
+    <sup>
+      sup
+    </sup>
+     
+
+    <sub>
+      sub
+    </sub>
+     
+Normal list: 
+* One 
+* Two 
+* Three 
+Ordered list: 
+1. 1 
+2. 2 
+3. 3
+  </p>,
+  "
+",
+]
+`;
+
+exports[`parseMarkdown renders body correctly. 1`] = `
+Array [
+  <h3>
+    Header
+  </h3>,
+  "
+",
+  <p>
+    <strong>
+      bold
+    </strong>
+    <br />
+    
+
+    <em>
+      italic
+    </em>
+    <br />
+    
+
+    <code>
+      code
+    </code>
+    <br />
+    
+
+    <sup>
+      sup
+    </sup>
+    <br />
+    
+
+    <sub>
+      sub
+    </sub>
+    <br />
+    
+Normal list:
+  </p>,
+  "
+",
+  <ul>
+    
+
+    <li>
+      One
+    </li>
+    
+
+    <li>
+      Two
+    </li>
+    
+
+    <li>
+      Three
+      <br />
+      
+Ordered list:
+    </li>
+    
+
+  </ul>,
+  "
+",
+  <ol>
+    
+
+    <li>
+      1
+    </li>
+    
+
+    <li>
+      2
+    </li>
+    
+
+    <li>
+      3
+    </li>
+    
+
+  </ol>,
+  "
+",
+]
+`;

--- a/packages/util/src/__tests__/__snapshots__/markdownHelpers-test.ts.snap
+++ b/packages/util/src/__tests__/__snapshots__/markdownHelpers-test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`parseMarkdown does not render richText when type=caption. 1`] = `
+exports[`parseMarkdown does not render block level elements when type=caption. 1`] = `
 Array [
   <p>
     ### Header

--- a/packages/util/src/__tests__/markdownHelpers-test.ts
+++ b/packages/util/src/__tests__/markdownHelpers-test.ts
@@ -19,7 +19,7 @@ test('parseMarkdown renders body correctly.', () => {
   expect(parsed).toMatchSnapshot();
 });
 
-test('parseMarkdown does not render richText when type=caption.', () => {
+test('parseMarkdown does not render block level elements when type=caption.', () => {
   const parsed = parseMarkdown(richMarkdown, 'caption');
 
   expect(parsed).toMatchSnapshot();

--- a/packages/util/src/__tests__/markdownHelpers-test.ts
+++ b/packages/util/src/__tests__/markdownHelpers-test.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/* eslint-env jest */
+
+import { parseMarkdown } from '../markdownHelpers';
+
+const richMarkdown =
+  '### Header\n **bold** \n_italic_ \n`code` \n^sup^ \n~sub~ \nNormal list: \n* One \n* Two \n* Three \nOrdered list: \n1. 1 \n2. 2 \n3. 3';
+
+test('parseMarkdown renders body correctly.', () => {
+  const parsed = parseMarkdown(richMarkdown, 'body');
+
+  expect(parsed).toMatchSnapshot();
+});
+
+test('parseMarkdown does not render richText when type=caption.', () => {
+  const parsed = parseMarkdown(richMarkdown, 'caption');
+
+  expect(parsed).toMatchSnapshot();
+});

--- a/packages/util/src/markdownHelpers.ts
+++ b/packages/util/src/markdownHelpers.ts
@@ -12,7 +12,7 @@ import parse from 'html-react-parser';
 
 export type ParseType = 'caption' | 'body';
 
-export const parseMarkdown = (embeddedCaption: string, parser: ParseType = 'caption') => {
+export const parseMarkdown = (content: string, parser: ParseType = 'caption') => {
   const markdown = new Remarkable({ breaks: true, html: true });
   markdown.inline.ruler.enable(['sub', 'sup']);
   if (parser === 'caption') {
@@ -44,13 +44,8 @@ export const parseMarkdown = (embeddedCaption: string, parser: ParseType = 'capt
       'text',
     ]);
   }
-  const caption = embeddedCaption || '';
-  /**
-   * Whitespace must be escaped in order for ^superscript^ and ~subscript~
-   * to render properly. Superfluous whitespace must be escaped in order for
-   * text within *italics* and *bold* to render properly.
-   */
-  const escapedMarkdown = markdown.render(caption.split(' ').join('\\ '));
-  const parsed = parse(escapedMarkdown.split('\\').join(''));
-  return Array.isArray(parsed) ? parsed[0] : parsed;
+  const rendered = markdown.render(content);
+  const parsed = parse(rendered);
+
+  return parsed;
 };


### PR DESCRIPTION
Avventer https://github.com/NDLANO/frontend-packages/pull/1115

Lister ble ikke rendret i blokkforklaring. Har derfor gjort noen endringer i markdownHelpers:
- Whitespace blir ikke lenger escaped ved parsing av markdown. 
   - Dette fører til at sub og sup KUN vil fungere dersom det ikke er whitespace som innhold. Ser ut til at dette er en forventet begrensning med markdown.
   - Lister fungerer nå. Parsing av disse ble forhindret av at whitespace ble escaped. Den klarte ikke å lese `1.\ Første listepunkt` som et listepunkt. Uten escaped whitespace blir det nå `1. Første listepunkt` som er riktig
- Har laget en enkel snapshot-test for å kunne oppdage om noe brekker dersom vi oppdaterer funksjonen mer i framtiden
- Lagt til eksempelvisning av forklaringsblokk med diverse markdown

Fjernet samtidig Figure fra visning av blokkforklaring da det ikke var naturlig å vise de med 133% bredde uten kontekst av å ligge i en artikkel. I noen tilfeller kunne forklaringen flyte utenfor skjermen.