### PR TITLE
Add z-index to figure

### DIFF
--- a/packages/core/scss/global/utilities/utilities.grids.scss
+++ b/packages/core/scss/global/utilities/utilities.grids.scss
@@ -16,6 +16,7 @@ $denominator: auto;
 $extra-margin: 10px;
 
 @mixin float($cols, $maxcols, $direction) {
+  z-index: 1;
   $colDifference: $maxcols - $cols;
   $cols-tablet: $cols - 1;
   @if ($cols == 1) {


### PR DESCRIPTION
Done in order to fix lists rendering over figcaption resulting in tooltips not rendering.

Closing https://github.com/NDLANO/Issues/issues/3163