### PR TITLE
Buttons only exists when necassary and adapted to window size

### DIFF
--- a/packages/ndla-ui/src/Filter/FilterCarousel.tsx
+++ b/packages/ndla-ui/src/Filter/FilterCarousel.tsx
@@ -99,8 +99,12 @@ const FilterCarousel = ({ children }: Props) => {
   }, [children]);
 
   useEffect(() => {
-    window.addEventListener('resize', showButtons);
-    return () => window.removeEventListener('resize', showButtons);
+    const resetTranslateX = () => {
+      setTranslateX(0);
+      showButtons();
+    };
+    window.addEventListener('resize', resetTranslateX);
+    return () => window.removeEventListener('resize', resetTranslateX);
   }, []);
 
   const updateIndex = (direction: string) => {

--- a/packages/ndla-ui/src/Filter/FilterCarousel.tsx
+++ b/packages/ndla-ui/src/Filter/FilterCarousel.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { ReactChild, useLayoutEffect, useRef, useState } from 'react';
+import React, { ReactChild, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
@@ -31,7 +31,6 @@ const Inner = styled.div`
 `;
 
 const NavButton = styled('button')<{
-  hide?: boolean;
   alignRight?: boolean;
 }>`
   box-sizing: border-box;
@@ -59,24 +58,11 @@ const NavButton = styled('button')<{
   }
 
   ${(props) =>
-    props.hide &&
-    `
-        opacity: 0;
-        transform: translate(-40px, 0px);
-    `}
-
-  ${(props) =>
     props.alignRight &&
     `
         right: 2px;
         left: unset;
-    `}
 
-    ${(props) =>
-    props.alignRight &&
-    props.hide &&
-    `
-        transform: translate(40px, 0px);
     `}
 `;
 
@@ -94,7 +80,7 @@ const FilterCarousel = ({ children }: Props) => {
   const innerRef: { current: HTMLDivElement | null } = useRef(null);
 
   // Check if we need to show the nav buttons
-  useLayoutEffect(() => {
+  const showButtons = () => {
     if (carouselRef.current && innerRef.current) {
       const carouselWidth = carouselRef.current.offsetWidth || 0;
       const innerWidth = innerRef.current.scrollWidth;
@@ -106,7 +92,16 @@ const FilterCarousel = ({ children }: Props) => {
     } else {
       setHideNext(true);
     }
+  };
+
+  useLayoutEffect(() => {
+    showButtons();
   }, [children]);
+
+  useEffect(() => {
+    window.addEventListener('resize', showButtons);
+    return () => window.removeEventListener('resize', showButtons);
+  }, []);
 
   const updateIndex = (direction: string) => {
     const carousel = carouselRef.current;
@@ -153,12 +148,16 @@ const FilterCarousel = ({ children }: Props) => {
           {children}
         </Inner>
       </Carousel>
-      <NavButton title={t('carousel.back')} onClick={() => updateIndex('PREV')} hide={translateX < 1}>
-        <ChevronLeft style={{ width: '18px', height: '18px' }} aria-hidden title="" />
-      </NavButton>
-      <NavButton title={t('carousel.forward')} onClick={() => updateIndex('NEXT')} alignRight hide={hideNext}>
-        <ChevronRight style={{ width: '18px', height: '18px' }} aria-hidden title="" />
-      </NavButton>
+      {!hideNext && (
+        <NavButton title={t('carousel.forward')} onClick={() => updateIndex('NEXT')} alignRight>
+          <ChevronRight style={{ width: '18px', height: '18px' }} aria-hidden title="" />
+        </NavButton>
+      )}
+      {translateX >= 1 && (
+        <NavButton title={t('carousel.back')} onClick={() => updateIndex('PREV')}>
+          <ChevronLeft style={{ width: '18px', height: '18px' }} aria-hidden title="" />
+        </NavButton>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Closes https://github.com/NDLANO/Issues/issues/3150 

Har fikset at knappene kun dukker opp når man skal bla gjennom filtre, og ikke blir værende i bakgrunnen når siden har plass til alle filtrene. "Bla fremover"-knappen ikke lenger henger igjen når man justerer skjermbredden. 

_Her er det feil_: https://test.ndla.no/lti og https://test.ndla.no/search?query=, der knappene "bla fremover" og "bla tilbake" ligger skjult i bakgrunnen og kan trykkes på selv om de ikke er synlige.