### PR TITLE
Expose more types for code sharing

### DIFF
--- a/packages/ndla-ui/src/User/apiTypes.ts
+++ b/packages/ndla-ui/src/User/apiTypes.ts
@@ -55,7 +55,7 @@ export interface FeideGoGroup extends FeideBaseGroup {
 
 export type FeideGroup = FeideOrg | FeideGoGroup;
 
-interface FeideUser {
+export interface FeideUser {
   cn: string[];
   displayName: string;
   eduPersonAffiliation: AffiliationType[] | AffiliationType;

--- a/packages/ndla-ui/src/User/index.ts
+++ b/packages/ndla-ui/src/User/index.ts
@@ -8,8 +8,8 @@
 
 import AuthModal from './AuthModal';
 import { UserInfo } from './UserInfo';
-import type { FeideGoGroup, FeideGroup, FeideOrg, FeideUserApiType } from './apiTypes';
+import type { FeideGoGroup, FeideGroup, FeideOrg, FeideUserApiType, FeideMembershipType, FeideUser } from './apiTypes';
 
 export { UserInfo };
-export type { FeideGoGroup, FeideGroup, FeideOrg, FeideUserApiType };
+export type { FeideGoGroup, FeideGroup, FeideOrg, FeideUserApiType, FeideMembershipType, FeideUser };
 export default AuthModal;

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -111,7 +111,7 @@ export { default as MastheadSearchModal } from './Masthead/MastheadSearchModal';
 export { default as MastheadAuthModal } from './Masthead/MastheadAuthModal';
 export { UserInfo } from './User';
 export { default as AuthModal } from './User';
-export type { FeideGoGroup, FeideGroup, FeideOrg, FeideUserApiType } from './User';
+export type { FeideGoGroup, FeideGroup, FeideOrg, FeideUserApiType, FeideMembershipType, FeideUser } from './User';
 
 export { default as CreatedBy } from './CreatedBy';
 


### PR DESCRIPTION
Jobber med å nøste opp tooltip-problematikken. Kom over en situasjon fra tidligere PR med `UserInfo`-komponent der det var noe krøll med API-typer. Ikke breaking på runtime, men feil typer. Exposer disse for å ta dem inn i f.eks `ndla-frontend`