### PR TITLE
3002 external embed fullframe type

### DIFF
--- a/packages/designmanual/stories/pages/ResourceBoxExample.jsx
+++ b/packages/designmanual/stories/pages/ResourceBoxExample.jsx
@@ -20,6 +20,11 @@ const ReferenceBoxExample = () => {
     margin-top: 200px;
   `;
 
+  const image = {
+    src: 'https://media.snl.no/media/27960/standard_Schaarwa_chter_Henrik_Ibsen_cropped.jpg',
+    alt: 'Henrik Ibsen',
+  };
+
   return (
     <Wrapper>
       <OneColumn cssModifier="narrow">
@@ -43,7 +48,7 @@ const ReferenceBoxExample = () => {
                     licenseRights={[BY, NC, ND]}
                     title="Mediehistorie"
                     caption="I dette interaktive oppslagsverket kan du lære om medieutviklingen, kan du lære om medieutviklingen, kan du lære om medieutviklingen. kan du lære om medieutviklingen. "
-                    image="https://media.snl.no/media/27960/standard_Schaarwa_chter_Henrik_Ibsen_cropped.jpg"
+                    image={image}
                     url="https://www.ndla.no"></ResourceBox>
                 </Figure>
 

--- a/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
+++ b/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
@@ -96,15 +96,21 @@ const LincenseWrapper = styled.div`
   }
 `;
 
-type Props = {
-  image: string;
+interface ImageMeta {
+  src: string;
+  alt: string;
+}
+
+interface Props {
+  image: ImageMeta;
   title: string;
   caption: string;
   licenseRights: string[];
-  authors?: { name: string }[];
+  authors?: string[];
   locale?: string;
   url: string;
-};
+}
+
 export const ResourceBox = ({ image, title, caption, licenseRights, locale, authors, url }: Props) => {
   const { t } = useTranslation();
   return (
@@ -112,12 +118,12 @@ export const ResourceBox = ({ image, title, caption, licenseRights, locale, auth
       <LincenseWrapper>
         <LicenseByline licenseRights={licenseRights} locale={locale} marginRight color={colors.brand.tertiary}>
           <div className="c-figure__byline-author-buttons">
-            <span className="c-figure__byline-authors">{authors?.map((author) => author.name).join(' ')}</span>
+            <span className="c-figure__byline-authors">{authors?.join(' ')}</span>
           </div>
         </LicenseByline>
       </LincenseWrapper>
       <ImageWrapper>
-        <Image alt={title} src={image} />
+        <Image src={image.src} alt={image.alt} />
       </ImageWrapper>
       <TextWrapper>
         <Title>{title}</Title>

--- a/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
+++ b/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
@@ -44,6 +44,8 @@ const Caption = styled.p`
 `;
 
 const TextWrapper = styled.div`
+  flex-basis: 0;
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -61,7 +63,7 @@ const StyledButton = styled(SafeLinkButton)`
   :hover {
     background-color: ${colors.brand.primary};
     border: 1px solid ${colors.brand.primary};
-    color: white;
+    color: ${colors.white};
   }
 `;
 
