### PR TITLE
Add save resource translation

### DIFF
--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -1081,6 +1081,7 @@ const messages = {
       titleUpdated: 'Title updated',
       tagsUpdated: 'Tags updated',
       show: 'Show',
+      save: 'Save resource',
     },
   },
   snackbar: {

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -1079,6 +1079,7 @@ const messages = {
       titleUpdated: 'Tittel oppdatert',
       tagsUpdated: 'Tags oppdatert',
       show: 'Vis',
+      save: 'Lagre ressurs',
     },
   },
   snackbar: {

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -1079,6 +1079,7 @@ const messages = {
       titleUpdated: 'Tittel oppdatert',
       tagsUpdated: 'Tags oppdatert',
       show: 'Vis',
+      save: 'Lagre ressurs',
     },
   },
   snackbar: {

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -1079,6 +1079,7 @@ const messages = {
       titleUpdated: 'Tittel oppdatert',
       tagsUpdated: 'Tags oppdatert',
       show: 'Vis',
+      save: 'Lagre ressurs',
     },
   },
   snackbar: {

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -1079,6 +1079,7 @@ const messages = {
       titleUpdated: 'Tittel oppdatert',
       tagsUpdated: 'Tags oppdatert',
       show: 'Vis',
+      save: 'Lagre ressurs',
     },
   },
   snackbar: {


### PR DESCRIPTION
Relatert til https://trello.com/c/AoHxZTUr/162-endre-lagre-til-lagre-ressurs-n%C3%A5r-en-ressurs-legges-til-i-en-mappe-og-f%C3%A5r-tags

Legger til ny oversettelse for "Lagre ressurs"