### PR TITLE
Concept iframe resize fix

### DIFF
--- a/packages/designmanual/stories/molecules/NotionBlock.tsx
+++ b/packages/designmanual/stories/molecules/NotionBlock.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import { ConceptNotion } from '@ndla/ui';
+import { FigureType } from '@ndla/ui/src/Figure';
 // @ts-ignore
 import { initArticleScripts } from '@ndla/article-scripts';
 import { uuid } from '@ndla/util';
@@ -263,9 +264,10 @@ type Props = {
   type: 'image' | 'video' | 'h5p' | 'iframe' | 'external';
   hideIconsAndAuthors?: boolean;
   data?: 'image' | 'video' | 'h5p' | 'iframe' | 'external' | 'other' | 'richtext';
+  figureType?: FigureType;
 };
 
-const NotionBlock = ({ type, hideIconsAndAuthors, data }: Props) => {
+const NotionBlock = ({ type, hideIconsAndAuthors, data, figureType }: Props) => {
   const id = useRunOnlyOnce(uuid(), () => {
     initArticleScripts();
   });
@@ -275,6 +277,7 @@ const NotionBlock = ({ type, hideIconsAndAuthors, data }: Props) => {
       disableScripts
       hideIconsAndAuthors={hideIconsAndAuthors}
       type={type}
+      figureType={figureType}
       concept={{ ...conceptData[getType(data || type)], id }}
     />
   );

--- a/packages/designmanual/stories/molecules/NotionSiteTabs.jsx
+++ b/packages/designmanual/stories/molecules/NotionSiteTabs.jsx
@@ -72,9 +72,7 @@ const NotionSiteTabs = () => {
                             eventuelt jobber sammen med i klassen.
                           </p>
                           <FigureImage alt="" src="https://api.staging.ndla.no/image-api/raw/42-45210905.jpg" />
-                          <Figure type="full">
-                            <NotionBlock type="image" hideIconsAndAuthors></NotionBlock>
-                          </Figure>
+                          <NotionBlock type="image" figureType="full" hideIconsAndAuthors></NotionBlock>
                           <p>
                             En pitch er en kortvarig framføring av en idé for en potensiell samarbeidspartner eller
                             kunde. I løpet av noen få minutter skal du få andre til å tenne på idéen din og se

--- a/packages/ndla-article-scripts/src/conceptScripts.js
+++ b/packages/ndla-article-scripts/src/conceptScripts.js
@@ -49,7 +49,7 @@ const checkClickOutside = (e) => {
   // click out side will close concept box.
   let { target } = e;
   let clickedInside = false;
-  while (target.nodeName !== 'BODY' && !clickedInside) {
+  while (target && target.nodeName !== 'BODY' && !clickedInside) {
     if (target.getAttribute('data-concept-id') || target.getAttribute('data-dialog-id')) {
       clickedInside = true;
     } else {
@@ -94,22 +94,21 @@ export const addShowConceptDefinitionClickListeners = () => {
         const parentOffset = getElementOffset(popup.offsetParent).top;
         const openBtnBottom = openBtn.getBoundingClientRect().bottom + window.pageYOffset - parentOffset;
         popup.style.top = `${openBtnBottom - 500}px`;
-        const conceptNotionIdentifier = popup.querySelector('figcaption');
         const viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
         const popupTop = getElementOffset(popup).top;
         const popupHeight = popup.offsetHeight;
         let offset = 0;
 
-        if (conceptNotionIdentifier) {
-          //checks if it is part of a notionblock
+        // checks if it is part of a notionblock
+        const plainId = id.split('-')[1];
+        const conceptNotionIdentifier = openBtn.closest(`#visual-element-${plainId}`);
+        if (conceptNotionIdentifier?.contains(openBtn)) {
+          // Positions the popup so that it does not expand the page
           if (popupTop + popupHeight > documentHeight) {
-            //Positions the popup so that it does not expand the page
             popup.style.top = `${openBtnBottom - 900}px`;
           }
-          jump(popup, {
-            offset: -((viewportHeight - popupHeight) / 2),
-            duration: 300,
-          });
+
+          offset = -((viewportHeight - popupHeight) / 2);
         } else {
           popup.style.top = `${openBtnBottom + 20}px`;
 

--- a/packages/ndla-article-scripts/src/conceptScripts.js
+++ b/packages/ndla-article-scripts/src/conceptScripts.js
@@ -99,13 +99,13 @@ export const addShowConceptDefinitionClickListeners = () => {
         const popupHeight = popup.offsetHeight;
         let offset = 0;
 
-        const plainId = id.split('-')[1];
+        const plainId = id.split('notion-')[1];
         const conceptNotionIdentifier = openBtn.closest(`#visual-element-${plainId}`);
         // checks if it is part of a notionblock
         if (conceptNotionIdentifier?.contains(openBtn)) {
           // Positions the popup so that it does not expand the page
           if (popupTop + popupHeight > documentHeight) {
-            popup.style.top = `${openBtnBottom - 900}px`;
+            popup.style.top = `${openBtnBottom - popupHeight}px`;
           }
 
           offset = -((viewportHeight - popupHeight) / 2);

--- a/packages/ndla-article-scripts/src/conceptScripts.js
+++ b/packages/ndla-article-scripts/src/conceptScripts.js
@@ -129,7 +129,7 @@ export const addShowConceptDefinitionClickListeners = () => {
           }
         }
 
-        if (inIframe() && window.parent) {
+        if (!conceptNotionIdentifier && inIframe() && window.parent) {
           window.parent.postMessage(
             {
               event: 'scrollTo',

--- a/packages/ndla-article-scripts/src/conceptScripts.js
+++ b/packages/ndla-article-scripts/src/conceptScripts.js
@@ -99,9 +99,9 @@ export const addShowConceptDefinitionClickListeners = () => {
         const popupHeight = popup.offsetHeight;
         let offset = 0;
 
-        // checks if it is part of a notionblock
         const plainId = id.split('-')[1];
         const conceptNotionIdentifier = openBtn.closest(`#visual-element-${plainId}`);
+        // checks if it is part of a notionblock
         if (conceptNotionIdentifier?.contains(openBtn)) {
           // Positions the popup so that it does not expand the page
           if (popupTop + popupHeight > documentHeight) {

--- a/packages/ndla-notion/src/NotionDialog.tsx
+++ b/packages/ndla-notion/src/NotionDialog.tsx
@@ -167,8 +167,8 @@ export const NotionDialogStyledWrapper = styled.div`
     margin-left: -250px;
   }
   ${mq.range({ from: breakpoints.desktop })} {
-    width: 880px;
-    margin-left: -440px;
+    width: 720px;
+    margin-left: -360px;
     left: 50%;
   }
   box-shadow: 0 0 30px rgba(0, 0, 0, 0.2);

--- a/packages/ndla-notion/src/NotionDialog.tsx
+++ b/packages/ndla-notion/src/NotionDialog.tsx
@@ -162,12 +162,12 @@ export const NotionDialogStyledWrapper = styled.div`
     z-index: 9999;
   }
   ${mq.range({ from: breakpoints.tablet })} {
-    max-width: 500px;
+    width: 500px;
     left: 50%;
     margin-left: -250px;
   }
   ${mq.range({ from: breakpoints.desktop })} {
-    max-width: 880px;
+    width: 880px;
     margin-left: -440px;
     left: 50%;
   }

--- a/packages/ndla-ui/src/Notion/ConceptNotion.tsx
+++ b/packages/ndla-ui/src/Notion/ConceptNotion.tsx
@@ -18,6 +18,7 @@ import { NotionImage } from './NotionImage';
 import NotionVisualElement, { NotionVisualElementType } from './NotionVisualElement';
 import FigureNotion from './FigureNotion';
 import { Copyright } from '../types';
+import { FigureType } from '../Figure';
 
 const ImageWrapper = styled.div`
   float: right;
@@ -47,9 +48,10 @@ interface Props {
   concept: ConceptNotionType;
   disableScripts?: boolean;
   hideIconsAndAuthors?: boolean;
+  figureType?: FigureType;
 }
 
-const ConceptNotion = ({ concept, disableScripts, type, hideIconsAndAuthors }: Props) => {
+const ConceptNotion = ({ concept, disableScripts, type, hideIconsAndAuthors, figureType }: Props) => {
   const notionId = `notion-${concept.id}`;
   const figureId = `notion-figure-${concept.id}`;
   const visualElementId = `visual-element-${concept.id}`;
@@ -69,7 +71,8 @@ const ConceptNotion = ({ concept, disableScripts, type, hideIconsAndAuthors }: P
       copyright={concept.copyright}
       licenseString={concept.copyright?.license?.license ?? ''}
       type="concept"
-      hideIconsAndAuthors={hideIconsAndAuthors}>
+      hideIconsAndAuthors={hideIconsAndAuthors}
+      figureType={figureType}>
       <UINotion
         id={notionId}
         title={concept.title}

--- a/packages/ndla-ui/src/Notion/FigureNotion.tsx
+++ b/packages/ndla-ui/src/Notion/FigureNotion.tsx
@@ -10,7 +10,7 @@ import { colors, spacing } from '@ndla/core';
 import { getGroupedContributorDescriptionList, getLicenseByAbbreviation } from '@ndla/licenses';
 import React, { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Figure, FigureCaption, FigureLicenseDialog } from '../Figure';
+import { Figure, FigureCaption, FigureLicenseDialog, FigureType } from '../Figure';
 import { Copyright } from '../types';
 
 const BottomBorder = styled.div`
@@ -29,6 +29,7 @@ interface Props {
   type: 'video' | 'h5p' | 'image' | 'concept' | 'other';
   hideFigCaption?: boolean;
   hideIconsAndAuthors?: boolean;
+  figureType?: FigureType;
 }
 
 const FigureNotion = ({
@@ -42,6 +43,7 @@ const FigureNotion = ({
   type,
   hideFigCaption,
   hideIconsAndAuthors,
+  figureType,
 }: Props) => {
   const { t, i18n } = useTranslation();
   const license = getLicenseByAbbreviation(licenseString, i18n.language);
@@ -56,7 +58,7 @@ const FigureNotion = ({
   ).map((i) => ({ name: i.description, type: i.label }));
 
   return (
-    <Figure resizeIframe={resizeIframe} id={figureId} type={'full-column'}>
+    <Figure resizeIframe={resizeIframe} id={figureId} type={figureType || 'full-column'}>
       {({ typeClass }) => (
         <>
           {typeof children === 'function' ? children({ typeClass }) : children}


### PR DESCRIPTION
Gjenstår litt arbeid

Endringer:
- Mulighet til å kontrollere figurtypen på ConceptNotion -> FigureNotion. Dette for å kunne sette den til 'full' og dermed få 133% width som brukes på figurer i artikler.
   - Eksemplene er oppdatert til å ta i bruk dette.
- conceptScripts gjør nå en korrekt sjekk for å hente conceptBlockIdentifier. Denne ga falske positiver og positive negativer før. (inline og block har litt forskjellig åpning av modal)
- NotionDialog hadde rar posisjonering. Tilbakestilte størresen på det bredeste formatet til 720px (denne var nylig oppjustert til 880px). Setter heller størrelsen fast i hvert intervall med `width` enn å sette en `max-width`. Da blir den midtstilt og det er ikke fare for at den blir for smal.
- Scroll ved åpning av modal trigger ikke lenger dobbelt.
- Spesialhåndtering av scroll ved iframe sjekkes nå kun ved inline-forklaring.

Kan teste flere av endringene her https://frontend-packages-pr-1126.ndla.sh/?path=/story/sammensatte-moduler--blokkvisning-begrepsforklaring:
- Scroll ved åpning av modal skal gå til korrekt posisjon, scrolles jevnt. Modal skal ikke havne utenfor skjerm/artikkel.
- Modal skal nå ha fast intervall på bredde (720px ved fullskjerm) og være midtstilt.