### PR TITLE
Add aria-labels to modals and translations

### DIFF
--- a/packages/ndla-howto/src/ArticleInModal.tsx
+++ b/packages/ndla-howto/src/ArticleInModal.tsx
@@ -11,17 +11,22 @@ interface ModalContentProps {
   onClose: () => void;
 }
 
+const headingId = 'popupModalHeader';
+
 const ModalContent = ({ pageId, onClose }: ModalContentProps) => {
   const useStory = stories[pageId] || {
     title: `Fant ingen veiledningstekster "${pageId}"`,
     lead: 'Sjekk key-names i @ndla-howto/src/StaticInfoComponents og propType pageId til <ArticleInModal />',
   };
+
   return (
     <Wrapper>
       <div>
         <InModalHeader>
           <InformationOutline style={{ position: 'absolute' }} />
-          <Heading inModal>{useStory.title}</Heading>
+          <Heading id={headingId} inModal>
+            {useStory.title}
+          </Heading>
           <ModalCloseButton onClick={onClose} />
         </InModalHeader>
         {useStory.imageUrl && (
@@ -66,6 +71,7 @@ interface Props {
 
 const ArticleInModal = ({ pageId, tooltip, activateButton }: Props) => (
   <Modal
+    labelledBy={headingId}
     size="medium"
     backgroundColor="white"
     wrapperFunctionForButton={tooltip ? (btn: ReactElement) => <Tooltip tooltip={tooltip}>{btn}</Tooltip> : undefined}

--- a/packages/ndla-modal/src/Modal.tsx
+++ b/packages/ndla-modal/src/Modal.tsx
@@ -28,6 +28,8 @@ interface Props {
   minHeight?: string;
   isOpen?: boolean;
   position?: 'center' | 'top' | 'bottom';
+  label?: string;
+  labelledBy?: string;
 }
 
 const Modal = ({
@@ -46,6 +48,8 @@ const Modal = ({
   isOpen: propsIsOpen,
   position = 'center',
   className = '',
+  label,
+  labelledBy,
 }: Props) => {
   const [isOpen, setIsOpen] = useState(false);
   const [animateIn, setAnimateIn] = useState(!!controllable);
@@ -88,6 +92,8 @@ const Modal = ({
       {modalButton}
       <StyledDialogOverlay isOpen={!!showDialog} animateIn={animateIn} onDismiss={closeModal} className={className}>
         <DialogContent
+          aria-label={label}
+          aria-labelledby={labelledBy}
           css={css`
             animation-duration: ${animationDuration}ms;
             min-height: ${minHeight};

--- a/packages/ndla-ui/src/Article/ArticleByline.tsx
+++ b/packages/ndla-ui/src/Article/ArticleByline.tsx
@@ -102,6 +102,8 @@ const ArticleByline = ({
   const showPrimaryContributors = suppliers.length > 0 || authors.length > 0;
   const showSecondaryContributors = suppliers.length > 0 && authors.length > 0;
 
+  const buttonId = 'popupUseContent';
+
   return (
     <Wrapper>
       <div>
@@ -124,8 +126,9 @@ const ArticleByline = ({
       <ButtonWrapper>
         {licenseBox && (
           <Modal
+            labelledBy={buttonId}
             activateButton={
-              <Button size="small" borderShape="rounded" outline>
+              <Button id={buttonId} size="small" borderShape="rounded" outline>
                 {t('article.useContent')}
               </Button>
             }

--- a/packages/ndla-ui/src/Article/ArticleNotions.tsx
+++ b/packages/ndla-ui/src/Article/ArticleNotions.tsx
@@ -165,14 +165,17 @@ type ArticleNotionsProps = {
 export const ArticleNotions = ({ notions, relatedContent = [], buttonOffsetRight, type }: ArticleNotionsProps) => {
   const { t } = useTranslation();
   const leftOffset = `${buttonOffsetRight - 32}px`;
+  const headingId = 'popupNotionHeading';
+
   return (
     <ArticleNotionsContainer>
       <Modal
+        labelledBy={headingId}
         activateButton={
           <NotionsTrigger role="button" aria-label={t('article.notionsPrompt')} style={{ left: leftOffset }}>
             <NotionFlip />
             <Explanation />
-            <span>{t('article.notionsPrompt')}</span>
+            <span id={headingId}>{t('article.notionsPrompt')}</span>
           </NotionsTrigger>
         }
         size="large"

--- a/packages/ndla-ui/src/CompetenceGoals/CompetenceGoalsDialog.jsx
+++ b/packages/ndla-ui/src/CompetenceGoals/CompetenceGoalsDialog.jsx
@@ -33,8 +33,11 @@ const HeadingWrapper = styled.h2`
 
 export const CompetenceGoalsDialog = ({ children, isOpen, onClose, subjectName, modalProps }) => {
   const { t } = useTranslation();
+  const iconId = 'popupCompetenceGoals';
+
   return (
     <Modal
+      labelledBy={iconId}
       {...modalProps}
       controllable
       isOpen={isOpen}
@@ -48,8 +51,8 @@ export const CompetenceGoalsDialog = ({ children, isOpen, onClose, subjectName, 
           <ModalHeader modifier="menu">
             <HeaderWrapper>
               <HeadingWrapper>
-                <FooterHeaderIcon size="24px" style={{ marginRight: '20px' }} />
-                {'Utforsk læreplankoblinger'} {subjectName && ` \u2022 ${subjectName}`}
+                <FooterHeaderIcon id={iconId} size="24px" style={{ marginRight: '20px' }} />
+                {t('competenceGoals.modalText')} {subjectName && ` \u2022 ${subjectName}`}
               </HeadingWrapper>
               <ModalCloseButton onClick={close} title={t('competenceGoals.competenceGoalClose')} />
             </HeaderWrapper>

--- a/packages/ndla-ui/src/Filter/FilterButtons.tsx
+++ b/packages/ndla-ui/src/Filter/FilterButtons.tsx
@@ -128,6 +128,7 @@ export const FilterButtons = ({ heading, items, onFilterToggle, onRemoveAllFilte
             </StyledButtonElementWrapper>
           ))}
           <Modal
+            label={t('searchPage.searchFilterMessages.resourceTypeFilter.button')}
             size="fullscreen"
             animation="subtle"
             backgroundColor="white"

--- a/packages/ndla-ui/src/Footer/FooterPrivacy.tsx
+++ b/packages/ndla-ui/src/Footer/FooterPrivacy.tsx
@@ -69,7 +69,10 @@ const StyledFooterText = styled.div`
 
 const FooterPrivacy = ({ lang, label }: FooterPrivacyProps) => (
   <StyledFooterText>
-    <Modal activateButton={<StyledPrivacyButton type="button">{label}</StyledPrivacyButton>} size="fullscreen">
+    <Modal
+      label={label}
+      activateButton={<StyledPrivacyButton type="button">{label}</StyledPrivacyButton>}
+      size="fullscreen">
       {(onClose: () => void) => (
         <OneColumn cssModifier="medium">
           <ModalHeader>

--- a/packages/ndla-ui/src/Masthead/MastheadSearchModal.tsx
+++ b/packages/ndla-ui/src/Masthead/MastheadSearchModal.tsx
@@ -117,6 +117,7 @@ const MastheadSearchModal = ({
   t,
 }: Props & WithTranslation) => (
   <Modal
+    label={t('searchPage.searchFieldPlaceholder')}
     backgroundColor="grey"
     animation="slide-down"
     animationDuration={200}

--- a/packages/ndla-ui/src/ResourcesWrapper/ResourcesTopicTitle.tsx
+++ b/packages/ndla-ui/src/ResourcesWrapper/ResourcesTopicTitle.tsx
@@ -66,6 +66,9 @@ const ResourcesTopicTitle = ({
   } else {
     heading = <h1 {...classes('topic-title', 'single')}>{messages.label}</h1>;
   }
+
+  const tooltipId = 'popupDialogTooltip';
+
   return (
     <header {...classes('topic-title-wrapper', { invertedStyle })}>
       <div>
@@ -82,6 +85,7 @@ const ResourcesTopicTitle = ({
             css={invertedStyle ? invertedSwitchCSS : switchCSS}
           />
           <Modal
+            labelledBy={tooltipId}
             narrow
             wrapperFunctionForButton={(activateButton: ReactNode) => (
               <TooltipWrapper>
@@ -89,7 +93,7 @@ const ResourcesTopicTitle = ({
               </TooltipWrapper>
             )}
             activateButton={
-              <TooltipButton aria-label={t('resource.dialogTooltip')}>
+              <TooltipButton id={tooltipId} aria-label={t('resource.dialogTooltip')}>
                 <HelpIcon invertedStyle={invertedStyle} />
               </TooltipButton>
             }>

--- a/packages/ndla-ui/src/SearchTypeResult/PopupFilter.tsx
+++ b/packages/ndla-ui/src/SearchTypeResult/PopupFilter.tsx
@@ -92,9 +92,11 @@ const PopupFilter = ({
 }: PopupFilterProps) => {
   const { t } = useTranslation();
   const [selectedMenu, setSelectedMenu] = useState(MENU_ALL_SUBJECTS);
+  const headingId = 'popupFilterHeading';
 
   return (
     <Modal
+      labelledBy={headingId}
       controllable
       backgroundColor="white"
       animation="subtle"
@@ -107,7 +109,7 @@ const PopupFilter = ({
           <ModalWrapper>
             <ModalContent>
               <ModalHeaderWrapper>
-                <ModalHeading>{t('searchPage.searchFilterMessages.filterLabel')}</ModalHeading>
+                <ModalHeading id={headingId}>{t('searchPage.searchFilterMessages.filterLabel')}</ModalHeading>
                 <ModalCloseButton onClick={() => onClose()} title={t('searchPage.close')} />
               </ModalHeaderWrapper>
               {subjectCategories && programmes && (

--- a/packages/ndla-ui/src/SearchTypeResult/components/ItemContexts.tsx
+++ b/packages/ndla-ui/src/SearchTypeResult/components/ItemContexts.tsx
@@ -98,6 +98,7 @@ const ItemContexts = ({ contexts, id, title }: ItemContextsType) => {
       &nbsp;
       {contexts.length > 1 && (
         <Modal
+          label={t('searchPage.contextModal.ariaLabel')}
           activateButton={
             <ModalButton link>
               {t('searchPage.contextModal.button', {

--- a/packages/ndla-ui/src/Topic/Topic.tsx
+++ b/packages/ndla-ui/src/Topic/Topic.tsx
@@ -268,6 +268,7 @@ const Topic = ({
                   {topic.visualElement ? (
                     <>
                       <Modal
+                        label={t('topicPage.imageModal')}
                         activateButton={
                           <VisualElementButton
                             stripped

--- a/packages/ndla-ui/src/User/AuthModal.tsx
+++ b/packages/ndla-ui/src/User/AuthModal.tsx
@@ -83,7 +83,8 @@ const AuthModal = ({
       position={position}
       isOpen={isOpen}
       onClose={onClose}
-      controllable={!activateButton}>
+      controllable={!activateButton}
+      label={isAuthenticated ? t('user.modal.isAuth') : t('user.modal.isNotAuth')}>
       {(onClose: () => void) => (
         <StyledModalBody>
           <StyledModalHeader>

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -276,6 +276,7 @@ const messages = {
       search: 'Search',
       toFrontpage: 'To frontpage',
       subjectOverview: 'All subjects',
+      modalLabel: 'Choose content',
       backToSubjectFrontpage: 'Back to subject frontpage',
       title: 'Content',
       subjectPage: 'Subject front page',

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -171,6 +171,7 @@ const messages = {
     contextModal: {
       button: '+ {{count}} more contexts',
       heading: 'The resource is used in several contexts',
+      ariaLabel: 'View more contexts',
     },
   },
 
@@ -217,6 +218,7 @@ const messages = {
     articleErrorDescription: 'Sorry, an error occurred while loading the topic description.',
     topic: 'TOPIC',
     topics: 'Topics',
+    imageModal: 'View full size image',
   },
   welcomePage: {
     search: 'Search',
@@ -394,6 +396,7 @@ const messages = {
   competenceGoals: {
     competenceGoal: 'competence-goal',
     title: 'Competence goals and curriculum ',
+    modalText: 'Explore curriculum links',
     closeCompetenceGoals: 'Close competence goals',
     showCompetenceGoals: 'Show competence goals',
     openCompentenceGoalsFilter: 'Filter competence goals',
@@ -962,6 +965,8 @@ const messages = {
       collectedInfo: 'We have collected the following information about you from Feide:',
       general: 'Resources that require logging in with Feide, are tagged with the icon',
       topic: 'Log in with Feide to access this topic.',
+      isAuth: 'User info',
+      isNotAuth: 'Log in with Feide',
     },
     resource: {
       accessDenied: 'We are sorry, but this resource is only available to teachers who are logged in with Feide.',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -171,6 +171,7 @@ const messages = {
     contextModal: {
       button: '+ {{count}} flere steder',
       heading: 'Ressursen er brukt flere steder',
+      ariaLabel: 'Se flere kontekster',
     },
   },
   subjectPage: {
@@ -216,6 +217,7 @@ const messages = {
     articleErrorDescription: 'Beklager, en feil oppstod under lasting av emnebeskrivelsen.',
     topic: 'EMNE',
     topics: 'Emner',
+    imageModal: 'Se bildet i full størrelse',
   },
   welcomePage: {
     search: 'Søk',
@@ -392,6 +394,7 @@ const messages = {
   competenceGoals: {
     competenceGoal: 'kompetansemål',
     title: 'Kompetansemål og læreplan',
+    modalText: 'Utforsk læreplankoblinger',
     closeCompetenceGoals: 'Lukk kompetansemål',
     showCompetenceGoals: 'Vis kompetansemål',
     openCompentenceGoalsFilter: 'Filtrer kompetansemål',
@@ -960,6 +963,8 @@ const messages = {
       collectedInfo: 'Vi har hentet følgende informasjon om deg fra Feide:',
       general: 'Ressursene som krever pålogging med Feide, vises med ikonet',
       topic: 'Logg inn med Feide for å få tilgang til dette emnet.',
+      isAuth: 'Brukerinfo',
+      isNotAuth: 'Logg inn med Feide',
     },
     resource: {
       accessDenied: 'Vi beklager, men denne ressursen er bare for lærere innlogget med Feide.',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -276,6 +276,7 @@ const messages = {
       toFrontpage: 'Til forsiden',
       subjectOverview: 'Alle fag',
       title: 'Innhold',
+      modalLabel: 'Velg innhold',
       subjectPage: 'Fagforside',
       backToSubjectFrontpage: 'Tilbake til fagforsiden',
       openFilter: 'Filter',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -171,6 +171,7 @@ const messages = {
     contextModal: {
       button: '+ {{count}} fleire stader',
       heading: 'Ressursen er brukt fleire stader',
+      ariaLabel: 'Sjå fleire kontekstar',
     },
   },
   subjectPage: {
@@ -216,6 +217,7 @@ const messages = {
     articleErrorDescription: 'Orsak, ein feil oppstod under lasting av emneskildringa.',
     topic: 'EMNE',
     topics: 'Emne',
+    imageModal: 'Sjå biletet i full storleik',
   },
   welcomePage: {
     search: 'Søk',
@@ -393,6 +395,7 @@ const messages = {
   competenceGoals: {
     competenceGoal: 'kompetansemål',
     title: 'Kompetansemål og læreplan',
+    modalText: 'Utforsk læreplankoplingar',
     closeCompetenceGoals: 'Lukk kompetansemål',
     showCompetenceGoals: 'Vis kompetansemål',
     openCompentenceGoalsFilter: 'Filtrer kompetansemål',
@@ -961,6 +964,8 @@ const messages = {
       collectedInfo: 'Vi har henta denne informasjonen om deg frå Feide:',
       general: 'Ressursane som krev pålogging med Feide, vises med ikonet',
       topic: ' Logg inn med Feide for å få tilgang til dette emnet.',
+      isAuth: 'Brukarinfo',
+      isNotAuth: 'Logg inn med Feide',
     },
     resource: {
       accessDenied: 'Vi beklagar, men denne ressursen er berre for lærarar innlogga med Feide.',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -276,6 +276,7 @@ const messages = {
       toFrontpage: 'Til framsida',
       subjectOverview: 'Alle fag',
       title: 'Innhald',
+      modalLabel: 'Vel innhald',
       subjectPage: 'Fagframside',
       backToSubjectFrontpage: 'Tilbake til fagframsida',
       openFilter: 'Filter',

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -171,6 +171,7 @@ const messages = {
     contextModal: {
       button: '+ {{count}} flere steder',
       heading: 'Ressursen er brukt flere steder',
+      ariaLabel: 'Se flere kontekster',
     },
   },
   subjectPage: {
@@ -216,6 +217,7 @@ const messages = {
     articleErrorDescription: 'Beklager, en feil oppstod under lasting av emnebeskrivelsen.',
     topic: 'EMNE',
     topics: 'Emner',
+    imageModal: 'Se bildet i full størrelse',
   },
   welcomePage: {
     search: 'Søk',
@@ -392,6 +394,7 @@ const messages = {
   competenceGoals: {
     competenceGoal: 'kompetansemål',
     title: 'Kompetansemål og læreplan',
+    modalText: 'Utforsk læreplankoblinger',
     closeCompetenceGoals: 'Lukk kompetansemål',
     showCompetenceGoals: 'Vis kompetansemål',
     openCompentenceGoalsFilter: 'Filtrer kompetansemål',
@@ -960,6 +963,8 @@ const messages = {
       collectedInfo: 'Vi har hentet følgende informasjon om deg fra Feide:',
       general: 'Ressursene som krever pålogging med Feide, vises med ikonet',
       topic: 'Logg inn med Feide for å få tilgang til dette emnet.',
+      isAuth: 'Brukerinfo',
+      isNotAuth: 'Logg inn med Feide',
     },
     resource: {
       accessDenied: 'Vi beklager, men denne ressursen er bare for lærere innlogget med Feide.',

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -276,6 +276,7 @@ const messages = {
       toFrontpage: 'Til forsiden',
       subjectOverview: 'Alle fag',
       title: 'Innhold',
+      modalLabel: 'Velg innhold',
       subjectPage: 'Fagforside',
       backToSubjectFrontpage: 'Tilbake til fagforsiden',
       openFilter: 'Filter',

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -171,6 +171,7 @@ const messages = {
     contextModal: {
       button: '+ {{count}} flere steder',
       heading: 'Ressursen er brukt flere steder',
+      ariaLabel: 'Se flere kontekster',
     },
   },
   subjectPage: {
@@ -216,6 +217,7 @@ const messages = {
     articleErrorDescription: 'Beklager, en feil oppstod under lasting av emnebeskrivelsen.',
     topic: 'EMNE',
     topics: 'Emner',
+    imageModal: 'Se bildet i full størrelse',
   },
   welcomePage: {
     search: 'Søk',
@@ -392,6 +394,7 @@ const messages = {
   competenceGoals: {
     competenceGoal: 'kompetansemål',
     title: 'Kompetansemål og læreplan',
+    modalText: 'Utforsk læreplankoblinger',
     closeCompetenceGoals: 'Lukk kompetansemål',
     showCompetenceGoals: 'Vis kompetansemål',
     openCompentenceGoalsFilter: 'Filtrer kompetansemål',
@@ -960,6 +963,8 @@ const messages = {
       collectedInfo: 'Vi har hentet følgende informasjon om deg fra Feide:',
       general: 'Ressursene som krever pålogging med Feide, vises med ikonet',
       topic: 'Logg inn med Feide for å få tilgang til dette emnet.',
+      isAuth: 'Brukerinfo',
+      isNotAuth: 'Logg inn med Feide',
     },
     resource: {
       accessDenied: 'Vi beklager, men denne ressursen er bare for lærere innlogget med Feide.',

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -276,6 +276,7 @@ const messages = {
       toFrontpage: 'Til forsiden',
       subjectOverview: 'Alle fag',
       title: 'Innhold',
+      modalLabel: 'Velg innhold',
       subjectPage: 'Fagforside',
       backToSubjectFrontpage: 'Tilbake til fagforsiden',
       openFilter: 'Filter',


### PR DESCRIPTION
Har lagt til aria-label og aria-labelledby på modaler for tilgjengelighet, samt oversettelser der det var nødvendig.

Har også tilhørende PR i ndla-frontend: https://github.com/NDLANO/ndla-frontend/pull/1044, 
og i editorial-frontend: https://github.com/NDLANO/editorial-frontend/pull/1539