### PR TITLE
Ressurs mobilvisning

### DIFF
--- a/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
@@ -10,7 +10,7 @@ import styled from '@emotion/styled';
 import React, { ReactNode } from 'react';
 import { FolderOutlined } from '@ndla/icons/contentType';
 import { FileDocumentOutline } from '@ndla/icons/common';
-import { fonts, spacing, colors } from '@ndla/core';
+import { fonts, spacing, colors, mq, breakpoints } from '@ndla/core';
 import { css } from '@emotion/core';
 import { useTranslation } from 'react-i18next';
 import SafeLink from '@ndla/safelink';
@@ -110,6 +110,10 @@ const IconCountWrapper = styled.div<IconCountWrapperProps>`
         opacity: 1;
       }
     `};
+
+  ${mq.range({ until: breakpoints.tabletWide })} {
+    display: none;
+  }
 `;
 
 const IconCount = ({ type, count, layoutType }: IconCountProps) => {

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -9,7 +9,8 @@
 import styled from '@emotion/styled';
 import React, { ReactNode } from 'react';
 import SafeLink from '@ndla/safelink';
-import { fonts, spacing, colors } from '@ndla/core';
+import { fonts, spacing, colors, breakpoints, mq } from '@ndla/core';
+import { isMobile } from 'react-device-detect';
 import Image from '../Image';
 import { CompressTagsLength, ResourceImageProps, ResourceTitle, Row, TopicList } from './resourceComponents';
 
@@ -60,6 +61,19 @@ const ResourceInfoWrapper = styled.div`
   overflow: hidden;
 `;
 
+const TagsandActionMenu = styled.div`
+  display: flex;
+  align-items: center;
+  ${mq.range({ until: breakpoints.tabletWide })} {
+    display: none;
+  }
+`;
+const TagsandActionMenuMobile = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+`;
+
 interface StyledImageProps {
   imageSize: 'normal' | 'compact';
 }
