### PR TITLE
Add safe area insets to DialogContent to ensure content is clickable on mobile

### DIFF
--- a/packages/ndla-modal/src/Modal.tsx
+++ b/packages/ndla-modal/src/Modal.tsx
@@ -336,6 +336,10 @@ const narrowStyle = css`
 `;
 
 const dialogStyles = css`
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-top: env(safe-area-inset-top);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
   ${modalAnimations}
   ${animationContainer}
 `;


### PR DESCRIPTION
https://trello.com/c/gJIPVaCm/124-lagre-avbryt-i-dialogvinduet-forsvinner-bort-fra-vinduet-p%C3%A5-mobil