### PR TITLE
3187 remove license icons

### DIFF
--- a/packages/designmanual/stories/collated-components.jsx
+++ b/packages/designmanual/stories/collated-components.jsx
@@ -80,13 +80,13 @@ storiesOf('Sammensatte moduler', module)
         <ArticleByline
           authors={[
             {
-              name: 'Cecilie Isaksen Eftedal',
-              shortName: 'Cecilie',
+              name: 'Frida Forfatter',
+              shortName: 'Frida',
               role: 'Forfatter',
             },
             {
-              name: 'Pål Frønsdal',
-              shortName: 'Pål',
+              name: 'Fred Forfatter',
+              shortName: 'Fred',
               role: 'Manusforfatter',
             },
           ]}
@@ -97,8 +97,8 @@ storiesOf('Sammensatte moduler', module)
         <ArticleByline
           authors={[
             {
-              name: 'Cecilie Isaksen Eftedal',
-              shortName: 'Cecilie',
+              name: 'Frida Forfatter',
+              shortName: 'Frida',
             },
           ]}
           published="21.06.2018"
@@ -111,8 +111,8 @@ storiesOf('Sammensatte moduler', module)
           authors={[
             {
               role: 'rolle',
-              name: 'Cecilie Isaksen Eftedal',
-              shortName: 'Cecilie',
+              name: 'Frida Forfatter',
+              shortName: 'Frida',
               urlContributions: '#',
               urlAuthor: '#',
               licenses: 'CC BY-SA',
@@ -134,36 +134,36 @@ storiesOf('Sammensatte moduler', module)
           authors={[
             {
               role: 'Forfatter',
-              name: 'Cecilie Isaksen Eftedal',
-              shortName: 'Cecilie',
+              name: 'Frida Forfatter',
+              shortName: 'Frida',
               urlContributions: '#',
               urlAuthor: '#',
               licenses: 'CC BY-SA',
               title: 'Stilling',
               phone: '+47 123 45 678',
-              email: 'cecilie@ndla.no',
+              email: 'fridaforfatter@ndla.no',
               image: cecilie,
               introduction:
                 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',
             },
             {
               role: 'Illustratør',
-              name: 'Siv Mundal',
-              shortName: 'Siv',
+              name: 'Ida Illustratør',
+              shortName: 'Ida',
               urlContributions: '#',
               urlAuthor: '#',
               licenses: 'CC BY-SA',
               title: 'Stilling',
               phone: '+47 123 45 678',
-              email: 'siv.mundal@keyteq.no',
+              email: 'idaillustrator@ndla.no',
               image: cecilie,
               introduction:
                 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',
             },
             {
               role: 'Manusforfatter',
-              name: 'Pål Frønsdal',
-              shortName: 'Pål',
+              name: 'Fred Forfatter',
+              shortName: 'Fred',
               urlContributions: '#',
               urlAuthor: '#',
               licenses: 'CC BY-SA',

--- a/packages/designmanual/stories/molecules/ArticleBylineExample.jsx
+++ b/packages/designmanual/stories/molecules/ArticleBylineExample.jsx
@@ -21,13 +21,13 @@ export const authorSimple = {
 export const authorRealText = [
   {
     role: 'Forfatter',
-    name: 'Cecilie Isaksen Eftedal',
-    shortName: 'Cecilie',
+    name: 'Frida Forfatter',
+    shortName: 'Frida',
     urlContributions: '#',
     urlAuthor: '#',
     title: 'Stilling',
     phone: '+47 123 45 678',
-    email: 'cecilie@ndla.no',
+    email: 'fridaforfatter@ndla.no',
     image: cecilie,
     introduction:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',
@@ -35,13 +35,13 @@ export const authorRealText = [
   },
   {
     role: 'Illustratør',
-    name: 'Siv Mundal',
-    shortName: 'Siv',
+    name: 'Ida Illustratør',
+    shortName: 'Ida',
     urlContributions: '#',
     urlAuthor: '#',
     title: 'Stilling',
     phone: '+47 123 45 678',
-    email: 'siv.mundal@keyteq.no',
+    email: 'idaillustrator@ndla.no',
     image: cecilie,
     introduction:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',
@@ -49,13 +49,13 @@ export const authorRealText = [
   },
   {
     role: 'Manusforfatter',
-    name: 'Pål Frønsdal',
-    shortName: 'Pål',
+    name: 'Fred Forfatter',
+    shortName: 'Fred',
     urlContributions: '#',
     urlAuthor: '#',
     title: 'Stilling',
     phone: '+47 123 45 678',
-    email: 'paal.fronsdal@ndla.no',
+    email: 'fredforfatter@ndla.no',
     image: cecilie,
     introduction:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',

--- a/packages/designmanual/stories/molecules/ConceptBlockExample.tsx
+++ b/packages/designmanual/stories/molecules/ConceptBlockExample.tsx
@@ -85,9 +85,9 @@ const ConceptBlockExample = () => {
           copyright: {
             license: { license: 'CC-BY-SA-4.0' },
             creators: [
-              { name: 'Cecilie Isaksen Eftedal', type: 'author' },
-              { name: 'Siv Mundal', type: 'author' },
-              { name: 'Pål Frønsdal', type: 'author' },
+              { name: 'Frida Forfatter', type: 'author' },
+              { name: 'Ida Illustratør', type: 'author' },
+              { name: 'Fred Forfatter', type: 'author' },
             ],
             rightsholders: [{ name: 'Riksarkivet', type: 'rightsholder' }],
             processors: [],

--- a/packages/designmanual/stories/molecules/ConceptBlockListExample.tsx
+++ b/packages/designmanual/stories/molecules/ConceptBlockListExample.tsx
@@ -87,9 +87,9 @@ const ConceptBlockListExample = () => {
           copyright: {
             license: { license: 'CC-BY-SA-4.0' },
             creators: [
-              { name: 'Cecilie Isaksen Eftedal', type: 'author' },
-              { name: 'Siv Mundal', type: 'author' },
-              { name: 'Pål Frønsdal', type: 'author' },
+              { name: 'Frida Forfatter', type: 'author' },
+              { name: 'Ida Illustratør', type: 'author' },
+              { name: 'Fred Forfatter', type: 'author' },
             ],
             processors: [],
             rightsholders: [{ name: 'Riksarkivet', type: 'owner' }],

--- a/packages/designmanual/stories/molecules/MessageBoxTabs.jsx
+++ b/packages/designmanual/stories/molecules/MessageBoxTabs.jsx
@@ -117,9 +117,9 @@ const MessageBoxTabs = () => {
                       copyright: {
                         license: { license: 'CC-BY-SA-4.0' },
                         creators: [
-                          { name: 'Cecilie Isaksen Eftedal' },
-                          { name: 'Siv Mundal' },
-                          { name: 'Pål Frønsdal' },
+                          { name: 'Frida Forfatter' },
+                          { name: 'Ida Illustratør' },
+                          { name: 'Fred Forfatter' },
                         ],
                         rightsholders: [{ name: 'Riksarkivet' }],
                       },

--- a/packages/designmanual/stories/pages/ArticleAdditional.jsx
+++ b/packages/designmanual/stories/pages/ArticleAdditional.jsx
@@ -174,7 +174,7 @@ const ArticleAdditional = () => (
         footNotes: '',
         copyright: {
           license: { license: 'CC-BY-SA-4.0' },
-          creators: [{ name: 'Cecilie Isaksen Eftedal' }, { name: 'Siv Mundal' }, { name: 'Pål Frønsdal' }],
+          creators: [{ name: 'Frida Forfatter' }, { name: 'Ida Illustratør' }, { name: 'Fred Forfatter' }],
           rightsholders: [{ name: 'Riksarkivet' }],
         },
       }}

--- a/packages/designmanual/stories/pages/ArticleAssessmentResource.jsx
+++ b/packages/designmanual/stories/pages/ArticleAssessmentResource.jsx
@@ -65,7 +65,7 @@ const ArticleAssessmentResource = () => (
         footNotes: '',
         copyright: {
           license: { license: 'CC-BY-SA-4.0' },
-          creators: [{ name: 'Cecilie Isaksen Eftedal' }, { name: 'Siv Mundal' }, { name: 'Pål Frønsdal' }],
+          creators: [{ name: 'Frida Forfatter' }, { name: 'Ida Illustratør' }, { name: 'Fred Forfatter' }],
           rightsholders: [{ name: 'Riksarkivet' }],
         },
       }}

--- a/packages/designmanual/stories/pages/ArticleExercise.jsx
+++ b/packages/designmanual/stories/pages/ArticleExercise.jsx
@@ -59,7 +59,7 @@ const ArticleExercise = () => (
         footNotes: '',
         copyright: {
           license: { license: 'CC-BY-SA-4.0' },
-          creators: [{ name: 'Cecilie Isaksen Eftedal' }, { name: 'Siv Mundal' }, { name: 'Pål Frønsdal' }],
+          creators: [{ name: 'Frida Forfatter' }, { name: 'Ida Illustratør' }, { name: 'Fred Forfatter' }],
           rightsholders: [{ name: 'Riksarkivet' }],
         },
       }}

--- a/packages/designmanual/stories/pages/ArticleExternalLearningResource.jsx
+++ b/packages/designmanual/stories/pages/ArticleExternalLearningResource.jsx
@@ -60,7 +60,7 @@ const ArticleExternalLearningResource = () => (
         footNotes: '',
         copyright: {
           license: { license: 'CC-BY-SA-4.0' },
-          creators: [{ name: 'Cecilie Isaksen Eftedal' }, { name: 'Siv Mundal' }, { name: 'Pål Frønsdal' }],
+          creators: [{ name: 'Frida Forfatter' }, { name: 'Ida Illustratør' }, { name: 'Fred Forfatter' }],
           rightsholders: [{ name: 'Riksarkivet' }],
         },
       }}

--- a/packages/designmanual/stories/pages/ArticleLearningmaterial.jsx
+++ b/packages/designmanual/stories/pages/ArticleLearningmaterial.jsx
@@ -74,7 +74,7 @@ const ArticleLearningMaterial = ({ accessRestricted }) => {
           footNotes: '',
           copyright: {
             license: { license: 'CC-BY-SA-4.0' },
-            creators: [{ name: 'Cecilie Isaksen Eftedal' }, { name: 'Siv Mundal' }, { name: 'Pål Frønsdal' }],
+            creators: [{ name: 'Frida Forfatter' }, { name: 'Ida Illustratør' }, { name: 'Fred Forfatter' }],
             rightsholders: [{ name: 'Riksarkivet' }],
           },
         }}

--- a/packages/designmanual/stories/pages/ArticleSourceMaterial.jsx
+++ b/packages/designmanual/stories/pages/ArticleSourceMaterial.jsx
@@ -75,7 +75,7 @@ const ArticleSourceMaterial = ({ addToFavoritesLabel, removeFromFavoritesLabel, 
         footNotes: '',
         copyright: {
           license: { license: 'CC-BY-SA-4.0' },
-          creators: [{ name: 'Cecilie Isaksen Eftedal' }, { name: 'Siv Mundal' }, { name: 'Pål Frønsdal' }],
+          creators: [{ name: 'Frida Forfatter' }, { name: 'Ida Illustratør' }, { name: 'Fred Forfatter' }],
           rightsholders: [{ name: 'Riksarkivet' }],
         },
       }}

--- a/packages/designmanual/stories/pages/ResourceBoxExample.jsx
+++ b/packages/designmanual/stories/pages/ResourceBoxExample.jsx
@@ -78,7 +78,7 @@ const ReferenceBoxExample = () => {
             footNotes: '',
             copyright: {
               license: { license: 'CC-BY-SA-4.0' },
-              creators: [{ name: 'Cecilie Isaksen Eftedal' }, { name: 'Siv Mundal' }, { name: 'Pål Frønsdal' }],
+              creators: [{ name: 'Frida Forfatter' }, { name: 'Ida Illustratør' }, { name: 'Fred Forfatter' }],
               rightsholders: [{ name: 'Riksarkivet' }],
             },
           }}

--- a/packages/designmanual/stories/pages/ResourceBoxExample.jsx
+++ b/packages/designmanual/stories/pages/ResourceBoxExample.jsx
@@ -8,7 +8,6 @@
 
 import React from 'react';
 import styled from '@emotion/styled';
-import { BY, NC, ND } from '@ndla/licenses';
 import { Article, OneColumn, TasksAndActivitiesBadge, constants, ResourceBox, Figure } from '@ndla/ui';
 import LicenseBox from '../article/LicenseBox';
 import { CompetenceGoalListExample } from '../organisms/CompetenceGoalsExample';
@@ -45,7 +44,6 @@ const ReferenceBoxExample = () => {
                 </p>
                 <Figure type={'full'}>
                   <ResourceBox
-                    licenseRights={[BY, NC, ND]}
                     title="Mediehistorie"
                     caption="I dette interaktive oppslagsverket kan du lære om medieutviklingen, kan du lære om medieutviklingen, kan du lære om medieutviklingen. kan du lære om medieutviklingen. "
                     image={image}

--- a/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
+++ b/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
@@ -10,7 +10,6 @@ import React from 'react';
 import { breakpoints, fonts, mq, colors, spacing } from '@ndla/core';
 import { useTranslation } from 'react-i18next';
 import { Launch } from '@ndla/icons/common';
-import { LicenseByline } from '@ndla/licenses';
 import { SafeLinkButton } from '@ndla/safelink';
 import styled from '@emotion/styled';
 import Image from '../Image';
@@ -81,12 +80,6 @@ const StyledImage = styled(Image)`
   }
 `;
 
-const LincenseWrapper = styled.div`
-  position: absolute;
-  top: 9px;
-  right: 0;
-`;
-
 interface ImageMeta {
   src: string;
   alt: string;
@@ -96,25 +89,13 @@ interface Props {
   image: ImageMeta;
   title: string;
   caption: string;
-  licenseRights: string[];
-  authors?: string[];
-  locale?: string;
   url: string;
 }
 
-export const ResourceBox = ({ image, title, caption, licenseRights, locale, authors, url }: Props) => {
+export const ResourceBox = ({ image, title, caption, url }: Props) => {
   const { t } = useTranslation();
   return (
     <ResourceBoxContainer>
-      <LincenseWrapper>
-        <LicenseByline licenseRights={licenseRights} locale={locale} marginRight color={colors.brand.tertiary}>
-          {authors && authors.length > 0 && (
-            <div className="c-figure__byline-author-buttons">
-              <span className="c-figure__byline-authors">{authors.join(' ')}</span>
-            </div>
-          )}
-        </LicenseByline>
-      </LincenseWrapper>
       <StyledImage src={image.src} alt={image.alt} />
       <ContentWrapper>
         <Title>{title}</Title>


### PR DESCRIPTION
Fixes NDLANO/Issues#3187

Fjerner lisensikoner fra ressurs fra lenke.
Bytter ut navn på tidligere (og eksisterende) medarbeidere med oppdikta navn.