### PR TITLE
Force smaller transform on mathjaxdecorator to prevent disappearing elements

### DIFF
--- a/packages/ndla-ui/src/Article/component.article.scss
+++ b/packages/ndla-ui/src/Article/component.article.scss
@@ -24,6 +24,10 @@
   @include font-size(18px, 29px);
   position: relative;
 
+  mjx-stretchy-v > mjx-ext > mjx-c {
+    transform: scaleY(200) translateY(0.075em);
+  }
+
   > section > p {
     &:not([class]) {
       margin-bottom: 29px;
@@ -117,7 +121,7 @@
   }
 
   &--multidisciplinary-topic {
-    margin-top:0;
+    margin-top: 0;
     padding: $spacing--small;
     @include mq(tablet) {
       padding: 0;
@@ -206,4 +210,3 @@
     }
   }
 }
-


### PR DESCRIPTION
Løser problemet med tegn i mathjax som forsvant. Siden dette må gjøres i både ed og ndla-frontend legger jeg dette inn i frontend-packages.

Hva som forårsaker problemer. Tegnet som forsvinner er en høy strek som i realiteten er en pipe `|` med transform for å gjøre den lenger. Her er det brukt en hack i form av `scaleY(500)` og `overflow:hidden` som i praksis gir 100% høyde. Dette bugger seg med en skalering på 500x (feiler på verdier over 440x ca). Ved å redusere denne til 200x, som er mer enn nok, vil pipen igjen vises.

Kan testes ved å linke ndla-ui inn i ndla-frontend og åpne http://localhost:3000/en/subject:1:734bd33b-da6d-49b0-bb34-c6df5b956f8e/topic:1:2737083d-8400-4a9f-b864-b05c42a470df/topic:1:2cd30524-12fe-41c6-9008-f36146369953/resource:20290ac7-9bad-4b1b-91cd-ef266bc9a028


<details>
<summary>
bilder
</summary>
Fikset:

![image](https://user-images.githubusercontent.com/17144211/169825287-c6123ae4-20c2-4267-a2b6-88b3923ee26d.png)

Feil:
![image](https://user-images.githubusercontent.com/17144211/169825401-8e201f49-dead-4e38-aed0-cd1de8300d8c.png)

</details>