### PR TITLE
Change absolute marker scaling to 100

### DIFF
--- a/packages/ndla-ui/src/Article/component.article.scss
+++ b/packages/ndla-ui/src/Article/component.article.scss
@@ -25,7 +25,7 @@
   position: relative;
 
   mjx-stretchy-v > mjx-ext > mjx-c {
-    transform: scaleY(200) translateY(0.075em);
+    transform: scaleY(100) translateY(0.075em);
   }
 
   > section > p {


### PR DESCRIPTION
Har testet denne størrelsen i ed og jeg har ikke klart å lage formler som er så store at absoluttverdi-markører blir for korte.