### PR TITLE
Run iframe resize in concepts also when in production environment

### DIFF
--- a/packages/ndla-article-scripts/src/conceptScripts.js
+++ b/packages/ndla-article-scripts/src/conceptScripts.js
@@ -137,16 +137,16 @@ export const addShowConceptDefinitionClickListeners = () => {
             },
             '*',
           );
-
-          popup.querySelectorAll('iframe').forEach((iframe) => {
-            initOpenedIframe(iframe);
-          });
         } else {
           jump(popup, {
             duration: 300,
             offset,
           });
         }
+        popup.querySelectorAll('iframe').forEach((iframe) => {
+          initOpenedIframe(iframe);
+        });
+
         window.addEventListener('keyup', ESCKeyListener, true);
         window.addEventListener('mousedown', checkClickOutside, true);
         closeBtn.focus();


### PR DESCRIPTION
Scriptet som resizet iframes ved åpning ble kun kjørt når innholdet var plassert i en iframe viewport. Dette skal kjøres uansett om det er i en iframe viewport (blant annet i designmanual) og i ed/ndla-frontend.