### PR TITLE
Fix vercel cache-control headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,7 +9,7 @@
       "headers": [
         {
           "key": "Cache-Control",
-          "value": "public, max-age=1000"
+          "value": "s-maxage=1000"
         }
       ]
     },
@@ -18,7 +18,7 @@
       "headers": [
         {
           "key": "Cache-Control",
-          "value": "public, max-age=86400"
+          "value": "s-maxage=86400"
         }
       ]
     }


### PR DESCRIPTION
En liten typo i omskrivingen. Dette er verdien som cache-control opprinnelig hadde og fortsatt burde ha. https://github.com/NDLANO/frontend-packages/pull/1142/files