### PR TITLE
Concept notion fixes. Markdown, list styling, iframe example.

### DIFF
--- a/packages/designmanual/stories/molecules/NotionBlock.tsx
+++ b/packages/designmanual/stories/molecules/NotionBlock.tsx
@@ -253,10 +253,8 @@ const conceptData = {
 };
 
 const getType = (type: string) => {
-  if (type === 'image' || type === 'video' || type === 'richtext' || type === 'iframe') {
+  if (type === 'image' || type === 'video' || type === 'richtext' || type === 'iframe' || type === 'h5p') {
     return type;
-  } else if (['h5p', 'external'].includes(type)) {
-    return 'h5p';
   }
   return 'other';
 };

--- a/packages/designmanual/stories/molecules/NotionBlock.tsx
+++ b/packages/designmanual/stories/molecules/NotionBlock.tsx
@@ -16,7 +16,6 @@ import { useRunOnlyOnce } from '../article/useRunOnlyOnce';
 
 const conceptData = {
   image: {
-    authors: [],
     title: 'And',
     source: 'https://www.snl.no',
     text: 'Ender tilhører andefamilien. I Norge har det vært vanlig å dele endene inn i tre grupper etter levevis: Gressender som spiser planter på grunt vann, dykkender som dykker etter virvelløse dyr, og fiskeender som spiser fisk. Ender ble husdyr i middelhavslandene kort tid før Kristi fødsel. Hos hannen, andriken, er de fire midtre halefjærene bøyd oppover. Som ofte ellers i fugleriket har hannen finere farger enn hunnen. Det finnes en rekke raser og krysninger. På bildet ser vi tamme ender, pekinand.',
@@ -51,7 +50,6 @@ const conceptData = {
     },
   },
   video: {
-    authors: [],
     text: 'I videoen kan du se en introduksjon til hva vi for eksempel mener når vi prater om «velferdsteknologi».',
     title: 'Velferdsteknologi',
     source: 'https://www.snl.no',
@@ -92,8 +90,49 @@ const conceptData = {
       },
     },
   },
+  iframe: {
+    title: 'Blodtyper',
+    text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    image: {
+      src: 'https://api.test.ndla.no/image-api/raw/id/32570',
+      alt: 'Blodtyper.',
+    },
+    copyright: {
+      license: {
+        license: 'CC-BY-SA-4.0',
+      },
+      creators: [
+        {
+          name: 'Fornavn Etternavn',
+          type: 'writer',
+        },
+      ],
+      processors: [
+        {
+          name: 'Et Byrå',
+          type: 'correction',
+        },
+      ],
+      rightsholders: [],
+    },
+    visualElement: {
+      resource: 'iframe',
+      title: 'Statistikk',
+      url: 'https://public.flourish.studio/visualisation/2152346/embed',
+      copyright: {
+        license: {
+          license: 'CC-BY-NC-SA-4.0',
+        },
+        creators: [
+          {
+            name: 'Vilkårlig Person',
+            type: 'Writer',
+          },
+        ],
+      },
+    },
+  },
   h5p: {
-    authors: [],
     title: 'Verdensrom og romskip',
     text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
     image: {
@@ -136,7 +175,6 @@ const conceptData = {
     },
   },
   other: {
-    authors: [],
     title: '6-akset robotarm',
     source: 'https://www.snl.no',
     text: 'En 6-akset robotarm betyr at den kan bevege seg i seks retninger. I akkurat denne konfigurasjonen eller løsningen kommer den sjette bevegelsesretningen av det robotarmen står på. I en slik løsning med transportband vil robotarmen ha større fleksibilitet og kan gjøre flere operasjoner raskere, for eksempel "pick and place" (plukk og plasser), som blir simulert her. Da kan man sortere ut varer eller enkeltprodukter på et samlebånd svært effektivt.',
@@ -179,7 +217,6 @@ const conceptData = {
     },
   },
   richtext: {
-    authors: [],
     title: '6-akset robotarm',
     source: 'https://www.snl.no',
     text: 'En 6-akset **robotarm** betyr at den kan bevege seg i seks `retninger`. I akkurat _denne_ konfigurasjonen eller løsningen kommer den ^sjette^ ~bevegelsesretningen~ av det robotarmen står på.\n1. I en slik løsning med transportband vil robotarmen ha større fleksibilitet og kan gjøre flere operasjoner raskere, for eksempel "pick and place" (plukk og plasser), som blir simulert her.\n2. Da kan man sortere ut varer eller enkeltprodukter på et samlebånd svært effektivt.',
@@ -188,6 +225,9 @@ const conceptData = {
       alt: 'Robotarmer i robotceller og på mobile enheter. Foto.',
     },
     copyright: {
+      license: {
+        license: 'CC-BY-SA-4.0',
+      },
       creators: [
         {
           name: 'Haldor Hove',
@@ -224,9 +264,9 @@ const conceptData = {
 };
 
 const getType = (type: string) => {
-  if (type === 'image' || type === 'video' || type === 'richtext') {
+  if (type === 'image' || type === 'video' || type === 'richtext' || type === 'iframe') {
     return type;
-  } else if (['iframe', 'h5p', 'external'].includes(type)) {
+  } else if (['h5p', 'external'].includes(type)) {
     return 'h5p';
   }
   return 'other';

--- a/packages/designmanual/stories/molecules/NotionBlock.tsx
+++ b/packages/designmanual/stories/molecules/NotionBlock.tsx
@@ -119,17 +119,6 @@ const conceptData = {
       resource: 'iframe',
       title: 'Statistikk',
       url: 'https://public.flourish.studio/visualisation/2152346/embed',
-      copyright: {
-        license: {
-          license: 'CC-BY-NC-SA-4.0',
-        },
-        creators: [
-          {
-            name: 'Vilkårlig Person',
-            type: 'Writer',
-          },
-        ],
-      },
     },
   },
   h5p: {

--- a/packages/designmanual/stories/molecules/NotionBlock.tsx
+++ b/packages/designmanual/stories/molecules/NotionBlock.tsx
@@ -188,7 +188,7 @@ const conceptData = {
     },
     visualElement: {
       title: 'Viper 6-akset robot',
-      resource: 'h5p',
+      resource: 'video',
       url: 'https://players.brightcove.net/4806596774001/BkLm8fT_default/index.html?videoId=6268441758001',
       copyright: {
         license: {
@@ -233,7 +233,7 @@ const conceptData = {
     },
     visualElement: {
       title: 'Viper 6-akset robot',
-      resource: 'h5p',
+      resource: 'video',
       url: 'https://players.brightcove.net/4806596774001/BkLm8fT_default/index.html?videoId=6268441758001',
       copyright: {
         license: {
@@ -274,6 +274,7 @@ const NotionBlock = ({ type, hideIconsAndAuthors, data }: Props) => {
 
   return (
     <ConceptNotion
+      disableScripts
       hideIconsAndAuthors={hideIconsAndAuthors}
       type={type}
       concept={{ ...conceptData[getType(data || type)], id }}

--- a/packages/designmanual/stories/organisms/NotionBlockExample.tsx
+++ b/packages/designmanual/stories/organisms/NotionBlockExample.tsx
@@ -38,6 +38,8 @@ class NotionBlockExample extends Component {
               <NotionBlock type="video" hideIconsAndAuthors />
               <h2 className="u-heading">Begrep med visuelt element h5p</h2>
               <NotionBlock type="h5p" hideIconsAndAuthors />
+              <h2 className="u-heading">Begrep med visuelt element iframe</h2>
+              <NotionBlock type="iframe" hideIconsAndAuthors />
               <h2 className="u-heading">Begrep med forfatter og lisensikoner</h2>
               <NotionBlock type="image" />
               <h2 className="u-heading">Begrep med manglende lisens</h2>

--- a/packages/ndla-article-scripts/src/conceptScripts.js
+++ b/packages/ndla-article-scripts/src/conceptScripts.js
@@ -137,7 +137,7 @@ export const addShowConceptDefinitionClickListeners = () => {
             },
             '*',
           );
-          popup.querySelectorAll('iframe').forEach((iframe) => resizeIframeElement(iframe));
+          popup.querySelectorAll('iframe').forEach((iframe) => resizeIframeElement(iframe, false, true));
         } else {
           jump(popup, {
             duration: 300,
@@ -170,10 +170,12 @@ export const addShowConceptDefinitionClickListeners = () => {
       popup.setAttribute('aria-hidden', true);
       window.removeEventListener('keyup', ESCKeyListener, true);
       openBtn.focus();
-      let iframe_tag = popup.querySelector('iframe');
-      if (iframe_tag) {
-        let iframeSrc = iframe_tag.src;
-        iframe_tag.src = iframeSrc;
+      let iframe = popup.querySelector('iframe');
+      if (iframe) {
+        const src = iframe.src;
+        if (src.match(/brightcove|youtube|youtu.be/g)) {
+          resetIframeElement(iframe);
+        }
       }
     };
   });

--- a/packages/ndla-article-scripts/src/conceptScripts.js
+++ b/packages/ndla-article-scripts/src/conceptScripts.js
@@ -9,7 +9,7 @@
 import jump from 'jump.js';
 
 import { forEachElement, inIframe, getElementOffset } from './domHelpers';
-import { resetIframeElement, resizeIframeElement } from './figureScripts';
+import { resetIframeElement, initOpenedIframe } from './figureScripts';
 
 const closeAllVisibleNotions = (returnFocusToParent) => {
   forEachElement('[data-notion]', (item) => {
@@ -137,7 +137,10 @@ export const addShowConceptDefinitionClickListeners = () => {
             },
             '*',
           );
-          popup.querySelectorAll('iframe').forEach((iframe) => resizeIframeElement(iframe, false, true));
+
+          popup.querySelectorAll('iframe').forEach((iframe) => {
+            initOpenedIframe(iframe);
+          });
         } else {
           jump(popup, {
             duration: 300,

--- a/packages/ndla-article-scripts/src/conceptScripts.js
+++ b/packages/ndla-article-scripts/src/conceptScripts.js
@@ -48,7 +48,7 @@ const checkClickOutside = (e) => {
   let { target } = e;
   let clickedInside = false;
   while (target.nodeName !== 'BODY' && !clickedInside) {
-    if (target.getAttribute('data-concept-id')) {
+    if (target.getAttribute('data-concept-id') || target.getAttribute('data-dialog-id')) {
       clickedInside = true;
     } else {
       target = target.parentNode;

--- a/packages/ndla-article-scripts/src/conceptScripts.js
+++ b/packages/ndla-article-scripts/src/conceptScripts.js
@@ -9,6 +9,7 @@
 import jump from 'jump.js';
 
 import { forEachElement, inIframe, getElementOffset } from './domHelpers';
+import { resetIframeElement, resizeIframeElement } from './figureScripts';
 
 const closeAllVisibleNotions = (returnFocusToParent) => {
   forEachElement('[data-notion]', (item) => {
@@ -17,12 +18,11 @@ const closeAllVisibleNotions = (returnFocusToParent) => {
     if (popup.classList.contains('visible')) {
       popup.classList.remove('visible');
       popup.setAttribute('aria-hidden', true);
-      let iframe_tag = popup.querySelector('iframe');
-      if (iframe_tag) {
-        let iframeSrc = iframe_tag.src;
-        iframe_tag.src = iframeSrc;
+      const iframe = popup.querySelector('iframe');
+      const src = iframe.src;
+      if (src.match(/brightcove|youtube|youtu.be/g)) {
+        resetIframeElement(iframe);
       }
-
       if (returnFocusToParent) {
         const openBtn = item.querySelector('[data-notion-link]');
         openBtn.focus();
@@ -137,6 +137,7 @@ export const addShowConceptDefinitionClickListeners = () => {
             },
             '*',
           );
+          popup.querySelectorAll('iframe').forEach((iframe) => resizeIframeElement(iframe));
         } else {
           jump(popup, {
             duration: 300,

--- a/packages/ndla-article-scripts/src/figureScripts.js
+++ b/packages/ndla-article-scripts/src/figureScripts.js
@@ -57,9 +57,7 @@ export const addCopyToClipboardListeners = () => {
   });
 };
 
-export const resizeIframeElement = (el, init = false) => {
-  const iframe = el;
-
+export const resizeIframeElement = (iframe, init = false, onOpen = false) => {
   const parent = iframe.parentNode;
   let ratio = 0.5625;
   const computedStyle = window.getComputedStyle(parent);
@@ -69,9 +67,9 @@ export const resizeIframeElement = (el, init = false) => {
 
   if (init && iframe.width && iframe.height) {
     ratio = iframe.height / iframe.width;
-    el.setAttribute('data-ratio', ratio);
+    iframe.setAttribute('data-ratio', ratio);
   } else {
-    const ratioAttr = el.getAttribute('data-ratio');
+    const ratioAttr = iframe.getAttribute('data-ratio');
     if (ratioAttr) {
       ratio = parseFloat(ratioAttr);
     }
@@ -79,9 +77,8 @@ export const resizeIframeElement = (el, init = false) => {
 
   const newHeight = parentWidth * ratio;
   const type = iframe.getAttribute('type');
-  if (type === 'h5p') {
-    console.log(iframe);
-    resetIframeElement(iframe);
+  if (type === 'h5p' && onOpen) {
+    resetIframeElement(iframe, true);
   }
 
   // fix for elements not visible
@@ -94,9 +91,18 @@ export const resizeIframeElement = (el, init = false) => {
   }
 };
 
-export const resetIframeElement = (el) => {
-  const iframe = el;
+export const resetIframeElement = (iframe, runOnce = false) => {
   if (iframe) {
+    if (runOnce) {
+      const reset = iframe.getAttribute('data-reset');
+      if (reset === 'true') {
+        return;
+      }
+      iframe.setAttribute('data-reset', 'true');
+    }
+
+    console.log('reset');
+
     const src = iframe.src;
     iframe.src = src;
   }

--- a/packages/ndla-article-scripts/src/figureScripts.js
+++ b/packages/ndla-article-scripts/src/figureScripts.js
@@ -57,42 +57,53 @@ export const addCopyToClipboardListeners = () => {
   });
 };
 
+export const resizeIframeElement = (el, init = false) => {
+  const iframe = el;
+
+  const parent = iframe.parentNode;
+  let ratio = 0.5625;
+  const computedStyle = window.getComputedStyle(parent);
+  const paddingLeft = parseFloat(computedStyle.paddingLeft);
+  const paddingRight = parseFloat(computedStyle.paddingRight);
+  const parentWidth = parent.clientWidth - paddingLeft - paddingRight;
+
+  if (init && iframe.width && iframe.height) {
+    ratio = iframe.height / iframe.width;
+    el.setAttribute('data-ratio', ratio);
+  } else {
+    const ratioAttr = el.getAttribute('data-ratio');
+    if (ratioAttr) {
+      ratio = parseFloat(ratioAttr);
+    }
+  }
+
+  const newHeight = parentWidth * ratio;
+  const type = iframe.getAttribute('type');
+  if (type === 'h5p') {
+    console.log(iframe);
+    resetIframeElement(iframe);
+  }
+
+  // fix for elements not visible
+  if (newHeight > 0) {
+    iframe.height = newHeight;
+  }
+
+  if (parentWidth > 0) {
+    iframe.width = parentWidth;
+  }
+};
+
+export const resetIframeElement = (el) => {
+  const iframe = el;
+  if (iframe) {
+    const src = iframe.src;
+    iframe.src = src;
+  }
+};
+
 export const updateIFrameDimensions = (init = true, topNode = null) => {
-  forEachElement(
-    '.c-figure--resize iframe',
-    (el) => {
-      const iframe = el;
-      const parent = iframe.parentNode;
-      let ratio = 0.5625;
-
-      const computedStyle = window.getComputedStyle(parent);
-      const paddingLeft = parseFloat(computedStyle.paddingLeft);
-      const paddingRight = parseFloat(computedStyle.paddingRight);
-      const parentWidth = parent.clientWidth - paddingLeft - paddingRight;
-
-      if (init && iframe.width && iframe.height) {
-        ratio = iframe.height / iframe.width;
-        el.setAttribute('data-ratio', ratio);
-      } else {
-        const ratioAttr = el.getAttribute('data-ratio');
-        if (ratioAttr) {
-          ratio = parseFloat(ratioAttr);
-        }
-      }
-
-      const newHeight = parentWidth * ratio;
-
-      // fix for elements not visible
-      if (newHeight > 0) {
-        iframe.height = newHeight;
-      }
-
-      if (parentWidth > 0) {
-        iframe.width = parentWidth;
-      }
-    },
-    topNode,
-  );
+  forEachElement('.c-figure--resize iframe', (el) => resizeIframeElement(el, init), topNode);
 };
 
 export const addEventListenerForFigureZoomButton = () => {

--- a/packages/ndla-article-scripts/src/figureScripts.js
+++ b/packages/ndla-article-scripts/src/figureScripts.js
@@ -57,7 +57,7 @@ export const addCopyToClipboardListeners = () => {
   });
 };
 
-export const resizeIframeElement = (iframe, init = false, onOpen = false) => {
+export const resizeIframeElement = (iframe, init = false) => {
   const parent = iframe.parentNode;
   let ratio = 0.5625;
   const computedStyle = window.getComputedStyle(parent);
@@ -76,10 +76,6 @@ export const resizeIframeElement = (iframe, init = false, onOpen = false) => {
   }
 
   const newHeight = parentWidth * ratio;
-  const type = iframe.getAttribute('type');
-  if (type === 'h5p' && onOpen) {
-    resetIframeElement(iframe, true);
-  }
 
   // fix for elements not visible
   if (newHeight > 0) {
@@ -91,18 +87,24 @@ export const resizeIframeElement = (iframe, init = false, onOpen = false) => {
   }
 };
 
-export const resetIframeElement = (iframe, runOnce = false) => {
+export const initOpenedIframe = (iframe) => {
+  resizeIframeElement(iframe);
+
   if (iframe) {
-    if (runOnce) {
+    const type = iframe.getAttribute('type');
+    if (type === 'h5p') {
       const reset = iframe.getAttribute('data-reset');
       if (reset === 'true') {
         return;
       }
       iframe.setAttribute('data-reset', 'true');
+      resetIframeElement(iframe);
     }
+  }
+};
 
-    console.log('reset');
-
+export const resetIframeElement = (iframe) => {
+  if (iframe) {
     const src = iframe.src;
     iframe.src = src;
   }

--- a/packages/ndla-notion/src/NotionDialog.tsx
+++ b/packages/ndla-notion/src/NotionDialog.tsx
@@ -11,6 +11,17 @@ const NotionDialogContentWrapper = styled.div`
   padding-bottom: ${spacing.normal};
   display: flex;
   flex-direction: column;
+
+  ${mq.range({ from: breakpoints.desktop })} {
+    ul,
+    ol {
+      margin: 12px 0;
+      padding: 0 1rem 0 2rem;
+    }
+    ol > li {
+      margin-left: 24px;
+    }
+  }
 `;
 
 interface NotionDialogContentProps extends HTMLProps<HTMLDivElement> {

--- a/packages/ndla-ui/src/Notion/ConceptNotion.tsx
+++ b/packages/ndla-ui/src/Notion/ConceptNotion.tsx
@@ -11,13 +11,13 @@ import React, { useEffect } from 'react';
 import { initArticleScripts } from '@ndla/article-scripts';
 import { useTranslation } from 'react-i18next';
 import { breakpoints, mq, spacing } from '@ndla/core';
+import { parseMarkdown } from '@ndla/util';
 import Notion, { NotionDialogContent, NotionDialogText, NotionDialogLicenses } from '@ndla/notion';
 import { Notion as UINotion } from '.';
 import { NotionImage } from './NotionImage';
 import NotionVisualElement, { NotionVisualElementType } from './NotionVisualElement';
 import FigureNotion from './FigureNotion';
 import { Copyright } from '../types';
-import { parseMarkdown } from '../../../util/src';
 
 const ImageWrapper = styled.div`
   float: right;

--- a/packages/ndla-ui/src/Notion/ConceptNotion.tsx
+++ b/packages/ndla-ui/src/Notion/ConceptNotion.tsx
@@ -17,6 +17,7 @@ import { NotionImage } from './NotionImage';
 import NotionVisualElement, { NotionVisualElementType } from './NotionVisualElement';
 import FigureNotion from './FigureNotion';
 import { Copyright } from '../types';
+import { parseMarkdown } from '../../../util/src';
 
 const ImageWrapper = styled.div`
   float: right;
@@ -88,7 +89,7 @@ const ConceptNotion = ({ concept, disableScripts, type, hideIconsAndAuthors }: P
                       {concept.visualElement?.resource === 'image' && concept.visualElement.image ? (
                         <NotionVisualElement visualElement={concept.visualElement} id={notionId} figureId={figureId} />
                       ) : undefined}
-                      <NotionDialogText>{concept.text}</NotionDialogText>
+                      <NotionDialogText>{parseMarkdown(concept.text, 'body')}</NotionDialogText>
                     </NotionDialogContent>
                     <NotionDialogLicenses license={concept.copyright?.license?.license ?? ''} source={concept.source} />
                   </>
@@ -124,7 +125,7 @@ const ConceptNotion = ({ concept, disableScripts, type, hideIconsAndAuthors }: P
                         <NotionVisualElement visualElement={concept.visualElement} id={notionId} figureId={figureId} />
                       ) : undefined}
 
-                      <NotionDialogText>{concept.text}</NotionDialogText>
+                      <NotionDialogText>{parseMarkdown(concept.text, 'body')}</NotionDialogText>
                     </NotionDialogContent>
                     <NotionDialogLicenses license={concept.copyright?.license?.license ?? ''} source={concept.source} />
                   </>

--- a/packages/ndla-ui/src/Notion/FigureNotion.tsx
+++ b/packages/ndla-ui/src/Notion/FigureNotion.tsx
@@ -26,7 +26,7 @@ interface Props {
   title?: string;
   copyright?: Partial<Copyright>;
   licenseString: string;
-  type: 'video' | 'h5p' | 'image' | 'concept';
+  type: 'video' | 'h5p' | 'image' | 'concept' | 'other';
   hideFigCaption?: boolean;
   hideIconsAndAuthors?: boolean;
 }

--- a/packages/ndla-ui/src/Notion/Notion.tsx
+++ b/packages/ndla-ui/src/Notion/Notion.tsx
@@ -11,8 +11,6 @@ import { useTranslation } from 'react-i18next';
 import { parseMarkdown } from '@ndla/util';
 import { breakpoints, fonts, mq, spacing } from '@ndla/core';
 
-const NotionContainer = styled.div``;
-
 const ContentWrapper = styled.div`
   ${mq.range({ until: breakpoints.tabletWide })} {
     display: flex;
@@ -31,6 +29,16 @@ const ContentWrapper = styled.div`
       padding: 0;
     }
   }
+  ${mq.range({ from: breakpoints.desktop })} {
+    ul,
+    ol {
+      margin: 12px 0;
+      padding: 0 1rem 0 2rem;
+    }
+    ol > li {
+      margin-left: 24px;
+    }
+  }
 `;
 const TextWrapper = styled.div<{ hasVisualElement: boolean }>`
   width: ${(props) => (props.hasVisualElement ? '75%' : '100%')};
@@ -42,16 +50,6 @@ const TextWrapper = styled.div<{ hasVisualElement: boolean }>`
   ${fonts.sizes('18px', '28px')};
   ${ContentWrapper} .c-figure.expanded + & {
     width: 100%;
-  }
-  ${mq.range({ from: breakpoints.desktop })} {
-    ul,
-    ol {
-      margin: 12px 0;
-      padding: 0 1rem 0 2rem;
-    }
-    ol > li {
-      margin-left: 24px;
-    }
   }
 `;
 
@@ -81,7 +79,7 @@ const Notion = ({ id, labels = [], text, title, visualElement, imageElement, chi
   const { t } = useTranslation();
 
   return (
-    <NotionContainer>
+    <div>
       <ContentWrapper>
         {imageElement}
         {visualElement}
@@ -103,7 +101,7 @@ const Notion = ({ id, labels = [], text, title, visualElement, imageElement, chi
         <ClearWrapper />
       </ContentWrapper>
       {children}
-    </NotionContainer>
+    </div>
   );
 };
 

--- a/packages/ndla-ui/src/Notion/Notion.tsx
+++ b/packages/ndla-ui/src/Notion/Notion.tsx
@@ -29,16 +29,6 @@ const ContentWrapper = styled.div`
       padding: 0;
     }
   }
-  ${mq.range({ from: breakpoints.desktop })} {
-    ul,
-    ol {
-      margin: 12px 0;
-      padding: 0 1rem 0 2rem;
-    }
-    ol > li {
-      margin-left: 24px;
-    }
-  }
 `;
 const TextWrapper = styled.div<{ hasVisualElement: boolean }>`
   width: ${(props) => (props.hasVisualElement ? '75%' : '100%')};
@@ -50,6 +40,16 @@ const TextWrapper = styled.div<{ hasVisualElement: boolean }>`
   ${fonts.sizes('18px', '28px')};
   ${ContentWrapper} .c-figure.expanded + & {
     width: 100%;
+  }
+  ${mq.range({ from: breakpoints.desktop })} {
+    ul,
+    ol {
+      margin: 12px 0;
+      padding: 0 1rem 0 2rem;
+    }
+    ol > li {
+      margin-left: 24px;
+    }
   }
 `;
 

--- a/packages/ndla-ui/src/Notion/NotionImage.tsx
+++ b/packages/ndla-ui/src/Notion/NotionImage.tsx
@@ -38,7 +38,7 @@ const StyledImage = styled(Image)`
 `;
 
 interface Props {
-  type?: 'image' | 'video' | 'h5p' | 'iframe' | 'external';
+  type: 'image' | 'video' | 'h5p' | 'iframe' | 'external' | undefined;
   id: string;
   src: string;
   alt: string;

--- a/packages/ndla-ui/src/Notion/NotionVisualElement.tsx
+++ b/packages/ndla-ui/src/Notion/NotionVisualElement.tsx
@@ -43,10 +43,10 @@ const getType = (resource: string) => {
   if (resource === 'brightcove') {
     return 'video';
   }
-  if (resource === 'image') {
-    return 'image';
+  if (resource === 'image' || resource === 'h5p') {
+    return resource;
   }
-  return 'h5p';
+  return 'other';
 };
 
 const NotionVisualElement = ({ visualElement, id, figureId }: Props) => {


### PR DESCRIPTION
Alt kan testes i https://frontend-packages-pr-1118.ndla.sh/?path=/story/sammensatte-moduler--blokkvisning-begrepsforklaring

Har et par oppdatering til:
- Stylingen på lister fungerer generelt ikke bra for lister som vises utenfor artikler. Dette burde klart fikses senere. Kanskje etter omskriving fra sass til emotion. Inntil videre må styling for lister overstyres.
    - Test: Sjekk at listen i eksempel holder seg innenfor boksen for alle skjermbredder.
- Rendrer markdown i forklarings-modal.
    - Test: Sjekk eksempel. Viktig at spesielt subscript/superscript og liste fungerer.
- Video iframes tilbakestilles ved hver gang en modal lukkes for å stanse avspilling
    - Test: Start video i modal og lukk den. Video skal stoppe.
- H5P får tilbakestilt source (tvinge ny render) første gang modalen åpnes. Ser så langt ut som at h5p alltid vises riktig.
    - Test: Åpne H5P og se at H5p vises på første forsøk. (må refreshe siden og teste på nytt opptil 10 ganger for å være sikker)
- Tilbakestilling av video påvirker ikke lenger alle iframes. Iframe av type=iframe beholder nå riktig størrelse selv etter gjentatte åpning/lukking av modalen. 
   - Test: Åpne og lukke iframe flere ganger på rad. Den skal alltid beholde størrelsen og innhold.