### PR TITLE
Resourcefolder button link restructure

### DIFF
--- a/packages/button/src/MenuButton.tsx
+++ b/packages/button/src/MenuButton.tsx
@@ -122,7 +122,12 @@ export const MenuButton = ({
       </StyledMenuButton>
       <StyledMenuList>
         {menuItems?.map(({ type, text, icon, onClick }) => (
-          <StyledMenuItem key={text} onSelect={onClick} type={type} aria-label={text}>
+          <StyledMenuItem
+            key={text}
+            onClick={(e) => e.preventDefault()}
+            onSelect={onClick}
+            type={type}
+            aria-label={text}>
             {icon}
             {text}
           </StyledMenuItem>

--- a/packages/button/src/MenuButton.tsx
+++ b/packages/button/src/MenuButton.tsx
@@ -62,7 +62,7 @@ const StyledMenuList = styled(MenuList)`
   z-index: 99999;
   position: relative;
   @media (prefers-reduced-motion: no-preference) {
-    ${animations.fadeInTop(animations.durations.fast)}
+    ${animations.fadeIn(animations.durations.fast)}
   }
 `;
 

--- a/packages/designmanual/stories/pages/MyNdla.tsx
+++ b/packages/designmanual/stories/pages/MyNdla.tsx
@@ -29,11 +29,7 @@ const BlockFolderWrapper = styled.div`
 `;
 
 export const menuItems: MenuItemProps[] = [
-  {
-    icon: <Pencil />,
-    text: 'Rediger',
-    onClick: () => {},
-  },
+  { icon: <Pencil />, text: 'Rediger', onClick: () => {} },
   { icon: <DeleteForever />, text: 'Slett', onClick: () => {}, type: 'danger' },
 ];
 

--- a/packages/designmanual/stories/pages/MyNdla.tsx
+++ b/packages/designmanual/stories/pages/MyNdla.tsx
@@ -29,7 +29,11 @@ const BlockFolderWrapper = styled.div`
 `;
 
 export const menuItems: MenuItemProps[] = [
-  { icon: <Pencil />, text: 'Rediger', onClick: () => {} },
+  {
+    icon: <Pencil />,
+    text: 'Rediger',
+    onClick: () => {},
+  },
   { icon: <DeleteForever />, text: 'Slett', onClick: () => {}, type: 'danger' },
 ];
 


### PR DESCRIPTION
Et par endring:
- Menyen tilhørende MenuButton (reach) animeres nå inn uten offset på posisjon. Oppsto en visuell bug det korte øyeblikket menyen lå i veien for cursor.
- preventDefault ved trykk på MenuItem. Uten dette vil lenken på Folder/Resource redirecte samtidig 🤷 