### PR TITLE
Inverts add to favourites. Move phrases to more logic placement.

### DIFF
--- a/packages/ndla-ui/src/ResourceGroup/ResourceGroup.tsx
+++ b/packages/ndla-ui/src/ResourceGroup/ResourceGroup.tsx
@@ -37,6 +37,7 @@ type Props = {
   invertedStyle?: boolean;
   toggleAdditionalResources: () => void;
   onToggleAddToFavorites: (id: string | number, add: string) => void;
+  showAddToFavoriteButton: boolean;
 };
 
 const ResourceGroup = ({
@@ -47,6 +48,7 @@ const ResourceGroup = ({
   contentType,
   invertedStyle,
   onToggleAddToFavorites,
+  showAddToFavoriteButton = false
 }: Props & ResourceListProps) => (
   <Wrapper>
     {title && (
@@ -62,6 +64,7 @@ const ResourceGroup = ({
         contentType={contentType}
         resources={resources}
         onToggleAddToFavorites={onToggleAddToFavorites}
+        showAddToFavoriteButton={showAddToFavoriteButton}
       />
     ) : null}
   </Wrapper>

--- a/packages/ndla-ui/src/ResourceGroup/ResourceGroup.tsx
+++ b/packages/ndla-ui/src/ResourceGroup/ResourceGroup.tsx
@@ -48,7 +48,7 @@ const ResourceGroup = ({
   contentType,
   invertedStyle,
   onToggleAddToFavorites,
-  showAddToFavoriteButton = false
+  showAddToFavoriteButton = false,
 }: Props & ResourceListProps) => (
   <Wrapper>
     {title && (

--- a/packages/ndla-ui/src/ResourceGroup/ResourceItem.tsx
+++ b/packages/ndla-ui/src/ResourceGroup/ResourceItem.tsx
@@ -230,7 +230,7 @@ type Props = {
   access?: 'teacher';
   isFavorite?: boolean;
   onToggleAddToFavorites: (id: string, add: boolean) => void;
-  hideAddToFavoriteButton?: boolean;
+  showAddToFavoriteButton: boolean;
 };
 
 const ResourceItem = ({
@@ -247,7 +247,7 @@ const ResourceItem = ({
   access,
   onToggleAddToFavorites,
   isFavorite,
-  hideAddToFavoriteButton,
+  showAddToFavoriteButton,
 }: Props & Resource) => {
   const { t } = useTranslation();
   const hidden = additional ? !showAdditionalResources : false;
@@ -301,7 +301,7 @@ const ResourceItem = ({
             )}
           </>
         )}
-        {!hideAddToFavoriteButton && (
+        {showAddToFavoriteButton && (
           <ArticleFavoritesButton
             isFavorite={isFavorite}
             articleId={id}

--- a/packages/ndla-ui/src/ResourceGroup/ResourceList.tsx
+++ b/packages/ndla-ui/src/ResourceGroup/ResourceList.tsx
@@ -49,7 +49,7 @@ export type ResourceListProps = {
   title?: string;
   showAdditionalResources?: boolean;
   onToggleAddToFavorites: (id: string, add: boolean) => void;
-  hideAddToFavoriteButton?: boolean;
+  showAddToFavoriteButton: boolean;
 };
 
 const ResourceList = ({
@@ -59,7 +59,7 @@ const ResourceList = ({
   contentType,
   title,
   showAdditionalResources,
-  hideAddToFavoriteButton,
+  showAddToFavoriteButton,
 }: ResourceListProps) => {
   const { t } = useTranslation();
   const renderAdditionalResourceTrigger =
@@ -76,7 +76,7 @@ const ResourceList = ({
             key={id}
             contentType={contentType}
             showAdditionalResources={showAdditionalResources}
-            hideAddToFavoriteButton={hideAddToFavoriteButton}
+            showAddToFavoriteButton={showAddToFavoriteButton}
             onToggleAddToFavorites={onToggleAddToFavorites}
             {...resource}
             contentTypeDescription={

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -1007,10 +1007,6 @@ const messages = {
       terms: 'terms of use',
       feide: 'We have retrieved this information from Feide',
       newFavourite: 'Recently favourited',
-      resource: {
-        addToMyNdla: 'Add to My NDLA',
-        addedToMyNdla: 'Added to My NDLA',
-      },
       storageInfo: {
         title: 'How to save your favourite resources from NDLA',
         text: 'When you wish to save a resource, you can do so by clicking the heart on the top right corner of the page. You will then get an option to store the resource in a folder',
@@ -1024,6 +1020,11 @@ const messages = {
         text: 'When you save a resource, you will have the option to tag it with a keyword. This tag can be used to find the resource across folders. By selecting my tags on the menu to the left, you will see all the tags your have used. You can also see which resources are tagget with which keyword.',
       },
     },
+    resource: {
+      addToMyNdla: 'Add to My NDLA',
+      addedToMyNdla: 'Added to My NDLA',
+    },
+
   },
   snackbar: {
     close: 'Close notification',

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -1024,7 +1024,6 @@ const messages = {
       addToMyNdla: 'Add to My NDLA',
       addedToMyNdla: 'Added to My NDLA',
     },
-
   },
   snackbar: {
     close: 'Close notification',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -1005,10 +1005,6 @@ const messages = {
       terms: 'vilkår for bruk',
       newFavourite: 'Nylig lagt til',
       feide: 'Dette henter vi om deg fra Feide',
-      resource: {
-        addToMyNdla: 'Legg i Min NDLA',
-        addedToMyNdla: 'Lagt i Min NDLA',
-      },
       storageInfo: {
         title: 'Slik lagrer du dine favorittressurser fra NDLA',
         text: 'Når du ønsker å lagre en ressurs, kan du gjøre dette ved å klikke på hjertet øverst til høyre på siden. Du vil da få mulighet til å lagre ressursen i en mappe.',
@@ -1022,6 +1018,11 @@ const messages = {
         text: 'Når du lagrer en ressurs får du mulighet til å tagge ressursen med et nøkkelord. Du kan senere bruke taggene til å finne tilbake til ressurser på tvers av mapper.  Ved å velge mine tagger i venstremenyen får du oversikt over alle taggene du har brukt og du kan også her se hvilke ressurser som du har tagget med det bestemte nøkkelordet.',
       },
     },
+    resource: {
+      addToMyNdla: 'Legg i Min NDLA',
+      addedToMyNdla: 'Lagt i Min NDLA',
+    },
+
   },
   snackbar: {
     close: 'Lukk melding',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -1022,7 +1022,6 @@ const messages = {
       addToMyNdla: 'Legg i Min NDLA',
       addedToMyNdla: 'Lagt i Min NDLA',
     },
-
   },
   snackbar: {
     close: 'Lukk melding',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -1023,7 +1023,6 @@ const messages = {
       addToMyNdla: 'Legg i Min NDLA',
       addedToMyNdla: 'Lagt i Min NDLA',
     },
-
   },
   snackbar: {
     close: 'Lukk melding',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -1006,10 +1006,6 @@ const messages = {
       terms: 'vilkår for bruk',
       newFavourite: 'Nylig lagt til',
       feide: 'Dette henter vi om deg fra Feide',
-      resource: {
-        addToMyNdla: 'Legg i Min NDLA',
-        addedToMyNdla: 'Lagt i Min NDLA',
-      },
       storageInfo: {
         title: 'Slik lagrer du dine favorittressurser fra NDLA',
         text: 'Når du ønsker å lagre en ressurs, kan du gjøre dette ved å klikke på hjertet øverst til høyre på siden. Du vil da få mulighet til å lagre ressursen i en mappe.',
@@ -1023,6 +1019,11 @@ const messages = {
         text: 'Når du lagrer en ressurs får du mulighet til å tagge ressursen med et nøkkelord. Du kan senere bruke taggene til å finne tilbake til ressurser på tvers av mapper.  Ved å velge mine tagger i venstremenyen får du oversikt over alle taggene du har brukt og du kan også her se hvilke ressurser som du har tagget med det bestemte nøkkelordet.',
       },
     },
+    resource: {
+      addToMyNdla: 'Legg i Min NDLA',
+      addedToMyNdla: 'Lagt i Min NDLA',
+    },
+
   },
   snackbar: {
     close: 'Lukk melding',

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -1005,10 +1005,6 @@ const messages = {
       terms: 'vilkår for bruk',
       newFavourite: 'Nylig lagt til',
       feide: 'Dette henter vi om deg fra Feide',
-      resource: {
-        addToMyNdla: 'Legg i Min NDLA',
-        addedToMyNdla: 'Lagt i Min NDLA',
-      },
       storageInfo: {
         title: 'Slik lagrer du dine favorittressurser fra NDLA',
         text: 'Når du ønsker å lagre en ressurs, kan du gjøre dette ved å klikke på hjertet øverst til høyre på siden. Du vil da få mulighet til å lagre ressursen i en mappe.',
@@ -1022,6 +1018,11 @@ const messages = {
         text: 'Når du lagrer en ressurs får du mulighet til å tagge ressursen med et nøkkelord. Du kan senere bruke taggene til å finne tilbake til ressurser på tvers av mapper.  Ved å velge mine tagger i venstremenyen får du oversikt over alle taggene du har brukt og du kan også her se hvilke ressurser som du har tagget med det bestemte nøkkelordet.',
       },
     },
+    resource: {
+      addToMyNdla: 'Legg i Min NDLA',
+      addedToMyNdla: 'Lagt i Min NDLA',
+    },
+
   },
   snackbar: {
     close: 'Lukk melding',

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -1022,7 +1022,6 @@ const messages = {
       addToMyNdla: 'Legg i Min NDLA',
       addedToMyNdla: 'Lagt i Min NDLA',
     },
-
   },
   snackbar: {
     close: 'Lukk melding',

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -1005,10 +1005,6 @@ const messages = {
       terms: 'vilkår for bruk',
       newFavourite: 'Nylig lagt til',
       feide: 'Dette henter vi om deg fra Feide',
-      resource: {
-        addToMyNdla: 'Legg i Min NDLA',
-        addedToMyNdla: 'Lagt i Min NDLA',
-      },
       storageInfo: {
         title: 'Slik lagrer du dine favorittressurser fra NDLA',
         text: 'Når du ønsker å lagre en ressurs, kan du gjøre dette ved å klikke på hjertet øverst til høyre på siden. Du vil da få mulighet til å lagre ressursen i en mappe.',
@@ -1022,6 +1018,11 @@ const messages = {
         text: 'Når du lagrer en ressurs får du mulighet til å tagge ressursen med et nøkkelord. Du kan senere bruke taggene til å finne tilbake til ressurser på tvers av mapper.  Ved å velge mine tagger i venstremenyen får du oversikt over alle taggene du har brukt og du kan også her se hvilke ressurser som du har tagget med det bestemte nøkkelordet.',
       },
     },
+    resource: {
+      addToMyNdla: 'Legg i Min NDLA',
+      addedToMyNdla: 'Lagt i Min NDLA',
+    },
+
   },
   snackbar: {
     close: 'Lukk melding',

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -1022,7 +1022,6 @@ const messages = {
       addToMyNdla: 'Legg i Min NDLA',
       addedToMyNdla: 'Lagt i Min NDLA',
     },
-
   },
   snackbar: {
     close: 'Lukk melding',


### PR DESCRIPTION
For meg gir det meir meining å skru på ny funksjonalitet enn å måtte skru av. I tillegg mangla det parameter i ResourceGroup til å styre visning av favorittikon. Og plassering av tekst i messsages var feil. Berre sjekk mouseover på ikona i launchpad her: https://designmanual.ndla.no/?path=/story/l%C3%A6ringsressurser--fagstoff