### PR TITLE
#3192: Make Switch `flex` instead of `inline-flex`

### DIFF
--- a/packages/switch/src/Switch.tsx
+++ b/packages/switch/src/Switch.tsx
@@ -25,7 +25,7 @@ const StyledSwitch = styled.div<StyledSwitchProps>`
   font-family: ${fonts.sans};
   position: relative;
   cursor: pointer;
-  display: inline-flex;
+  display: flex;
   min-height: ${spacing.normal};
   align-items: center;
   ${(props) =>


### PR DESCRIPTION
inline-flex gjør denne vanskelig å plassere riktig i noen tilfeller.
Jeg klarte ikke finne noen steder der dette utgjorde noen forskjell utenom i revisjsons editoren i editorial-frontend som det kommer egen pr på :^)