### PR TITLE
Use menuPopover in menubutton to handle left and right align

### DIFF
--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -25,7 +25,8 @@
   "files": [
     "scss",
     "lib",
-    "es"
+    "es",
+    "dist"
   ],
   "dependencies": {
     "@ndla/core": "^2.3.2",

--- a/packages/button/src/MenuButton.tsx
+++ b/packages/button/src/MenuButton.tsx
@@ -9,7 +9,8 @@
 import styled from '@emotion/styled';
 import React, { ReactNode, MouseEvent, ButtonHTMLAttributes } from 'react';
 import { colors, spacing, shadows, misc, animations } from '@ndla/core';
-import { Menu, MenuList, MenuItem, MenuButton as MenuButtonReach } from '@reach/menu-button';
+import { Menu, MenuItem, MenuButton as MenuButtonReach, MenuPopover, MenuItems } from '@reach/menu-button';
+import { positionRight, positionDefault } from '@reach/popover';
 import { HorizontalMenu } from '@ndla/icons/contentType';
 import { useTranslation } from 'react-i18next';
 import { ButtonSize } from './';
@@ -54,7 +55,7 @@ const StyledHorizontalMenu = styled(HorizontalMenu)`
   }
 `;
 
-const StyledMenuList = styled(MenuList)`
+const StyledMenuItems = styled(MenuItems)`
   overflow: hidden;
   padding: 0;
   background-color: white;
@@ -99,6 +100,7 @@ interface MenuButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   hideMenuIcon?: boolean;
   tabIndex?: number;
   size?: ButtonSize;
+  alignRight?: boolean;
 }
 export const MenuButton = ({
   menuItems,
@@ -107,6 +109,7 @@ export const MenuButton = ({
   hideMenuIcon,
   className,
   tabIndex,
+  alignRight,
   ...rest
 }: MenuButtonProps) => {
   const { t } = useTranslation();
@@ -122,19 +125,21 @@ export const MenuButton = ({
         {children}
         {!hideMenuIcon && <StyledHorizontalMenu />}
       </StyledMenuButton>
-      <StyledMenuList>
-        {menuItems?.map(({ type, text, icon, onClick }) => (
-          <StyledMenuItem
-            key={text}
-            onClick={(e) => e.preventDefault()}
-            onSelect={onClick}
-            type={type}
-            aria-label={text}>
-            {icon}
-            {text}
-          </StyledMenuItem>
-        ))}
-      </StyledMenuList>
+      <MenuPopover portal={true} position={alignRight ? positionRight : positionDefault}>
+        <StyledMenuItems>
+          {menuItems?.map(({ type, text, icon, onClick }) => (
+            <StyledMenuItem
+              key={text}
+              onClick={(e) => e.preventDefault()}
+              onSelect={onClick}
+              type={type}
+              aria-label={text}>
+              {icon}
+              {text}
+            </StyledMenuItem>
+          ))}
+        </StyledMenuItems>
+      </MenuPopover>
     </Menu>
   );
 };

--- a/packages/button/src/MenuButton.tsx
+++ b/packages/button/src/MenuButton.tsx
@@ -20,16 +20,15 @@ interface StyledButtonProps {
   svgSize: number;
 }
 
-const StyledMenuButton = styled(MenuButtonReach, {
-  shouldForwardProp: (name) => name !== 'svgSize',
-})<StyledButtonProps>`
+const shouldForwardProp = (name: string) => name !== 'svgSize';
+
+const StyledMenuButton = styled(MenuButtonReach, { shouldForwardProp })<StyledButtonProps>`
   display: flex;
-  justify-content: center;
   align-items: center;
   gap: ${spacing.small};
   padding: 0;
   cursor: pointer;
-  background-color: transparent;
+  background: none;
   border: none;
   &:hover *,
   &:active *,
@@ -38,12 +37,12 @@ const StyledMenuButton = styled(MenuButtonReach, {
   }
 
   svg {
-    margin: 0;
     width: ${({ svgSize }) => svgSize}px;
     height: ${({ svgSize }) => svgSize}px;
     fill: ${colors.brand.secondary};
   }
 `;
+
 const StyledHorizontalMenu = styled(HorizontalMenu)`
   border-radius: 100%;
   transition: ${misc.transition.default};
@@ -56,14 +55,11 @@ const StyledHorizontalMenu = styled(HorizontalMenu)`
 `;
 
 const StyledMenuItems = styled(MenuItems)`
-  overflow: hidden;
   padding: 0;
-  background-color: white;
   border: none;
   border-radius: 4px;
   box-shadow: ${shadows.levitate1};
   z-index: 99999;
-  position: relative;
   @media (prefers-reduced-motion: no-preference) {
     ${animations.fadeIn(animations.durations.fast)}
   }

--- a/packages/core/scss/global/elements/_elements.page.scss
+++ b/packages/core/scss/global/elements/_elements.page.scss
@@ -28,7 +28,10 @@ body {
   height: 100%;
 }
 
-input, textarea, select, button {
+input,
+textarea,
+select,
+button {
   font-family: $font;
 }
 

--- a/packages/ndla-ui/src/Masthead/component.masthead.scss
+++ b/packages/ndla-ui/src/Masthead/component.masthead.scss
@@ -60,6 +60,7 @@
   }
 
   &__content {
+    overflow: hidden;
     justify-content: center;
     align-items: center;
     text-align: center;

--- a/packages/ndla-ui/src/Masthead/component.masthead.scss
+++ b/packages/ndla-ui/src/Masthead/component.masthead.scss
@@ -60,7 +60,6 @@
   }
 
   &__content {
-    overflow: hidden;
     justify-content: center;
     align-items: center;
     text-align: center;

--- a/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
@@ -141,7 +141,7 @@ const Folder = ({ link, title, subFolders, subResources, type = 'list', menuItem
       <FolderTitle>{title}</FolderTitle>
       <IconCount layoutType={type} type={'folder'} count={subFolders} />
       <IconCount layoutType={type} type={'resource'} count={subResources} />
-      {menuItems && menuItems.length > 0 && <MenuButton size="small" menuItems={menuItems} />}
+      {menuItems && menuItems.length > 0 && <MenuButton alignRight size="small" menuItems={menuItems} />}
     </FolderWrapper>
   );
 };

--- a/packages/ndla-ui/src/Resource/BlockResource.tsx
+++ b/packages/ndla-ui/src/Resource/BlockResource.tsx
@@ -92,7 +92,7 @@ const BlockResource = ({ link, title, tags, resourceImage, topics, description, 
         <BlockDescription>{description}</BlockDescription>
         <RightRow>
           {tags && <CompressedTagList tags={tags} />}
-          {menuItems && menuItems.length > 0 && <MenuButton size="small" menuItems={menuItems} />}
+          {menuItems && menuItems.length > 0 && <MenuButton alignRight size="small" menuItems={menuItems} />}
         </RightRow>
       </BlockInfoWrapper>
     </BlockElementWrapper>

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -131,7 +131,7 @@ const ListResource = ({ link, title, tags, resourceImage, topics, description, m
       {showDescription && <ResourceDescription>{description}</ResourceDescription>}
       <TagsandActionMenu>
         {tags && <CompressedTagList tags={tags} />}
-        {menuItems && menuItems.length > 0 && <MenuButton size="small" menuItems={menuItems} />}
+        {menuItems && menuItems.length > 0 && <MenuButton alignRight size="small" menuItems={menuItems} />}
       </TagsandActionMenu>
     </ResourceWrapper>
   );

--- a/packages/ndla-ui/src/TopicMenu/TopicMenuButton.jsx
+++ b/packages/ndla-ui/src/TopicMenu/TopicMenuButton.jsx
@@ -9,7 +9,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
-import { spacing, fonts, colors } from '@ndla/core';
+import { spacing, fonts, colors, mq, breakpoints } from '@ndla/core';
 import { Menu } from '@ndla/icons/common';
 import Button from '@ndla/button';
 
@@ -37,6 +37,10 @@ const style = css`
     border: 2px solid ${colors.brand.lighter};
     background: ${colors.white};
     color: ${colors.brand.primary};
+  }
+  ${mq.range({ until: breakpoints.tablet })} {
+    padding-left: ${spacing.xsmall};
+    padding-right: ${spacing.xsmall};
   }
 `;
 


### PR DESCRIPTION

Reach MenuButton har en bug som fører til at popoveren noen ganger forsvinner utfor skjermen ved første klikk. Denne buggen har vi kun klart å framprovosere på veldig smale skjermer.

Løsningen på dette problemet er dessverre ikke en faktisk feilretting, men en måte å omgå det. Har lagt til støtte for at popover kan alignes både til høyre og venstre som default. På den måten kan man sørge for at MenuButtons som er helt til høyre på en siden vil ha en popover som vokser mot venstre.

Buggen er ikke reproduserbar i designmanual, men test følgende:
- /?path=/story/min-ndla--elementer
- Elementer som har menyknapp på høyre side skal ha popover som vokser mot venstre.