### PR TITLE
Bugfix conceptnotion illegal html

### DIFF
--- a/packages/ndla-ui/src/Figure/FigureOpenDialogButton.tsx
+++ b/packages/ndla-ui/src/Figure/FigureOpenDialogButton.tsx
@@ -19,11 +19,10 @@ interface Props {
   };
 }
 
-export function FigureOpenDialogButton({ messages, type }: Props) {
+export const FigureOpenDialogButton = ({ messages, type }: Props) => {
   return (
-    <button
+    <div
       className="c-figure__fullscreen-btn"
-      type="button"
       data-aria={messages.zoomImageButtonLabel}
       data-ariaexpanded={messages.zoomOutImageButtonLabel}
       aria-label={messages.zoomImageButtonLabel}>
@@ -32,6 +31,6 @@ export function FigureOpenDialogButton({ messages, type }: Props) {
       {type === 'iframe' && <CursorClick style={{ width: '24px', height: '24px' }} />}
       {type === 'external' && <CursorClick style={{ width: '24px', height: '24px' }} />}
       {type === 'video' && <Play style={{ width: '24px', height: '24px' }} />}
-    </button>
+    </div>
   );
-}
+};

--- a/packages/ndla-ui/src/Notion/NotionImage.tsx
+++ b/packages/ndla-ui/src/Notion/NotionImage.tsx
@@ -19,17 +19,19 @@ const StyledImageWrapper = styled.div`
   ${mq.range({ until: breakpoints.tabletWide })} {
     margin: 0 auto;
   }
+  &:hover {
+    img {
+      transform: scale(1.1);
+      opacity: 1.1;
+      transition-duration: 0.5s;
+    }
+  }
 `;
 
 const StyledImage = styled(Image)`
   object-fit: cover;
   max-height: 162px;
   transition: transform ${animations.durations.fast};
-  &:hover {
-    transform: scale(1.1);
-    opacity: 1.1;
-    transition-duration: 0.5s;
-  }
   ${mq.range({ until: breakpoints.tabletWide })} {
     min-width: 260px;
   }


### PR DESCRIPTION
Fikser et obskurt problem som oppsto i article-converter der den statiske HTML-en som ble generert var fullstendig stokket om på. Dette viste seg å være cheerio som ikke aksepterte `<button>` inni `<button>` og antakelig forsøkte å normalisere HTML-en på et vis. Vel å merke uten å produsere feilmeldinger.

Om dette skal testes må man spinne opp ed lokalt og article-converter med ndla-ui linket inn. 

Her er skjermbilde med frontend-packages linket inn:
![image](https://user-images.githubusercontent.com/17144211/168981300-9ce4890e-dfad-4c15-b39d-88c503d1b563.png)

Uten frontend-packages linket inn:
![image](https://user-images.githubusercontent.com/17144211/168981619-4f0d1969-d5ba-41fc-b78b-fab7e760ae2e.png)