@@ -69,8 +83,11 @@ const StyledImage = styled(Image)<StyledImageProps>`
   border-radius: 2px;
   object-fit: cover;
   width: ${(p) => (p.imageSize === 'normal' ? '136px' : '56px')};
-  min-width: ${(p) => (p.imageSize === 'normal' ? '136px' : '56px')};
   height: ${(p) => (p.imageSize === 'normal' ? '96px' : '40px')};
+  ${mq.range({ until: breakpoints.tabletWide })} {
+    max-width: 54px;
+    height: 40px;
+  }
 `;
 
 export interface ListResourceProps {
@@ -92,8 +109,10 @@ const ListResource = ({ link, title, tags, resourceImage, topics, description, a
       <ResourceInfoWrapper>
         <Row>
           <ResourceTitle>{title}</ResourceTitle>
-          {tags && CompressTagsLength(tags)}
-          {actionMenu}
+          <TagsandActionMenu>
+            {tags && CompressTagsLength(tags)}
+            {actionMenu}
+          </TagsandActionMenu>
         </Row>
         <Row>
           <TopicList topics={topics} />
@@ -102,6 +121,12 @@ const ListResource = ({ link, title, tags, resourceImage, topics, description, a
           <Row>
             <ResourceDescription>{description}</ResourceDescription>
           </Row>
+        )}
+        {isMobile && (
+          <TagsandActionMenuMobile>
+            {tags && CompressTagsLength(tags)}
+            {actionMenu}
+          </TagsandActionMenuMobile>
         )}
       </ResourceInfoWrapper>
     </ResourceWrapper>

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -64,7 +64,7 @@ const ResourceInfoWrapper = styled.div`
 const TagsandActionMenu = styled.div`
   display: flex;
   align-items: center;
-  ${mq.range({ until: breakpoints.tabletWide })} {
+  ${mq.range({ until: breakpoints.mobileWide })} {
     display: none;
   }
 `;

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -10,9 +10,8 @@ import styled from '@emotion/styled';
 import React, { ReactNode } from 'react';
 import SafeLink from '@ndla/safelink';
 import { fonts, spacing, colors, breakpoints, mq } from '@ndla/core';
-import { isMobile } from 'react-device-detect';
 import Image from '../Image';
-import { CompressTagsLength, ResourceImageProps, ResourceTitle, Row, TopicList } from './resourceComponents';
+import { CompressTagsLength, ResourceImageProps, ResourceTitle, TopicList } from './resourceComponents';
 
 const ResourceDescription = styled.p`
   line-clamp: 2;
@@ -27,6 +26,7 @@ const ResourceDescription = styled.p`
   -webkit-line-clamp: 2;
   line-clamp: 2;
   -webkit-box-orient: vertical;
+  grid-area: resourceDescription;
 `;
 
 const ResourceWrapper = styled(SafeLink)`
@@ -52,26 +52,31 @@ const ResourceWrapper = styled(SafeLink)`
     }
   }
 `;
-
-const ResourceInfoWrapper = styled.div`
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  max-width: 100%;
-  overflow: hidden;
-`;
-
 const TagsandActionMenu = styled.div`
   display: flex;
   align-items: center;
-  ${mq.range({ until: breakpoints.mobileWide })} {
-    display: none;
+  grid-area: tagsandaction;
+  ${mq.range({ until: breakpoints.tabletWide })} {
+    justify-content: flex-end;
   }
 `;
-const TagsandActionMenuMobile = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
+const ResourceInfoWrapper = styled.div`
+  display: grid;
+  max-width: 100%;
+  overflow: hidden;
+  align-items: baseline;
+  grid-template-areas:
+    'resourceTitle tagsandaction'
+    'topicList topicList'
+    'resourceDescription resourceDescription';
+  grid-template-columns: 7fr 3fr;
+  ${mq.range({ until: breakpoints.tabletWide })} {
+    grid-template-areas:
+      'resourceTitle resourceTitle'
+      'topicList topicList'
+      'resourceDescription resourceDescription'
+      'tagsandaction tagsandaction';
+  }
 `;
 
 interface StyledImageProps {
@@ -107,27 +112,13 @@ const ListResource = ({ link, title, tags, resourceImage, topics, description, a
     <ResourceWrapper to={link}>
       <StyledImage alt={resourceImage.alt} src={resourceImage.src} imageSize={showDescription ? 'normal' : 'compact'} />
       <ResourceInfoWrapper>
-        <Row>
-          <ResourceTitle>{title}</ResourceTitle>
-          <TagsandActionMenu>
-            {tags && CompressTagsLength(tags)}
-            {actionMenu}
-          </TagsandActionMenu>
-        </Row>
-        <Row>
-          <TopicList topics={topics} />
-        </Row>
-        {showDescription && (
-          <Row>
-            <ResourceDescription>{description}</ResourceDescription>
-          </Row>
-        )}
-        {isMobile && (
-          <TagsandActionMenuMobile>
-            {tags && CompressTagsLength(tags)}
-            {actionMenu}
-          </TagsandActionMenuMobile>
-        )}
+        <ResourceTitle>{title}</ResourceTitle>
+        <TagsandActionMenu>
+          {tags && CompressTagsLength(tags)}
+          {actionMenu}
+        </TagsandActionMenu>
+        <TopicList topics={topics} />
+        {showDescription && <ResourceDescription>{description}</ResourceDescription>}
       </ResourceInfoWrapper>
     </ResourceWrapper>
   );

--- a/packages/ndla-ui/src/Resource/resourceComponents.tsx
+++ b/packages/ndla-ui/src/Resource/resourceComponents.tsx
@@ -31,6 +31,7 @@ export const ResourceTitle = styled.h2`
   -webkit-line-clamp: 1;
   line-clamp: 1;
   -webkit-box-orient: vertical;
+  grid-area: resourceTitle;
 `;
 
 const StyledTagList = styled.ul`
@@ -57,6 +58,7 @@ const StyledTopicList = styled.ul`
   margin: 0;
   padding: 0;
   overflow: hidden;
+  grid-area: topicList;
 `;
 
 const StyledTopicListElement = styled.li`


### PR DESCRIPTION
Endret ListResource slik at den er lik designet på mobilvisning. 

Skjuler elementer med ismobile og viser med mediaqueries fordi tags skal stå på forskjellige steder i DOMet basert på om det finnes en description på ressursen eller ei. 
<img width="451" alt="image" src="https://user-images.githubusercontent.com/25527932/175314449-a0aa7dc3-f21c-4973-89c6-db08f8f860d9.png">
