### PR TITLE
Myndla addfolder input

### DIFF
--- a/packages/designmanual/stories/pages/MyNdla.tsx
+++ b/packages/designmanual/stories/pages/MyNdla.tsx
@@ -47,7 +47,12 @@ export const MyNdla = () => {
               type={'list'}
             />
             <h2>Legg til mappe</h2>
-            <FolderInput onAddFolder={() => {}} onClose={() => {}} />
+            {/* eslint-disable-next-line no-console */}
+            <FolderInput
+              autoFocus
+              onAddFolder={() => console.log('onAddFolder')}
+              onClose={() => console.log('onClose')}
+            />
             <h2>Blokkvisning av folder</h2>
             <BlockFolderWrapper>
               <Folder

--- a/packages/designmanual/stories/pages/MyNdla.tsx
+++ b/packages/designmanual/stories/pages/MyNdla.tsx
@@ -47,10 +47,11 @@ export const MyNdla = () => {
               type={'list'}
             />
             <h2>Legg til mappe</h2>
-            {/* eslint-disable-next-line no-console */}
             <FolderInput
               autoFocus
+              // eslint-disable-next-line no-console
               onAddFolder={() => console.log('onAddFolder')}
+              // eslint-disable-next-line no-console
               onClose={() => console.log('onClose')}
             />
             <h2>Blokkvisning av folder</h2>

--- a/packages/designmanual/stories/pages/MyNdla.tsx
+++ b/packages/designmanual/stories/pages/MyNdla.tsx
@@ -10,11 +10,11 @@ import styled from '@emotion/styled';
 import { spacing } from '@ndla/core';
 import { ListResource, BlockResource, Folder } from '@ndla/ui';
 import { MenuButton } from '@ndla/button';
+import { FolderInput } from '@ndla/ui';
 import MyNdlaResourceView from '../molecules/MyNdlaResourceView';
 
 //@ts-ignore
 import ComponentInfo from '../ComponentInfo';
-import { FolderInput } from '@ndla/ui/src';
 
 const Wrapper = styled.div`
   max-width: 960px;

--- a/packages/designmanual/stories/pages/MyNdla.tsx
+++ b/packages/designmanual/stories/pages/MyNdla.tsx
@@ -14,6 +14,7 @@ import MyNdlaResourceView from '../molecules/MyNdlaResourceView';
 
 //@ts-ignore
 import ComponentInfo from '../ComponentInfo';
+import { FolderInput } from '@ndla/ui/src';
 
 const Wrapper = styled.div`
   max-width: 960px;
@@ -45,6 +46,8 @@ export const MyNdla = () => {
               subResources={3}
               type={'list'}
             />
+            <h2>Legg til mappe</h2>
+            <FolderInput onAddFolder={() => {}} onClose={() => {}} />
             <h2>Blokkvisning av folder</h2>
             <BlockFolderWrapper>
               <Folder

--- a/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
@@ -95,6 +95,7 @@ interface IconCountProps {
 interface IconCountWrapperProps {
   type: LayoutType;
 }
+
 const IconCountWrapper = styled.div<IconCountWrapperProps>`
   display: flex;
   align-items: center;
@@ -109,6 +110,7 @@ const IconCountWrapper = styled.div<IconCountWrapperProps>`
       }
     `};
 `;
+
 const IconCount = ({ type, count, layoutType }: IconCountProps) => {
   const Icon = type === 'resource' ? FileDocumentOutline : FolderOutlined;
   const { t } = useTranslation();

--- a/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
@@ -22,7 +22,7 @@ interface FolderIconWrapperProps {
 const FolderIconWrapper = styled.div<FolderIconWrapperProps>`
   display: flex;
   border-radius: 100%;
-  padding: 11px;
+  padding: ${spacing.small};
   background-color: ${colors.brand.greyLighter};
   svg {
     width: 18px;

--- a/packages/ndla-ui/src/MyNdla/Resource/FolderInput.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/FolderInput.tsx
@@ -10,7 +10,7 @@ import styled from '@emotion/styled';
 import { IconButton } from '@ndla/button/src';
 import { FolderOutlined } from '@ndla/icons/contentType';
 import { Cross } from '@ndla/icons/action';
-import React, { ChangeEvent, FocusEvent, KeyboardEvent, useEffect, useRef, useState } from 'react';
+import React, { ChangeEvent, KeyboardEvent, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { colors, spacing } from '@ndla/core';
 
@@ -43,6 +43,7 @@ const StyledInput = styled.input`
   outline: none;
   border: none;
   margin-right: auto;
+  line-height: 1.75em;
 
   ::selection {
     background: ${colors.brand.lighter};
@@ -57,7 +58,9 @@ interface Props {
 
 const FolderInput = ({ onAddFolder, onClose, autoSelect }: Props) => {
   const { t } = useTranslation();
-  const [input, setInput] = useState('Ny mappe');
+  const newFolderText = t('treeStructure.newFolder.defaultName');
+  const [input, setInput] = useState<string>(newFolderText);
+  const [mounted, setMounted] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -72,22 +75,26 @@ const FolderInput = ({ onAddFolder, onClose, autoSelect }: Props) => {
   };
 
   useEffect(() => {
-    if (autoSelect) {
+    if (mounted) {
       inputRef.current?.select();
+    } else {
+      setMounted(true);
     }
-  }, [autoSelect]);
-
-  const onFocus = (event: FocusEvent<HTMLInputElement>) => {
-    event.target.select();
-  };
+  }, [mounted]);
 
   return (
     <FolderInputWrapper>
       <StyledFolderIcon>
         <FolderOutlined />
       </StyledFolderIcon>
-      <StyledInput ref={inputRef} value={input} onChange={handleInputChange} onKeyDown={onKeydown} onFocus={onFocus} />
-      <IconButton aria-label="temp" size="small" ghostPill onClick={onClose}>
+      <StyledInput
+        ref={inputRef}
+        value={input}
+        onChange={handleInputChange}
+        onKeyDown={onKeydown}
+        aria-label={newFolderText}
+      />
+      <IconButton aria-label={t('close')} size="small" ghostPill onClick={onClose}>
         <Cross />
       </IconButton>
     </FolderInputWrapper>

--- a/packages/ndla-ui/src/MyNdla/Resource/FolderInput.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/FolderInput.tsx
@@ -30,7 +30,7 @@ const FolderInputWrapper = styled.div`
 
 const StyledFolderIcon = styled.span`
   display: flex;
-  padding: 11px;
+  padding: ${spacing.small};
   svg {
     color: ${colors.brand.primary};
     height: 20px;

--- a/packages/ndla-ui/src/MyNdla/Resource/FolderInput.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/FolderInput.tsx
@@ -75,12 +75,12 @@ const FolderInput = ({ onAddFolder, onClose, autoSelect }: Props) => {
   };
 
   useEffect(() => {
-    if (mounted) {
+    if (mounted && autoSelect) {
       inputRef.current?.select();
     } else {
       setMounted(true);
     }
-  }, [mounted]);
+  }, [mounted, autoSelect]);
 
   return (
     <FolderInputWrapper>

--- a/packages/ndla-ui/src/MyNdla/Resource/FolderInput.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/FolderInput.tsx
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import styled from '@emotion/styled';
+import { IconButton } from '@ndla/button/src';
+import { FolderOutlined } from '@ndla/icons/contentType';
+import { Cross } from '@ndla/icons/action';
+import React, { ChangeEvent, FocusEvent, KeyboardEvent, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { colors, spacing } from '@ndla/core';
+
+// Source: https://kovart.github.io/dashed-border-generator/
+const borderStyle = `url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' stroke='${encodeURIComponent(
+  colors.brand.tertiary,
+)}' stroke-width='2' stroke-dasharray='8%2c8' stroke-dashoffset='4' stroke-linecap='square'/%3e%3c/svg%3e")`;
+
+const FolderInputWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: ${spacing.small};
+
+  background-image: ${borderStyle};
+`;
+
+const StyledFolderIcon = styled.span`
+  display: flex;
+  padding: 11px;
+  svg {
+    color: ${colors.brand.primary};
+    height: 20px;
+    width: 20px;
+  }
+`;
+
+const StyledInput = styled.input`
+  color: ${colors.brand.primary};
+  outline: none;
+  border: none;
+  margin-right: auto;
+
+  ::selection {
+    background: ${colors.brand.lighter};
+  }
+`;
+
+interface Props {
+  onAddFolder: (name: string) => void;
+  onClose: () => void;
+  autoSelect?: boolean;
+}
+
+const FolderInput = ({ onAddFolder, onClose, autoSelect }: Props) => {
+  const { t } = useTranslation();
+  const [input, setInput] = useState('Ny mappe');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setInput(e.target.value);
+  };
+
+  const onKeydown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && input) {
+      e.preventDefault();
+      onAddFolder(input);
+    }
+  };
+
+  useEffect(() => {
+    if (autoSelect) {
+      inputRef.current?.select();
+    }
+  }, [autoSelect]);
+
+  const onFocus = (event: FocusEvent<HTMLInputElement>) => {
+    event.target.select();
+  };
+
+  return (
+    <FolderInputWrapper>
+      <StyledFolderIcon>
+        <FolderOutlined />
+      </StyledFolderIcon>
+      <StyledInput ref={inputRef} value={input} onChange={handleInputChange} onKeyDown={onKeydown} onFocus={onFocus} />
+      <IconButton aria-label="temp" size="small" ghostPill onClick={onClose}>
+        <Cross />
+      </IconButton>
+    </FolderInputWrapper>
+  );
+};
+
+export default FolderInput;

--- a/packages/ndla-ui/src/MyNdla/Resource/FolderInput.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/FolderInput.tsx
@@ -53,10 +53,10 @@ const StyledInput = styled.input`
 interface Props {
   onAddFolder: (name: string) => void;
   onClose: () => void;
-  autoSelect?: boolean;
+  autoFocus?: boolean;
 }
 
-const FolderInput = ({ onAddFolder, onClose, autoSelect }: Props) => {
+const FolderInput = ({ onAddFolder, onClose, autoFocus }: Props) => {
   const { t } = useTranslation();
   const newFolderText = t('treeStructure.newFolder.defaultName');
   const [input, setInput] = useState<string>(newFolderText);
@@ -75,12 +75,12 @@ const FolderInput = ({ onAddFolder, onClose, autoSelect }: Props) => {
   };
 
   useEffect(() => {
-    if (mounted && autoSelect) {
+    if (mounted && autoFocus) {
       inputRef.current?.select();
     } else {
       setMounted(true);
     }
-  }, [mounted, autoSelect]);
+  }, [mounted, autoFocus]);
 
   return (
     <FolderInputWrapper>

--- a/packages/ndla-ui/src/MyNdla/Resource/index.ts
+++ b/packages/ndla-ui/src/MyNdla/Resource/index.ts
@@ -7,4 +7,5 @@
  */
 
 import Folder from './Folder';
-export { Folder };
+import FolderInput from './FolderInput';
+export { Folder, FolderInput };

--- a/packages/ndla-ui/src/MyNdla/index.ts
+++ b/packages/ndla-ui/src/MyNdla/index.ts
@@ -1,3 +1,4 @@
 import Folder from './Resource/Folder';
+import FolderInput from './Resource/FolderInput';
 import { VerticalNavigation } from './Navigation';
-export { VerticalNavigation, Folder };
+export { VerticalNavigation, Folder, FolderInput };

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -223,7 +223,7 @@ export { default as CopyParagraphButton } from './CopyParagraphButton';
 export { default as ContentPlaceholder } from './ContentPlaceholder';
 export { Notion, ConceptNotion } from './Notion';
 export { BannerCard } from './BannerCard';
-export { VerticalNavigation, Folder } from './MyNdla';
+export { VerticalNavigation, Folder, FolderInput } from './MyNdla';
 export { ListResource, BlockResource } from './Resource';
 export type { ListResourceProps } from './Resource';
 export type { TagType } from './TagSelector';


### PR DESCRIPTION
Lagt til ny input-komponent for oppretting av ny mappe. En kjapp liste over features. Ellers se figma-skisse for design:
- Aria-label på input (Ny mappe) og knapp (Lukk). Med translations.
- Mulighet for autoFocus. Da blir hele input-feltet markert ved mount.
- props for å legge til mappe ved enter-trykk i input og onClose ved trykk på lukk-knapp.

Animasjon kan gjøres utenom komponenten. Går ut fra at en max-height/opacity-animasjon holder.

<details>
    <summary>Figma-skisse</summary>

![image](https://user-images.githubusercontent.com/17144211/175249028-f6289629-46e0-42b0-ba6c-8d9b4212adaa.png)
</details>

