### PR TITLE
Prevent links from triggering in Resource/Folder when clicking MenuButton

### DIFF
--- a/packages/button/src/MenuButton.tsx
+++ b/packages/button/src/MenuButton.tsx
@@ -7,12 +7,12 @@
  */
 
 import styled from '@emotion/styled';
-import React, { ReactNode, MouseEvent } from 'react';
+import React, { ReactNode, MouseEvent, ButtonHTMLAttributes } from 'react';
 import { colors, spacing, shadows, misc, animations } from '@ndla/core';
 import { Menu, MenuList, MenuItem, MenuButton as MenuButtonReach } from '@reach/menu-button';
 import { HorizontalMenu } from '@ndla/icons/contentType';
 import { useTranslation } from 'react-i18next';
-import { ButtonProps } from './';
+import { ButtonSize } from './';
 import { convertSizeForSVG } from './IconButton';
 
 interface StyledButtonProps {
@@ -90,12 +90,13 @@ export interface MenuItemProps {
   type?: 'danger';
 }
 
-interface MenuButtonProps extends ButtonProps {
+interface MenuButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   menuItems?: MenuItemProps[];
   children?: ReactNode;
   menuButtonPrefix?: ReactNode;
   hideMenuIcon?: boolean;
   tabIndex?: number;
+  size?: ButtonSize;
 }
 export const MenuButton = ({
   menuItems,
@@ -104,16 +105,19 @@ export const MenuButton = ({
   hideMenuIcon,
   className,
   tabIndex,
+  'aria-label': ariaLabel,
   ...rest
 }: MenuButtonProps) => {
   const { t } = useTranslation();
   return (
     <Menu tabIndex={tabIndex}>
       <StyledMenuButton
-        aria-label={rest['aria-label'] || t('myNdla.more')}
+        aria-label={ariaLabel || t('myNdla.more')}
         tabIndex={tabIndex}
         className={className}
-        svgSize={convertSizeForSVG(size || 'normal')}>
+        svgSize={convertSizeForSVG(size || 'normal')}
+        onClick={(e) => e.preventDefault()} // Prevent redirect from triggering when placed inside <a>
+        {...rest}>
         {children}
         {!hideMenuIcon && <StyledHorizontalMenu />}
       </StyledMenuButton>

--- a/packages/button/src/MenuButton.tsx
+++ b/packages/button/src/MenuButton.tsx
@@ -105,14 +105,13 @@ export const MenuButton = ({
   hideMenuIcon,
   className,
   tabIndex,
-  'aria-label': ariaLabel,
   ...rest
 }: MenuButtonProps) => {
   const { t } = useTranslation();
   return (
     <Menu tabIndex={tabIndex}>
       <StyledMenuButton
-        aria-label={ariaLabel || t('myNdla.more')}
+        aria-label={t('myNdla.more')}
         tabIndex={tabIndex}
         className={className}
         svgSize={convertSizeForSVG(size || 'normal')}

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -119,7 +119,7 @@ const ListResource = ({ link, title, tags, resourceImage, topics, description, m
   const showDescription = description !== undefined;
 
   return (
-    <ResourceWrapper to={'https://google.com'}>
+    <ResourceWrapper to={link}>
       <StyledImageWrapper imageSize={showDescription ? 'normal' : 'compact'}>
         <StyledImage alt={resourceImage.alt} src={resourceImage.src} />
       </StyledImageWrapper>

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -31,12 +31,13 @@ const ResourceDescription = styled.p`
 `;
 
 const ResourceWrapper = styled(SafeLink)`
-  display: grid;
   flex: 1;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   grid-template-areas:
     'image  topicAndTitle   tags'
     'image  description     description';
-  grid-template-columns: auto 1fr auto;
+
   ${mq.range({ until: breakpoints.mobileWide })} {
     grid-template-columns: auto 1fr;
     grid-template-areas:
@@ -52,6 +53,7 @@ const ResourceWrapper = styled(SafeLink)`
   border-radius: 2px;
   color: ${colors.brand.greyDark};
   gap: 0 ${spacing.small};
+
   &:hover {
     box-shadow: 1px 1px 6px 2px rgba(9, 55, 101, 0.08);
     transition-duration: 0.2s;
@@ -117,7 +119,7 @@ const ListResource = ({ link, title, tags, resourceImage, topics, description, m
   const showDescription = description !== undefined;
 
   return (
-    <ResourceWrapper to={link}>
+    <ResourceWrapper to={'https://google.com'}>
       <StyledImageWrapper imageSize={showDescription ? 'normal' : 'compact'}>
         <StyledImage alt={resourceImage.alt} src={resourceImage.src} />
       </StyledImageWrapper>


### PR DESCRIPTION
Se: /?path=/story/min-ndla--elementer

Mappe/Ressurs er komponenter der hele elementet er wrappet i en `<a>`. Har derfor satt preventDefault på knapp som brukes for å unngå redirect ved trykk på knappen

![image](https://user-images.githubusercontent.com/17144211/177110537-9e5954a5-4a74-48b4-bb3e-de38aac784ce.png)
