### PR TITLE
Show all filters when adjusting screen size

### DIFF
--- a/packages/ndla-ui/src/Filter/FilterButtons.tsx
+++ b/packages/ndla-ui/src/Filter/FilterButtons.tsx
@@ -24,15 +24,14 @@ const StyledHeading = styled.h3`
 `;
 
 const StyledButtonsWrapper = styled.div`
-  display: flex;
-  flex-wrap: nowrap;
-  position: relative;
+  display: inline-flex;
+  flex-wrap: wrap;
 `;
 
 const StyledButtonElementWrapper = styled.div`
   margin: 0 ${spacing.xsmall} ${spacing.xsmall} 0;
   break-inside: avoid;
-  flex: 1 0 auto;
+  flex-shrink: 0;
 `;
 
 const StyledList = styled.ul`


### PR DESCRIPTION
Closes https://github.com/NDLANO/Issues/issues/3160

Når man minsker skjermbredden etter å ha valgt filtre skal man nå kunne se alle filtrene.
