### PR TITLE
Fix filelisteditor checkbox onclick

### DIFF
--- a/packages/ndla-editor/src/FileListEditor.tsx
+++ b/packages/ndla-editor/src/FileListEditor.tsx
@@ -10,6 +10,7 @@ import React, { Component, MouseEvent as ReactMouseEvent, createRef, MutableRefO
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import Tooltip from '@ndla/tooltip';
+import { isNumber } from 'lodash';
 import { DragHorizontal, DeleteForever } from '@ndla/icons/editor';
 import { Pencil } from '@ndla/icons/action';
 import { spacing, spacingUnit, fonts, colors, shadows, animations } from '@ndla/core';
@@ -341,7 +342,7 @@ class FileListEditor extends Component<Props, State> {
                     checked={file.display === 'block'}
                     value=""
                     id={index}
-                    onChange={(i) => i && onToggleRenderInline(i)}
+                    onChange={(i) => isNumber(i) && onToggleRenderInline(i)}
                   />
                 </Tooltip>
               )}


### PR DESCRIPTION
onChange i FileListEditor ble ikke kalt dersom index === 0. Retter nå opp i dette slik at det er mulig å toggle checkbox i første linje i file editor

![image](https://user-images.githubusercontent.com/17144211/176914233-68c880e0-27cf-4bd3-b50b-73fbf7b9412b.png)
