### PR TITLE
MinNdla:  Keyboard navigation support for block resource

### DIFF
--- a/packages/ndla-ui/src/Resource/BlockResource.tsx
+++ b/packages/ndla-ui/src/Resource/BlockResource.tsx
@@ -47,7 +47,7 @@ const BlockDescription = styled.p`
   overflow: hidden;
   text-overflow: ellipsis;
   transition: height 0.2s ease-out;
-  ${() => BlockElementWrapper}:hover & {
+  ${() => BlockElementWrapper}:hover &, ${() => BlockElementWrapper}:focus & {
     // Unfortunate css needed for multi-line text overflow ellipsis.
     height: 3.1em;
     -webkit-line-clamp: 2;


### PR DESCRIPTION
Added :focus on blockresource to show description of blockresource with keyboard navigation.


<img width="419" alt="image" src="https://user-images.githubusercontent.com/25527932/182544751-7e9fad6b-d51d-45a1-9afc-9715917e7740.png">
