### PR TITLE
Increase specifity for label override

### DIFF
--- a/packages/ndla-forms/src/Input.tsx
+++ b/packages/ndla-forms/src/Input.tsx
@@ -35,12 +35,14 @@ const FormWarningText = styled.span<FormWarningTextProps>`
 `;
 
 const StyledLabel = styled.label`
-  width: ${spacingUnit * 4}px;
-  max-width: ${spacingUnit * 4}px;
-  padding: 20px ${spacing.small} ${spacing.small} 0;
-  text-transform: uppercase;
-  font-weight: ${fonts.weight.semibold};
-  ${fonts.sizes(14, 1.1)};
+  && {
+    width: ${spacingUnit * 4}px;
+    max-width: ${spacingUnit * 4}px;
+    padding: 20px ${spacing.small} ${spacing.small} 0;
+    text-transform: uppercase;
+    font-weight: ${fonts.weight.semibold};
+    ${fonts.sizes(14, 1.1)};
+  }
 `;
 
 interface StyledInputWrapperProps {


### PR DESCRIPTION
Relatert til NDLANO/Issues#3162

Overstyring av label i fungerte ikke alltid fordi spesifiteten på den originale stylingen og den nye stylingen var lik. Med `&&` dobles klassenavnet-selectoren og den vil dermed få høyere spesifitet.


Kan testes ved å linke ndla/forms inn i ed og sjekke feks bildeskjema. Label ved siden av input-felt skal ikke lenger være oversized.