### PR TITLE
Remove FigureCaption from NotionImage

### DIFF
--- a/packages/designmanual/stories/molecules/NotionBlock.tsx
+++ b/packages/designmanual/stories/molecules/NotionBlock.tsx
@@ -188,7 +188,7 @@ const conceptData = {
     },
     visualElement: {
       title: 'Viper 6-akset robot',
-      resource: 'video',
+      resource: 'brightcove',
       url: 'https://players.brightcove.net/4806596774001/BkLm8fT_default/index.html?videoId=6268441758001',
       copyright: {
         license: {
@@ -233,7 +233,7 @@ const conceptData = {
     },
     visualElement: {
       title: 'Viper 6-akset robot',
-      resource: 'video',
+      resource: 'brightcove',
       url: 'https://players.brightcove.net/4806596774001/BkLm8fT_default/index.html?videoId=6268441758001',
       copyright: {
         license: {

--- a/packages/designmanual/stories/organisms/NotionBlockExample.tsx
+++ b/packages/designmanual/stories/organisms/NotionBlockExample.tsx
@@ -43,9 +43,9 @@ class NotionBlockExample extends Component {
               <h2 className="u-heading">Begrep med forfatter og lisensikoner</h2>
               <NotionBlock type="image" />
               <h2 className="u-heading">Begrep med manglende lisens</h2>
-              <NotionBlock type="image" data="other" />
+              <NotionBlock type="video" data="other" />
               <h2 className="u-heading">Begrep med markdown-innhold</h2>
-              <NotionBlock type="image" data="richtext" />
+              <NotionBlock type="video" data="richtext" />
             </OneColumn>
           }
           onSite={[<NotionSiteTabs></NotionSiteTabs>]}

--- a/packages/ndla-ui/src/Notion/ConceptNotion.tsx
+++ b/packages/ndla-ui/src/Notion/ConceptNotion.tsx
@@ -100,7 +100,6 @@ const ConceptNotion = ({ concept, disableScripts, type, hideIconsAndAuthors }: P
                     id={visualElementId}
                     src={concept.visualElement.image.src}
                     alt={concept.visualElement.image.alt ?? ''}
-                    imageCopyright={concept.visualElement.copyright}
                   />
                 )}
               </Notion>
@@ -136,7 +135,6 @@ const ConceptNotion = ({ concept, disableScripts, type, hideIconsAndAuthors }: P
                     id={visualElementId}
                     src={concept.image?.src}
                     alt={concept.image?.alt ?? ''}
-                    imageCopyright={concept.visualElement.copyright}
                   />
                 )}
               </Notion>

--- a/packages/ndla-ui/src/Notion/NotionImage.tsx
+++ b/packages/ndla-ui/src/Notion/NotionImage.tsx
@@ -10,9 +10,7 @@ import styled from '@emotion/styled';
 import { animations, breakpoints, mq, spacing } from '@ndla/core';
 import { useTranslation } from 'react-i18next';
 import Image from '../Image';
-import { FigureOpenDialogButton } from '../Figure';
-import { Copyright } from '../types';
-import FigureNotion from './FigureNotion';
+import { Figure, FigureOpenDialogButton } from '../Figure';
 
 const StyledImageWrapper = styled.div`
   overflow: hidden;
@@ -42,40 +40,29 @@ interface Props {
   id: string;
   src: string;
   alt: string;
-  imageCopyright?: Partial<Copyright>;
 }
-export const NotionImage = ({ id, src, alt, imageCopyright, type }: Props) => {
+export const NotionImage = ({ id, src, alt, type }: Props) => {
   const { t } = useTranslation();
 
-  const imageId = `image-${id}`;
   const imageFigureId = `image-figure-${id}`;
 
   return (
-    <FigureNotion
-      hideFigCaption
-      figureId={imageFigureId}
-      id={imageId}
-      title={alt}
-      copyright={imageCopyright}
-      licenseString={imageCopyright?.license?.license ?? ''}
-      type={'image'}>
-      {({ typeClass }) => (
-        <StyledImageWrapper>
-          <StyledImage
-            alt={alt}
-            src={src}
-            expandButton={
-              <FigureOpenDialogButton
-                type={type}
-                messages={{
-                  zoomImageButtonLabel: t('license.images.itemImage.zoomImageButtonLabel'),
-                  zoomOutImageButtonLabel: t('license.image.itemImage.zoomOutImageButtonLabel'),
-                }}
-              />
-            }
-          />
-        </StyledImageWrapper>
-      )}
-    </FigureNotion>
+    <Figure resizeIframe id={imageFigureId} type={'full-column'}>
+      <StyledImageWrapper>
+        <StyledImage
+          alt={alt}
+          src={src}
+          expandButton={
+            <FigureOpenDialogButton
+              type={type}
+              messages={{
+                zoomImageButtonLabel: t('license.images.itemImage.zoomImageButtonLabel'),
+                zoomOutImageButtonLabel: t('license.image.itemImage.zoomOutImageButtonLabel'),
+              }}
+            />
+          }
+        />
+      </StyledImageWrapper>
+    </Figure>
   );
 };


### PR DESCRIPTION
Bilder i blokkforklaring skal ikke lenger vise lisensknapper. Fjerner derfor bruk av FigureCaption. Dette løser samtidig et problem med at det kom grå border under bildet dersom lisens ikke eksisterte.