@@ -114,9 +116,7 @@ export const ResourceBox = ({ image, title, caption, licenseRights, locale, auth
           </div>
         </LicenseByline>
       </LincenseWrapper>
-      <div>
-        <StyledImage src={image.src} alt={image.alt} />
-      </div>
+      <StyledImage src={image.src} alt={image.alt} />
       <TextWrapper>
         <Title>{title}</Title>
         <Caption>{caption}</Caption>

--- a/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
+++ b/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
@@ -7,7 +7,7 @@
  *
  */
 import React from 'react';
-import { breakpoints, fonts, mq, colors } from '@ndla/core';
+import { breakpoints, fonts, mq, colors, spacing } from '@ndla/core';
 import { useTranslation } from 'react-i18next';
 import { Launch } from '@ndla/icons/common';
 import { LicenseByline } from '@ndla/licenses';
@@ -17,18 +17,18 @@ import Image from '../Image';
 
 const ResourceBoxContainer = styled.div`
   display: flex;
-  padding: 20px;
+  padding: ${spacing.nsmall};
   border-radius: 5px;
   border: 1px solid ${colors.brand.light};
   position: relative;
   font-family: ${fonts.sans};
   box-shadow: 0px 20px 35px -15px rgba(32, 88, 143, 0.15);
-  gap: 40px;
+  gap: ${spacing.medium};
 
   ${mq.range({ until: breakpoints.desktop })} {
     gap: 0;
     flex-direction: column;
-    padding-top: 30px;
+    padding-top: ${spacing.medium};
     text-align: center;
   }
 `;
@@ -41,11 +41,6 @@ const Title = styled.h3`
 
 const Caption = styled.p`
   font-size: ${fonts.sizes(14)};
-  max-width: 600px;
-
-  ${mq.range({ until: breakpoints.desktop })} {
-    line-height: 22px;
-  }
 `;
 
 const TextWrapper = styled.div`
@@ -54,11 +49,14 @@ const TextWrapper = styled.div`
   align-items: flex-start;
   ${mq.range({ until: breakpoints.desktop })} {
     align-items: center;
-    padding-top: 10px;
+    padding-top: ${spacing.small};
   }
 `;
 
 const StyledButton = styled(SafeLinkButton)`
+  display: flex;
+  gap: ${spacing.xxsmall};
+  align-items: center;
   border: 1px solid ${colors.brand.tertiary};
   :hover {
     background-color: ${colors.brand.primary};
@@ -67,14 +65,8 @@ const StyledButton = styled(SafeLinkButton)`
   }
 `;
 
-const StyledLaunchIcon = styled(Launch)`
-  margin-left: 8px;
-  height: 15px;
-  width: 15px;
-`;
-
-const ImageWrapper = styled.div`
-  img {
+const StyledImage = styled(Image)`
+  && {
     object-fit: cover;
     width: 134px;
     height: 134px;
@@ -122,16 +114,16 @@ export const ResourceBox = ({ image, title, caption, licenseRights, locale, auth
           </div>
         </LicenseByline>
       </LincenseWrapper>
-      <ImageWrapper>
-        <Image src={image.src} alt={image.alt} />
-      </ImageWrapper>
+      <div>
+        <StyledImage src={image.src} alt={image.alt} />
+      </div>
       <TextWrapper>
         <Title>{title}</Title>
         <Caption>{caption}</Caption>
 
         <StyledButton to={url} target="_blank" outline borderShape="rounded">
           {t('license.other.itemImage.ariaLabel')}
-          <StyledLaunchIcon aria-hidden />
+          <Launch aria-hidden />
         </StyledButton>
       </TextWrapper>
     </ResourceBoxContainer>

--- a/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
+++ b/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
@@ -17,10 +17,10 @@ import Image from '../Image';
 
 const ResourceBoxContainer = styled.div`
   display: flex;
+  position: relative;
   padding: ${spacing.nsmall};
   border-radius: 5px;
   border: 1px solid ${colors.brand.light};
-  position: relative;
   font-family: ${fonts.sans};
   box-shadow: 0px 20px 35px -15px rgba(32, 88, 143, 0.15);
   gap: ${spacing.medium};
@@ -82,9 +82,9 @@ const StyledImage = styled(Image)`
 `;
 
 const LincenseWrapper = styled.div`
-  top: 9px;
   position: absolute;
-  right: 1px;
+  top: 9px;
+  right: 0;
 `;
 
 interface ImageMeta {

--- a/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
+++ b/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
@@ -43,7 +43,7 @@ const Caption = styled.p`
   font-size: ${fonts.sizes(14)};
 `;
 
-const TextWrapper = styled.div`
+const ContentWrapper = styled.div`
   flex-basis: 0;
   flex-grow: 1;
   display: flex;
@@ -116,7 +116,7 @@ export const ResourceBox = ({ image, title, caption, licenseRights, locale, auth
         </LicenseByline>
       </LincenseWrapper>
       <StyledImage src={image.src} alt={image.alt} />
-      <TextWrapper>
+      <ContentWrapper>
         <Title>{title}</Title>
         <Caption>{caption}</Caption>
 
@@ -124,7 +124,7 @@ export const ResourceBox = ({ image, title, caption, licenseRights, locale, auth
           {t('license.other.itemImage.ariaLabel')}
           <Launch aria-hidden />
         </StyledButton>
-      </TextWrapper>
+      </ContentWrapper>
     </ResourceBoxContainer>
   );
 };

--- a/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
+++ b/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
@@ -85,9 +85,6 @@ const LincenseWrapper = styled.div`
   top: 9px;
   position: absolute;
   right: 1px;
-  ul {
-    margin-right: 0;
-  }
 `;
 
 interface ImageMeta {
@@ -111,9 +108,11 @@ export const ResourceBox = ({ image, title, caption, licenseRights, locale, auth
     <ResourceBoxContainer>
       <LincenseWrapper>
         <LicenseByline licenseRights={licenseRights} locale={locale} marginRight color={colors.brand.tertiary}>
-          <div className="c-figure__byline-author-buttons">
-            <span className="c-figure__byline-authors">{authors?.join(' ')}</span>
-          </div>
+          {authors && authors.length > 0 && (
+            <div className="c-figure__byline-author-buttons">
+              <span className="c-figure__byline-authors">{authors.join(' ')}</span>
+            </div>
+          )}
         </LicenseByline>
       </LincenseWrapper>
       <StyledImage src={image.src} alt={image.alt} />


### PR DESCRIPTION
Relatert til NDLANO/Issues#3002

Har fått tilbakemelding på design:
- `alt` på bilde skal settes fra bildeobjektet som hentes fra image-api. Dette må nå sendes inn som et bildeobjekt med `src` og `alt`.

Av annet har jeg ryddet litt opp i komponenten:
- Fjernet wrapper rundt bilde
- Satt marginer/gap og liknende fra `spacing`
- Rendering av authors kun dersom authors finnes.

Hvordan teste:
- Sjekk at komponenten ser lik ut som før på /?path=/story/sammensatte-moduler--ressurs-fra-lenke. Spesielt viktig at den oppfører seg bra responsivt fra smal skjerm til full bredde.