### PR TITLE
Remove emotion/core in packages that barely use it.

### DIFF
--- a/packages/ndla-accordion/src/AccordionBar.tsx
+++ b/packages/ndla-accordion/src/AccordionBar.tsx
@@ -8,7 +8,6 @@
 
 import React, { ReactNode } from 'react';
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 import { ChevronRight } from '@ndla/icons/common';
 import { colors, spacing, spacingUnit, fonts } from '@ndla/core';
 import { openIndexesProps } from '../types';
@@ -20,27 +19,17 @@ type StyledAccordionBarProps = {
 };
 
 const StyledAccordionBar = styled.div<StyledAccordionBarProps>`
-  ${(props) =>
-    props.tiny
-      ? css`
-          padding: ${spacing.xsmall} ${spacing.small} ${spacing.xsmall} 0;
-        `
-      : css`
-          padding: ${spacing.small} ${spacing.normal} ${spacing.small} calc(${spacing.xsmall} * 3);
-        `}
-  background: ${colors.brand.light};
+  padding: ${(p) =>
+    p.tiny
+      ? `${spacing.xsmall} ${spacing.small} ${spacing.xsmall} 0`
+      : `${spacing.small} ${spacing.normal} ${spacing.small} calc(${spacing.xsmall} * 3`};
+  background: ${(p) => (p.hasError && p.isOpen ? colors.support.redLight : colors.brand.light)};
   display: flex;
   align-items: center;
   justify-content: flex-start;
   transition: color 100ms ease, background 100ms ease;
   border: 2px solid ${(props) => (props.hasError ? colors.support.redLight : 'transparent')};
-  ${({ hasError, isOpen }) =>
-    hasError &&
-    isOpen &&
-    css`
-      background: ${colors.support.redLight};
-      border-bottom-color: transparent;
-    `}
+  border-bottom-color: ${(p) => p.hasError && p.isOpen && 'transparent'};
 `;
 
 type ButtonProps = {
@@ -56,10 +45,14 @@ const StyledButton = styled.button<ButtonProps>`
   color: ${colors.brand.primary};
   display: flex;
   align-items: center;
+  height: ${(p) => !p.tiny && spacing.large};
+  padding: ${(p) =>
+    p.tiny ? `${spacing.xsmall} ${spacing.xsmall} ${spacing.xsmall} ${spacing.small}` : `0 0 0 ${spacing.small}`};
   span {
     text-align: left;
     text-decoration: underline;
     font-weight: ${fonts.weight.semibold};
+    ${(p) => (p.tiny ? fonts.sizes(18, 1.1) : fonts.sizes(spacing.normal, 1.1))};
   }
   &:hover,
   &:focus {
@@ -70,32 +63,10 @@ const StyledButton = styled.button<ButtonProps>`
   svg {
     transition: transform 100ms ease;
     transform: rotate(${(props) => (props.isOpen ? '90' : '0')}deg);
+    width: ${(p) => (p.tiny ? '16px' : '22px')};
+    height: ${(p) => (p.tiny ? '16px' : '22px')};
+    margin-right: ${(p) => (p.tiny ? `${spacingUnit / 8}px` : spacing.xsmall)};
   }
-  ${(props) =>
-    props.tiny
-      ? css`
-          padding: ${spacing.xsmall} ${spacing.xsmall} ${spacing.xsmall} ${spacing.small};
-          span {
-            ${fonts.sizes(18, 1.1)};
-          }
-          svg {
-            width: 16px;
-            height: 16px;
-            margin-right: ${spacingUnit / 8}px;
-          }
-        `
-      : css`
-          height: ${spacing.large};
-          padding-right: ${spacing.small};
-          span {
-            ${fonts.sizes(spacing.normal, 1.1)};
-          }
-          svg {
-            width: 22px;
-            height: 22px;
-            margin-right: ${spacing.xsmall};
-          }
-        `}
 `;
 
 const StyledChildrenWrapper = styled.div<{ tiny?: boolean }>`

--- a/packages/ndla-accordion/src/AccordionSection.tsx
+++ b/packages/ndla-accordion/src/AccordionSection.tsx
@@ -45,7 +45,7 @@ const AccordionSection = (props: Props) => {
         {barChildren}
       </AccordionBar>
       {isOpen && (
-        <AccordionPanel id={id} hasError={hasError} isOpen={isOpen}>
+        <AccordionPanel id={id} hasError={hasError} isOpen={false}>
           <div className={className}>
             {Children.map(children, (child) => {
               if (isValidElement(child) && typeof child.type !== 'string') {

--- a/packages/ndla-code/package.json
+++ b/packages/ndla-code/package.json
@@ -38,7 +38,6 @@
     "react-syntax-highlighter": "^15.4.4"
   },
   "peerDependencies": {
-    "@emotion/core": "^10.0.35",
     "@emotion/styled": "^10.0.27",
     "react": "16.13.1 || ^17.0.0",
     "react-i18next": "^11.11.0"

--- a/packages/ndla-image-search/package.json
+++ b/packages/ndla-image-search/package.json
@@ -39,7 +39,6 @@
     "@ndla/types-image-api": "^0.0.5"
   },
   "peerDependencies": {
-    "@emotion/core": "^10.0.9",
     "@emotion/styled": "^10.0.9",
     "react": "^16.0.0 || ^17.0.0"
   },

--- a/packages/ndla-image-search/src/ImageSearch.tsx
+++ b/packages/ndla-image-search/src/ImageSearch.tsx
@@ -8,7 +8,6 @@
 
 import React, { ChangeEvent, Component, ReactNode, KeyboardEvent } from 'react';
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 import { fonts, colors, spacing, mq, breakpoints } from '@ndla/core';
 import Pager from '@ndla/pager';
 import { IImageMetaInformationV2, ISearchResult, IImageMetaSummary, ISearchParams } from '@ndla/types-image-api';
@@ -265,7 +264,7 @@ const ImageSearchWrapper = styled.div`
   }
 `;
 
-const searchIconCss = css`
+const SearchIconButton = styled.button`
   border: 0;
   background: transparent;
   margin: 0;
@@ -378,15 +377,14 @@ class ImageSearch extends Component<Props, State> {
           placeholder={searchPlaceholder}
           autoFocus
           iconRight={
-            <button
-              css={searchIconCss}
+            <SearchIconButton
               aria-label={searchButtonTitle}
               type="button"
               onClick={() => {
                 this.searchImages({ query: queryString, page: 1 });
               }}>
               <SearchIcon />
-            </button>
+            </SearchIconButton>
           }
           value={queryString}
           onChange={(evt: ChangeEvent<HTMLInputElement>) => this.setState({ queryString: evt.target.value })}

--- a/packages/ndla-listview/package.json
+++ b/packages/ndla-listview/package.json
@@ -31,7 +31,6 @@
     "@ndla/ui": "^22.0.0"
   },
   "peerDependencies": {
-    "@emotion/core": "^10.0.9",
     "@emotion/styled": "^10.0.9",
     "react": "^16.4.2 || ^17.0.0",
     "react-bem-helper": "^1.4.1",

--- a/packages/ndla-listview/src/ListView.tsx
+++ b/packages/ndla-listview/src/ListView.tsx
@@ -1,6 +1,5 @@
 import React, { ChangeEvent, ReactNode } from 'react';
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 import BEMHelper from 'react-bem-helper';
 import { spacing, fonts, colors, misc, breakpoints, mq } from '@ndla/core';
 // @ts-ignore
@@ -131,7 +130,7 @@ const ListViewWrapper = styled.div`
   }
 `;
 
-const inputStyle = css`
+const StyledInput = styled.input`
   width: 100%;
   height: 48px;
   line-height: 48px;
@@ -266,8 +265,7 @@ const ListView = ({
             <div className={'search'}>
               <div {...searchFieldClasses()}>
                 <div {...searchFieldClasses('input-wrapper', 'with-icon', 'search-input-wrapper')}>
-                  <input
-                    css={inputStyle}
+                  <StyledInput
                     type="search"
                     placeholder={t(`listview.search.placeholder`)}
                     value={searchValue}

--- a/packages/ndla-modal/package.json
+++ b/packages/ndla-modal/package.json
@@ -30,7 +30,6 @@
     "@reach/dialog": "^0.16.2"
   },
   "peerDependencies": {
-    "@emotion/core": "^10.0.9",
     "@emotion/styled": "^10.0.9",
     "react": "^16.4.2 || ^17.0.0"
   },

--- a/packages/ndla-modal/src/Backdrop.tsx
+++ b/packages/ndla-modal/src/Backdrop.tsx
@@ -8,7 +8,6 @@
 
 import React, { forwardRef } from 'react';
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 
 const StyledBackdrop = styled('div')<Props>`
   position: fixed;
@@ -18,12 +17,7 @@ const StyledBackdrop = styled('div')<Props>`
   right: 0;
   bottom: 0;
   background: rgba(1, 1, 1, 0.3);
-  animation-name: fadeOut;
-  ${(props) =>
-    props.animateIn &&
-    css`
-      animation-name: fadeIn;
-    `}
+  animation-name: ${(p) => (p.animateIn ? 'fadeIn' : 'fadeOut')};
   animation-duration: ${(props) => props.animationDuration};
 `;
 

--- a/packages/ndla-modal/src/StyledDialogOverlay.tsx
+++ b/packages/ndla-modal/src/StyledDialogOverlay.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { DialogOverlay } from '@reach/dialog';
-import { css } from '@emotion/core';
+import styled from '@emotion/styled';
 interface Props {
   className: string;
   animateIn: boolean;
@@ -10,7 +10,11 @@ interface Props {
   children?: ReactNode;
 }
 
-const dialogStyles = css`
+interface StyledDialogOverlayProps {
+  animationName: string;
+  animationDuration: string;
+}
+const InternalStyledDialogOverlay = styled(DialogOverlay)<StyledDialogOverlayProps>`
   position: fixed;
   top: 0;
   left: 0;
@@ -22,18 +26,17 @@ const dialogStyles = css`
   align-items: center;
   justify-content: center;
   min-height: 100vh;
+  animation-name: ${(p) => p.animationName};
+  animation-duration: ${(p) => p.animationDuration};
 `;
 
 export const StyledDialogOverlay = ({ animateIn, animationDuration = '400ms', children, ...props }: Props) => {
   return (
-    <DialogOverlay
-      css={css`
-        animation-name: ${animateIn ? 'fadeIn' : 'fadeOut'};
-        animation-duration: ${animationDuration};
-        ${dialogStyles}
-      `}
+    <InternalStyledDialogOverlay
+      animationName={animateIn ? 'fadeIn' : 'fadeOut'}
+      animationDuration={animationDuration}
       {...props}>
       {children}
-    </DialogOverlay>
+    </InternalStyledDialogOverlay>
   );
 };

--- a/packages/ndla-notion/package.json
+++ b/packages/ndla-notion/package.json
@@ -32,7 +32,6 @@
     "@ndla/safelink": "^2.2.4"
   },
   "peerDependencies": {
-    "@emotion/core": "^10.0.9",
     "@emotion/styled": "^10.0.9",
     "react": "^16.4.2 || ^17.0.0",
     "react-i18next": "^11.11.0"

--- a/packages/ndla-notion/src/Notion.tsx
+++ b/packages/ndla-notion/src/Notion.tsx
@@ -7,9 +7,8 @@
  */
 
 import React, { ReactNode } from 'react';
-import styled from '@emotion/styled';
+import styled, { Interpolation } from '@emotion/styled';
 import { ShortText } from '@ndla/icons/common';
-import { css, InterpolationWithTheme } from '@emotion/core';
 import { createUniversalPortal } from '@ndla/util';
 import { colors } from '@ndla/core';
 import NotionDialog from './NotionDialog';
@@ -23,7 +22,7 @@ const BaselineIcon = styled(ShortText)`
   color: rgba(165, 188, 211, 1);
   transition: transform 0.1s ease;
 `;
-const NotionCSS = css`
+const NotionSpan = styled.span`
   display: inline;
   .link {
     background: none;
@@ -57,7 +56,7 @@ interface Props {
   children?: ReactNode;
   content?: ReactNode;
   headerContent?: ReactNode;
-  customCSS?: InterpolationWithTheme<any>;
+  customCSS?: Interpolation;
   hideBaselineIcon?: boolean;
 }
 const Notion = ({
@@ -71,7 +70,7 @@ const Notion = ({
   headerContent,
   hideBaselineIcon,
 }: Props) => (
-  <span css={NotionCSS} id={id} data-notion>
+  <NotionSpan id={id} data-notion>
     <button type="button" aria-label={ariaLabel} className={'link'} data-notion-link>
       {children}
       {!hideBaselineIcon && <BaselineIcon />}
@@ -83,6 +82,6 @@ const Notion = ({
       </NotionDialog>,
       'body',
     )}
-  </span>
+  </NotionSpan>
 );
 export default Notion;

--- a/packages/ndla-notion/src/NotionDialog.tsx
+++ b/packages/ndla-notion/src/NotionDialog.tsx
@@ -1,7 +1,6 @@
 import React, { HTMLProps, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import { InterpolationWithTheme } from '@emotion/core';
-import styled from '@emotion/styled';
+import styled, { Interpolation } from '@emotion/styled';
 import { fonts, spacing, colors, misc, breakpoints, mq } from '@ndla/core';
 import SafeLink from '@ndla/safelink';
 import NotionHeader from './NotionHeader';
@@ -176,7 +175,7 @@ interface Props {
   subTitle?: string;
   ariaHidden?: boolean;
   children?: ReactNode;
-  customCSS?: InterpolationWithTheme<any>;
+  customCSS?: Interpolation;
   headerContent?: ReactNode;
 }
 

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -29,7 +29,6 @@
     "@ndla/core": "^2.3.3"
   },
   "peerDependencies": {
-    "@emotion/core": "^10.0.9",
     "@emotion/styled": "^10.0.9",
     "react": "^16.8.0 || ^17.0.0"
   },

--- a/packages/switch/src/Switch.tsx
+++ b/packages/switch/src/Switch.tsx
@@ -8,7 +8,6 @@
 
 import React, { ChangeEventHandler, ReactNode, useState } from 'react';
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 import { colors, fonts, spacing, spacingUnit, utils } from '@ndla/core';
 
 const SIZE: number = 22;
@@ -28,15 +27,11 @@ const StyledSwitch = styled.div<StyledSwitchProps>`
   display: inline-flex;
   min-height: ${spacing.normal};
   align-items: center;
-  ${(props) =>
-    props.hasFocus &&
-    css`
-      ${utils.restoreOutline};
-    `};
+  ${(props) => props.hasFocus && utils.restoreOutline};
   label {
     cursor: pointer;
     &:after {
-      content "";
+      content: '';
       display: block;
       width: ${SIZE}px;
       height: ${SIZE}px;
@@ -50,7 +45,7 @@ const StyledSwitch = styled.div<StyledSwitchProps>`
       cursor: pointer;
     }
     &:before {
-      content "";
+      content: '';
       display: block;
       position: absolute;
       right: 0;

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -40,7 +40,6 @@
     "webpack-cli": "^3.3.12"
   },
   "peerDependencies": {
-    "@emotion/core": "^10.0.9",
     "@emotion/styled": "^10.0.9",
     "react": "^16.4.2 || ^17.0.0",
     "react-device-detect": "^2.1.2"


### PR DESCRIPTION
Vi må nok snart over på Emotion 11. Storybook, vår tidligere blokker, har nå gått over til å bruke emotion 11. For at vi skal kunne oppdatere Storybook videre må vi nesten over på Emotion 11.