### PR TITLE
Use Safelink in treestructure instead of anchor

### DIFF
--- a/packages/ndla-ui/src/TreeStructure/FolderItem.tsx
+++ b/packages/ndla-ui/src/TreeStructure/FolderItem.tsx
@@ -11,8 +11,8 @@ import styled from '@emotion/styled';
 import { ArrowDropDown } from '@ndla/icons/common';
 import { FolderOutlined } from '@ndla/icons/contentType';
 import { colors, spacing, misc, animations } from '@ndla/core';
+import SafeLink from '@ndla/safelink';
 import { SetFocusedFolderId, FolderChildFuncType } from './TreeStructure.types';
-import SafeLink from '../../../safelink/src';
 
 const OpenButton = styled.button<{ isOpen: boolean }>`
   background: transparent;

--- a/packages/ndla-ui/src/TreeStructure/FolderItem.tsx
+++ b/packages/ndla-ui/src/TreeStructure/FolderItem.tsx
@@ -12,6 +12,7 @@ import { ArrowDropDown } from '@ndla/icons/common';
 import { FolderOutlined } from '@ndla/icons/contentType';
 import { colors, spacing, misc, animations } from '@ndla/core';
 import { SetFocusedFolderId, FolderChildFuncType } from './TreeStructure.types';
+import SafeLink from '../../../safelink/src';
 
 const OpenButton = styled.button<{ isOpen: boolean }>`
   background: transparent;
@@ -75,7 +76,7 @@ const FolderName = styled.button<{ marked: boolean; noArrow?: boolean }>`
   text-align: left;
 `;
 
-const FolderNameLink = FolderName.withComponent('a');
+const FolderNameLink = FolderName.withComponent(SafeLink);
 
 interface Props {
   name: string;
@@ -135,9 +136,9 @@ const FolderItem = ({
         <FolderNameLink
           ref={folderNameLinkRef}
           noArrow={hideArrow}
+          to={loading ? '' : url}
           tabIndex={marked ? 0 : -1}
           marked={marked}
-          href={loading ? undefined : url}
           onFocus={() => {
             setFocusedFolderId(id);
           }}

--- a/packages/safelink/src/SafeLink.tsx
+++ b/packages/safelink/src/SafeLink.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { HTMLAttributes, ReactNode, useContext } from 'react';
+import React, { HTMLAttributes, MutableRefObject, ReactNode, useContext } from 'react';
 import { Link, LinkProps } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { Launch } from '@ndla/icons/common';
@@ -27,20 +27,21 @@ const LaunchIcon = styled(Launch)`
 
 type Props = {
   showNewWindowIcon?: boolean;
+  ref?: MutableRefObject<HTMLAnchorElement | null>;
   children?: ReactNode;
 };
 
 export type SafeLinkProps = Props & LinkProps & HTMLAttributes<HTMLElement>;
 
 // Fallback to normal link if app is missing RouterContext, link is external or is old ndla link
-const SafeLink = ({ to, replace, children, showNewWindowIcon, tabIndex, ...rest }: SafeLinkProps) => {
+const SafeLink = ({ to, replace, children, showNewWindowIcon, tabIndex, ref, ...rest }: SafeLinkProps) => {
   const isMissingRouterContext = useContext(MissingRouterContext);
 
   if (isMissingRouterContext || isExternalLink(to) || isOldNdlaLink(to)) {
     const href = typeof to === 'string' ? to : '#';
     return (
       <>
-        <a href={href} {...rest}>
+        <a href={href} ref={ref} {...rest}>
           {children}
           {showNewWindowIcon && <LaunchIcon style={{ verticalAlign: 'text-top' }} />}
         </a>
@@ -50,7 +51,7 @@ const SafeLink = ({ to, replace, children, showNewWindowIcon, tabIndex, ...rest 
 
   return (
     // RR6 link immediately fails if to is somehow undefined, so we provide an empty fallback to recover.
-    <Link tabIndex={tabIndex ?? 0} to={to ?? ''} replace={replace} {...rest}>
+    <Link ref={ref} tabIndex={tabIndex ?? 0} to={to ?? ''} replace={replace} {...rest}>
       {children}
       {showNewWindowIcon && <LaunchIcon style={{ verticalAlign: 'text-top' }} />}
     </Link>


### PR DESCRIPTION
Har byttet anchor med SafeLink i trestruktur for at routing skal fungere ved klikk på lenker. La til støtte for ref i SafeLink da dette var nødvendig for funksjonaliteten i trestruktur.