### PR TITLE
Hotfix block concepts

### DIFF
--- a/packages/designmanual/stories/molecules/NotionBlock.tsx
+++ b/packages/designmanual/stories/molecules/NotionBlock.tsx
@@ -25,7 +25,7 @@ const conceptData = {
       license: {
         license: 'CC-BY-NC-SA-4.0',
       },
-      creators: [{ name: 'En skaper', type: 'Writer' }],
+      creators: [{ name: 'En skaper', type: 'writer' }],
       processors: [{ name: 'Totaltekst', type: 'Correction' }],
       rightsholders: [],
     },
@@ -66,7 +66,7 @@ const conceptData = {
       creators: [
         {
           name: 'Bjørnar Mortensen Vik',
-          type: 'Writer',
+          type: 'writer',
         },
       ],
       processors: [],
@@ -167,7 +167,7 @@ const conceptData = {
         creators: [
           {
             name: 'Vilkårlig Person',
-            type: 'Writer',
+            type: 'writer',
           },
         ],
       },

--- a/packages/ndla-ui/src/Notion/ConceptNotion.tsx
+++ b/packages/ndla-ui/src/Notion/ConceptNotion.tsx
@@ -74,6 +74,7 @@ const ConceptNotion = ({ concept, disableScripts, type, hideIconsAndAuthors, fig
     <FigureNotion
       resizeIframe
       id={figureId}
+      title={concept.title}
       figureId={visualElementId}
       copyright={concept.copyright}
       licenseString={concept.copyright?.license?.license ?? ''}

--- a/packages/ndla-ui/src/Notion/FigureNotion.tsx
+++ b/packages/ndla-ui/src/Notion/FigureNotion.tsx
@@ -7,7 +7,7 @@
 
 import styled from '@emotion/styled';
 import { colors, spacing } from '@ndla/core';
-import { getLicenseByAbbreviation, getLicenseCredits } from '@ndla/licenses';
+import { getGroupedContributorDescriptionList, getLicenseByAbbreviation, getLicenseCredits } from '@ndla/licenses';
 import React, { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Figure, FigureCaption, FigureLicenseDialog, FigureType } from '../Figure';
@@ -23,7 +23,7 @@ interface Props {
   figureId: string;
   children: ReactNode | ((params: { typeClass: string }) => ReactNode);
   id: string;
-  title?: string;
+  title: string;
   copyright?: Partial<Copyright>;
   licenseString: string;
   type: 'video' | 'h5p' | 'image' | 'concept' | 'other';
@@ -47,9 +47,15 @@ const FigureNotion = ({
 }: Props) => {
   const { t, i18n } = useTranslation();
   const license = getLicenseByAbbreviation(licenseString, i18n.language);
-  const { creators, rightsholders, processors } = getLicenseCredits(copyright);
+  const licenseCredits = getLicenseCredits(copyright);
+  const { creators, rightsholders, processors } = licenseCredits;
 
   const authors = creators.length || rightsholders.length ? [...creators, ...rightsholders] : [...processors];
+
+  const groupedAuthors = getGroupedContributorDescriptionList(licenseCredits, i18n.language).map((item) => ({
+    name: item.description,
+    type: item.label,
+  }));
 
   return (
     <Figure resizeIframe={resizeIframe} id={figureId} type={figureType || 'full-column'}>
@@ -67,7 +73,7 @@ const FigureNotion = ({
               hideIconsAndAuthors={hideIconsAndAuthors}>
               <FigureLicenseDialog
                 id={id}
-                authors={authors}
+                authors={groupedAuthors}
                 locale={i18n.language}
                 title={title}
                 origin={copyright?.origin}
@@ -78,7 +84,8 @@ const FigureNotion = ({
                   source: t('source'),
                   learnAboutLicenses: t('license.learnMore'),
                   title: t('title'),
-                }}></FigureLicenseDialog>
+                }}
+              />
             </FigureCaption>
           ) : (
             <BottomBorder />

--- a/packages/ndla-ui/src/Notion/NotionVisualElement.tsx
+++ b/packages/ndla-ui/src/Notion/NotionVisualElement.tsx
@@ -68,7 +68,7 @@ const NotionVisualElement = ({ visualElement, id, figureId }: Props) => {
       {visualElement.image?.src ? (
         <img src={visualElement.image?.src} alt={visualElement.image.alt} />
       ) : (
-        <StyledIframe type={type} src={visualElement.url} title={visualElement.title} />
+        <StyledIframe allowFullScreen type={type} src={visualElement.url} title={visualElement.title} />
       )}
     </FigureNotion>
   );


### PR DESCRIPTION
Et par nye endringer som var ønsket. Alt kan testes i /?path=/story/sammensatte-moduler--blokkvisning-begrepsforklaring

Fullscreen knapp på video i blokkforklarings-modal skal fungere ⬇️ 

<details>
<summary>
bilde
</summary>

<img width="593" alt="image" src="https://user-images.githubusercontent.com/17144211/174318808-e9b48dee-4ee8-4170-b96c-20e243c69523.png">

</details>


Tittel skal vises i toppen av lisensmodal. Både i "Bruk forklaring" fra blokkforklaring og "Bruk -innholdstype-" i modalen.⬇️ 

<details>
<summary>
bilde
</summary>

<img width="560" alt="image" src="https://user-images.githubusercontent.com/17144211/174319010-36559e60-61d0-4985-9c5d-4b7dd90315f9.png">


</details>

Samme sted som over. Utlisting av personer/bedrifter skal nå grupperes på samme måte som i feks bilder. Kategoriseres etter Opphaver, Rettighetshaver og Bearbeider. Hver forfatter får også type foran navnet sitt, feks "Forfatter"⬇️ 

<details>
<summary>
bilde
</summary>

<img width="560" alt="image" src="https://user-images.githubusercontent.com/17144211/174319413-eb07a921-6ee8-4475-8f21-0e7d7ece117c.png">


</details>