### PR TITLE
Restructure breadcrumbs to make overriding text ellipsis color easier

### DIFF
--- a/packages/designmanual/stories/molecules/breadcrumbs.tsx
+++ b/packages/designmanual/stories/molecules/breadcrumbs.tsx
@@ -41,6 +41,10 @@ export const BreadcrumbWithHeader = () => {
   return <HeaderBreadcrumb items={items} />;
 };
 
+export const BreadcrumbWhiteWithHeader = () => {
+  return <HeaderBreadcrumb light items={items} />;
+};
+
 export const BreadcrumbWithHome = () => {
   return <HomeBreadcrumb items={items} />;
 };

--- a/packages/ndla-ui/src/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/ndla-ui/src/Breadcrumb/BreadcrumbItem.tsx
@@ -51,6 +51,7 @@ const StyledListItem = styled.li<AutoCollapseProps>`
 
 const CollapseContainer = styled.div<AutoCollapseProps>`
   display: inline-block;
+  color: inherit;
   ${({ autoCollapse }) =>
     autoCollapse &&
     css`
@@ -63,6 +64,7 @@ const CollapseContainer = styled.div<AutoCollapseProps>`
 
 const StyledChevron = styled(ChevronRight)`
   margin: ${spacing.xxsmall};
+  color: inherit;
 `;
 
 const StyledSafeLink = styled(SafeLink)`

--- a/packages/ndla-ui/src/Breadcrumb/HeaderBreadcrumb.tsx
+++ b/packages/ndla-ui/src/Breadcrumb/HeaderBreadcrumb.tsx
@@ -18,21 +18,19 @@ interface ThemeProps {
   light: boolean | undefined;
 }
 
-const StyledHeaderSafeLink = styled(SafeLink)<ThemeProps>`
-  ${fonts.sizes(14)};
-  font-weight: ${fonts.weight.bold};
+const HeaderBreadcrumbWrapper = styled.div<ThemeProps>`
   color: ${({ light }) => (light ? colors.white : colors.brand.primary)};
 `;
 
-const StyledRightChevron = styled(ChevronRight)<ThemeProps>`
-  color: ${({ light }) => (light ? colors.white : colors.brand.primary)};
+const StyledHeaderSafeLink = styled(SafeLink)`
+  ${fonts.sizes(14)};
+  font-weight: ${fonts.weight.bold};
+  color: inherit;
+`;
+
+const StyledRightChevron = styled(ChevronRight)`
   margin: ${spacing.xxsmall};
-`;
-const StyledSpan = styled.span<ThemeProps>`
-  color: ${({ light }) => (light ? colors.white : colors.brand.primary)};
-`;
-const StyledSafeLink = styled(SafeLink)<ThemeProps>`
-  color: ${({ light }) => (light ? colors.white : colors.brand.primary)};
+  color: inherit;
 `;
 
 interface Props {
@@ -41,37 +39,18 @@ interface Props {
 }
 
 const HeaderBreadcrumb = ({ items, light }: Props) => {
-  const renderItem = (item: IndexedBreadcrumbItem, totalCount: number) => {
-    if (item.index === totalCount - 1) {
-      return <StyledSpan light={light}>{item.name}</StyledSpan>;
-    }
-    return (
-      <StyledSafeLink light={light} to={item.to}>
-        {item.name}
-      </StyledSafeLink>
-    );
-  };
-
   const renderSeparator = (item: IndexedBreadcrumbItem, totalCount: number) => {
     if (item.index === totalCount - 1) {
       return null;
     }
-    return <StyledRightChevron light={light} />;
+    return <StyledRightChevron />;
   };
 
   return (
-    <div>
-      <StyledHeaderSafeLink light={light} to={items[0]?.to}>
-        {items[0]?.name}
-      </StyledHeaderSafeLink>
-      <Breadcrumb
-        items={items.slice(1)}
-        renderItem={renderItem}
-        renderSeparator={renderSeparator}
-        autoCollapse
-        collapseFirst
-      />
-    </div>
+    <HeaderBreadcrumbWrapper light={light}>
+      <StyledHeaderSafeLink to={items[0]?.to}>{items[0]?.name}</StyledHeaderSafeLink>
+      <Breadcrumb items={items.slice(1)} renderSeparator={renderSeparator} autoCollapse collapseFirst />
+    </HeaderBreadcrumbWrapper>
   );
 };
 


### PR DESCRIPTION
En ganske usynlig feil som dukket opp i da komponenten skulle implementeres i ndla-frontend.

![image](https://user-images.githubusercontent.com/17144211/173856674-6b824943-c730-4c55-8b0f-31284d0b9d39.png)

Prikkene ved collapse er grå. Dette er også tilfellet på designmanual.ndla.no. Det er bare ikke så lett å se siden grå og blå på hvit bakgrunn ser likt ut:

![image](https://user-images.githubusercontent.com/17144211/173856840-0ec4ec92-0282-4f19-884c-9bd7091eac89.png)



Hvordan teste:
- Åpne PR-instans av designmanual og sjekk at prikkene er blå.