### PR TITLE
Removed unneeded react router imports to ease rr6 transition

### DIFF
--- a/packages/ndla-pager/src/Pager.tsx
+++ b/packages/ndla-pager/src/Pager.tsx
@@ -7,7 +7,6 @@
  */
 
 import React, { ElementType, ReactNode } from 'react';
-import { Link } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import { colors } from '@ndla/core';
@@ -70,7 +69,7 @@ export const PageItem = <T extends Query>({
 
   const handleClick = () => onClick(query);
 
-  if (Component === SafeLink || Component === Link) {
+  if (Component === SafeLink) {
     return (
       <SafeLink css={pageItemStyle} onClick={handleClick} to={linkToPage}>
         {children}

--- a/packages/ndla-ui/src/BlogPosts/BlogPost.tsx
+++ b/packages/ndla-ui/src/BlogPosts/BlogPost.tsx
@@ -8,7 +8,6 @@
 
 import React from 'react';
 import styled from '@emotion/styled';
-import { LinkProps } from 'react-router-dom';
 import { spacing, colors, fonts, breakpoints, mq, misc, spacingUnit } from '@ndla/core';
 import { getLicenseByAbbreviation, LicenseByline } from '@ndla/licenses';
 import { Launch as LaunchIcon } from '@ndla/icons/common';
@@ -116,7 +115,7 @@ const StyledTag = styled.div`
   }
 `;
 
-const StyledSafeLink = styled(SafeLink)<LinkProps>`
+const StyledSafeLink = styled(SafeLink)`
   padding: ${spacing.xsmall} 0 ${spacing.small};
   ${fonts.sizes(22, 1.1)};
   font-weight: ${fonts.weight.bold};

--- a/packages/ndla-ui/src/CreatedBy/CreatedBy.tsx
+++ b/packages/ndla-ui/src/CreatedBy/CreatedBy.tsx
@@ -7,7 +7,6 @@
  */
 
 import React from 'react';
-import { LinkProps } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { colors, fonts } from '@ndla/core';
 import SafeLink from '@ndla/safelink';
@@ -30,7 +29,7 @@ const Text = styled.div`
   ${fonts.sizes('20px', '20px')};
 `;
 
-const StyledSafeLink = styled(SafeLink)<LinkProps>`
+const StyledSafeLink = styled(SafeLink)`
   color: ${colors.text.light};
 `;
 

--- a/packages/ndla-ui/src/Footer/FooterLinks.tsx
+++ b/packages/ndla-ui/src/Footer/FooterLinks.tsx
@@ -1,6 +1,5 @@
 import React, { ReactNode } from 'react';
 import styled from '@emotion/styled';
-import { LinkProps } from 'react-router-dom';
 import { spacing, fonts, colors, mq, breakpoints, spacingUnit } from '@ndla/core';
 import SafeLink from '@ndla/safelink';
 import { Forward, Launch } from '@ndla/icons/common';
@@ -57,7 +56,7 @@ const StyledNav = styled.nav`
   }
 `;
 
-const StyledSafeLink = styled(SafeLink)<LinkProps>`
+const StyledSafeLink = styled(SafeLink)`
   color: #fff;
   ${fonts.sizes(16, 1.5)};
   svg {


### PR DESCRIPTION
Importerer `Link` og `LinkProps` steder man egentlig ikke trenger det. I `styled`-tilfellene vil `SafeLink` holde, mens man heller kan passere inn `SafeLink` som komponent i `Pager`.