### PR TITLE
Provide an empty fallback string to account for cases where the SafeLink to prop is undefined.

### DIFF
--- a/packages/safelink/src/SafeLink.tsx
+++ b/packages/safelink/src/SafeLink.tsx
@@ -49,7 +49,8 @@ const SafeLink = ({ to, replace, children, showNewWindowIcon, tabIndex, ...rest 
   }
 
   return (
-    <Link tabIndex={tabIndex ?? 0} to={to} replace={replace} {...rest}>
+    // RR6 link immediately fails if to is somehow undefined, so we provide an empty fallback to recover.
+    <Link tabIndex={tabIndex ?? 0} to={to ?? ''} replace={replace} {...rest}>
       {children}
       {showNewWindowIcon && <LaunchIcon style={{ verticalAlign: 'text-top' }} />}
     </Link>


### PR DESCRIPTION
Unngår et hardt krasj. RR5 autogenererte en lenke til siden du stod på automatisk. RR6 er ikke like hyggelig. Dette problemet er nok mest hyppig i designmanualen, da store deler av testdataen vår har udefinerte lenker.