### PR TITLE
Render conjunction at correct index in dialog licenses

### DIFF
--- a/packages/designmanual/dummydata/mockExplanationService.js
+++ b/packages/designmanual/dummydata/mockExplanationService.js
@@ -30,7 +30,7 @@ export const mockExplanationService = {
           value: 'Naturbruk Vg1',
         },
       ],
-      authors: ['Ola Nordmann', 'Kari Nordmann'],
+      authors: ['Ola Nordmann', 'Kari Nordmann', 'Per Nordmann', 'Randi Nordmann'],
       source: 'snl.no',
       license: 'by-nc-nd',
       tags: ['Naturbruk Vg1'],

--- a/packages/ndla-notion/src/NotionDialogLicenses.tsx
+++ b/packages/ndla-notion/src/NotionDialogLicenses.tsx
@@ -56,7 +56,7 @@ const NotionDialogLicenses = ({ license, authors = [], source, locale, licenseBo
       {authorsLength > 0 && (
         <span>
           {authors.reduce((prev, curr, i) => {
-            if (i === authorsLength - 2) {
+            if (i === authorsLength - 1) {
               return prev + ` ${t('article.conjunction')} ` + curr;
             }
             return prev + ', ' + curr;


### PR DESCRIPTION
Relatert til NDLANO/Issues#3113

Blingset på indeks i omskriving fra reduceRight til reduce. For å se at innsetting av "og" og komma blir riktig har jeg utvidet den første forklaringen på eksempelet "forklaringstjenesten" med to forfattere til.