### PR TITLE
Add inline-flex to StyledMenuButton to avoid ActionItem being higher than other crumbs

### DIFF
--- a/packages/button/src/MenuButton.tsx
+++ b/packages/button/src/MenuButton.tsx
@@ -23,7 +23,7 @@ interface StyledButtonProps {
 const shouldForwardProp = (name: string) => name !== 'svgSize';
 
 const StyledMenuButton = styled(MenuButtonReach, { shouldForwardProp })<StyledButtonProps>`
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: ${spacing.small};
   padding: 0;


### PR DESCRIPTION
https://trello.com/c/0w59epAT/154-litt-rart-hopp-i-br%C3%B8dsmulestien