### PR TITLE
3113 author list formatting

### DIFF
--- a/packages/ndla-notion/src/NotionDialogLicenses.tsx
+++ b/packages/ndla-notion/src/NotionDialogLicenses.tsx
@@ -56,7 +56,7 @@ const NotionDialogLicenses = ({ license, authors = [], source, locale, licenseBo
       {authorsLength > 0 && (
         <span>
           {authors.reduceRight((acc, curr, i) => {
-            if (i === 0) {
+            if (i === authorsLength - 2) {
               return curr + ` ${t('article.conjunction')} ` + acc;
             }
             return curr + ', ' + acc;

--- a/packages/ndla-notion/src/NotionDialogLicenses.tsx
+++ b/packages/ndla-notion/src/NotionDialogLicenses.tsx
@@ -1,7 +1,8 @@
-import React, { Fragment, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import styled from '@emotion/styled';
 import { fonts, spacing, colors } from '@ndla/core';
 import { LicenseByline, getLicenseByAbbreviation } from '@ndla/licenses';
+import { useTranslation } from 'react-i18next';
 
 const NotionDialogLicensesWrapper = styled.div`
   border-top: 1px solid ${colors.brand.tertiary};
@@ -38,6 +39,7 @@ interface Props {
 }
 
 const NotionDialogLicenses = ({ license, authors = [], source, locale, licenseBox }: Props) => {
+  const { t } = useTranslation();
   const licenseRights = license ? getLicenseByAbbreviation(license, locale).rights : [];
   const authorsLength = authors.length;
   const wrapLink = (source?: ReactNode) => {
@@ -47,18 +49,18 @@ const NotionDialogLicenses = ({ license, authors = [], source, locale, licenseBo
     return source;
   };
   const sourceElem = React.isValidElement(source) ? source : <span>{wrapLink(source)}</span>;
+
   return (
     <NotionDialogLicensesWrapper>
       {licenseRights.length > 0 && <LicenseByline locale={locale} marginRight licenseRights={licenseRights} />}
       {authorsLength > 0 && (
         <span>
-          {authors.map((author, index) => (
-            <Fragment key={author}>
-              {author}
-              {index < authorsLength - 3 && ', '}
-              {index === authorsLength - 2 && ' og '}
-            </Fragment>
-          ))}
+          {authors.reduceRight((acc, curr, i) => {
+            if (i === 0) {
+              return curr + ` ${t('article.conjunction')} ` + acc;
+            }
+            return curr + ', ' + acc;
+          })}
         </span>
       )}
       {source && sourceElem}

--- a/packages/ndla-notion/src/NotionDialogLicenses.tsx
+++ b/packages/ndla-notion/src/NotionDialogLicenses.tsx
@@ -55,11 +55,11 @@ const NotionDialogLicenses = ({ license, authors = [], source, locale, licenseBo
       {licenseRights.length > 0 && <LicenseByline locale={locale} marginRight licenseRights={licenseRights} />}
       {authorsLength > 0 && (
         <span>
-          {authors.reduceRight((acc, curr, i) => {
+          {authors.reduce((prev, curr, i) => {
             if (i === authorsLength - 2) {
-              return curr + ` ${t('article.conjunction')} ` + acc;
+              return prev + ` ${t('article.conjunction')} ` + curr;
             }
-            return curr + ', ' + acc;
+            return prev + ', ' + curr;
           })}
         </span>
       )}


### PR DESCRIPTION
Relatert til NDLANO/Issues#3113

Fikser en feil der komma-separering av forfattere ikke fungerte ordentlig. Se: https://liste.ndla.no/nn/?concept=1805. Her mangler det komma mellom de to første forfatterene. 

Hvordan teste:
- Åpne en av følgende i designmanual: Listevisning eller forklaringstjenesten.
- Trykk på en forklaring.
- Se at forfattere er riktig formatert.