### PR TITLE
Show correct type in concept block visual element modal

### DIFF
--- a/packages/ndla-ui/src/Notion/FigureNotion.tsx
+++ b/packages/ndla-ui/src/Notion/FigureNotion.tsx
@@ -74,7 +74,7 @@ const FigureNotion = ({
                 license={license}
                 messages={{
                   close: t('close'),
-                  rulesForUse: t('license.concept.rules'),
+                  rulesForUse: t(`license.${type}.rules`),
                   source: t('source'),
                   learnAboutLicenses: t('license.learnMore'),
                   title: t('title'),


### PR DESCRIPTION
Feilretting basert på kommentar i PR https://github.com/NDLANO/article-converter/pull/333. Modal for regler av bruk på et visuelt element skal ha tittel som er tilpasset typen visuelt element. 

Det er snakk om tittelen i denne modalen. Utsnitt hentet fra etter feilen er rettet:
![image](https://user-images.githubusercontent.com/17144211/174091861-e7afcbc2-da14-49f1-88e3-161717a58e2e.png)


Hvordan teste:
- Åpne /?path=/story/sammensatte-moduler--blokkvisning-begrepsforklaring
- Trykk på visuelt element og deretter "Bruk bildet/video/h5p" på alle blokkforklaringer.
- Tittel i modalen skal nå tilpasse seg typen visuelt element. E.g. om det er et bilde skal det så "Regler for bruk av bildet:". Tidligere sto det alltid "Regler for bruk av forklaring".