### PR TITLE
Ensure mobile content is accessible on mobile, especially iOS

### DIFF
--- a/packages/designmanual/stories/molecules/ModalExample.jsx
+++ b/packages/designmanual/stories/molecules/ModalExample.jsx
@@ -122,7 +122,7 @@ class ModalExample extends Component {
             name: 'animation',
             type: 'String',
             default: 'zoom-in',
-            description: `PropTypes.oneOf(['slide-up', 'slide-down', 'zoom-in', 'subtle'])`,
+            description: `PropTypes.oneOf(['slide-down', 'zoom-in', 'subtle'])`,
           },
           {
             name: 'backgroundColor',
@@ -173,7 +173,7 @@ class ModalExample extends Component {
                 <hr />
                 <p>Lukk denne modal eller åpne en ny modal fra denne modalen</p>
                 <div className="u-horisontal-list">
-                  <Modal narrow size="fullscreen" animation="slide-up" activateButton={<Button>Åpne ny modal</Button>}>
+                  <Modal narrow size="fullscreen" activateButton={<Button>Åpne ny modal</Button>}>
                     {(onClose2ndModal) => (
                       <Fragment>
                         <ModalHeader>
@@ -232,7 +232,6 @@ class ModalExample extends Component {
           options={[
             { title: 'Zoom in (default)', value: 'zoom-in' },
             { title: 'Subtle', value: 'subtle' },
-            { title: 'Slide up', value: 'slide-up' },
             { title: 'Slide down', value: 'slide-down' },
           ]}
           values={[this.state.animation]}

--- a/packages/ndla-modal/src/Modal.tsx
+++ b/packages/ndla-modal/src/Modal.tsx
@@ -16,7 +16,7 @@ interface Props {
   children: (closeModal: () => void) => ReactNode;
   onClick?: () => void;
   onClose?: () => void;
-  animation?: 'slide-up' | 'slide-down' | 'zoom-in' | 'subtle';
+  animation?: 'slide-down' | 'zoom-in' | 'subtle';
   size?: 'regular' | 'medium' | 'large' | 'fullscreen' | 'full-width' | 'custom';
   backgroundColor?: 'white' | 'grey' | 'grey-dark' | 'blue' | 'light-gradient';
   animationDuration?: number;
@@ -75,16 +75,13 @@ const Modal = ({
     }
   };
 
-  let clonedComponent: ReactElement | undefined;
-  if (activateButton) {
-    clonedComponent = cloneElement(activateButton, {
-      onClick: (e: MouseEvent<HTMLButtonElement>) => {
-        openModal();
-        onClickEvent?.();
-        e.preventDefault();
-      },
-    });
-  }
+  const onActivateClick = (e: MouseEvent<HTMLButtonElement>) => {
+    openModal();
+    onClickEvent?.();
+    e.preventDefault();
+  };
+
+  const clonedComponent = activateButton ? cloneElement(activateButton, { onClick: onActivateClick }) : undefined;
 
   const modalButton = clonedComponent && (wrapperFunctionForButton?.(clonedComponent) ?? clonedComponent);
   return (
@@ -142,23 +139,6 @@ const modalAnimations = `
     }
   }
 
-  @keyframes modal-slideup {
-    0% {
-      transform: translate3d(0, 100vh, 0);
-    }
-    100% {
-      transform: translate3d(0, 0, 0);
-    }
-  }
-  @keyframes modal-slideup-exit {
-    0% {
-      transform: translate3d(0, 0, 0);
-    }
-    100% {
-      transform: translate3d(0, 100vh, 0);
-    }
-  }
-
   @keyframes modal-slidedown {
     0% {
       opacity: 0;
@@ -207,18 +187,12 @@ const animationContainer = css`
   z-index: 9001;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  max-height: 100vh;
+  max-height: 100%;
   // 1. Animations
   &.zoom-in {
     animation-name: modal-zoomIn-exit;
     &.animateIn {
       animation-name: modal-zoomIn;
-    }
-  }
-  &.slide-up {
-    animation-name: modal-slideup-exit;
-    &.animateIn {
-      animation-name: modal-slideup;
     }
   }
   &.slide-down {
@@ -235,48 +209,48 @@ const animationContainer = css`
   }
   // 2. Modal size modifiers
   &.fullscreen {
-    width: 100vw;
-    height: 100vh;
+    width: 100%;
+    height: 100%;
   }
   &.full-width {
-    width: 100vw;
+    width: 100%;
     height: auto;
     box-shadow: 0 0 30px rgba(0, 0, 0, 0.2);
   }
   &.large {
     max-width: 60.625em;
     width: 60.625em;
-    max-height: 85vh;
+    max-height: 85%;
     box-shadow: 0 0 30px rgba(0, 0, 0, 0.2);
     ${mq.range({ until: '60.625em' })} {
       box-shadow: none;
-      width: 100vw;
-      height: 100vw;
-      max-height: 100vh;
-      min-height: 100vh;
+      width: 100%;
+      height: 100%;
+      max-height: 100%;
+      min-height: 100%;
     }
   }
   &.medium {
     max-width: 49.375em;
     width: 49.375em;
-    max-height: 85vh;
+    max-height: 85%;
     box-shadow: 0 0 30px rgba(0, 0, 0, 0.2);
     ${mq.range({ until: '49.375em' })} {
       box-shadow: none;
-      height: 100vh;
-      width: 100vw;
-      min-height: 100vh;
+      height: 100%;
+      width: 100%;
+      min-height: 100%;
     }
   }
   &.regular {
     ${mq.range({ until: breakpoints.tablet })} {
-      height: 100vh;
-      width: 100vw;
+      height: 100%;
+      width: 100%;
     }
     ${mq.range({ from: breakpoints.tablet })} {
       box-shadow: 0 0 30px rgba(0, 0, 0, 0.2);
       width: 90%;
-      max-height: 85vh;
+      max-height: 85%;
       max-width: 38.3125em;
       min-width: 38.3125em;
     }

--- a/packages/ndla-modal/src/StyledDialogOverlay.tsx
+++ b/packages/ndla-modal/src/StyledDialogOverlay.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { DialogOverlay } from '@reach/dialog';
-import { css } from '@emotion/core';
+import styled from '@emotion/styled';
 interface Props {
   className: string;
   animateIn: boolean;
@@ -10,7 +10,12 @@ interface Props {
   children?: ReactNode;
 }
 
-const dialogStyles = css`
+interface StyledDialogOverlayComponentProps {
+  animateIn?: boolean;
+  animationDuration?: string;
+}
+
+const StyledDialogOverlayComponent = styled(DialogOverlay)<StyledDialogOverlayComponentProps>`
   position: fixed;
   top: 0;
   left: 0;
@@ -21,19 +26,15 @@ const dialogStyles = css`
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 100vh;
+  height: 100%;
+  animation-name: ${(p) => (p.animateIn ? 'fadeIn' : 'fadeOut')};
+  animation-duration: ${(p) => p.animationDuration};
 `;
 
 export const StyledDialogOverlay = ({ animateIn, animationDuration = '400ms', children, ...props }: Props) => {
   return (
-    <DialogOverlay
-      css={css`
-        animation-name: ${animateIn ? 'fadeIn' : 'fadeOut'};
-        animation-duration: ${animationDuration};
-        ${dialogStyles}
-      `}
-      {...props}>
+    <StyledDialogOverlayComponent animateIn={animateIn} animationDuration={animationDuration} {...props}>
       {children}
-    </DialogOverlay>
+    </StyledDialogOverlayComponent>
   );
 };

--- a/packages/ndla-ui/src/CompetenceGoals/CompetenceGoalsDialog.jsx
+++ b/packages/ndla-ui/src/CompetenceGoals/CompetenceGoalsDialog.jsx
@@ -43,7 +43,6 @@ export const CompetenceGoalsDialog = ({ children, isOpen, onClose, subjectName, 
       isOpen={isOpen}
       onClose={onClose}
       size="fullscreen"
-      animation="slide-up"
       backgroundColor="light-gradient"
       narrow>
       {(close) => (

--- a/packages/ndla-ui/src/Filter/FilterListPhone.jsx
+++ b/packages/ndla-ui/src/Filter/FilterListPhone.jsx
@@ -121,7 +121,6 @@ class FilterListPhone extends Component {
           )}
           <Modal
             size="fullscreen"
-            animation="slide-up"
             backgroundColor="grey"
             activateButton={
               <Button outline {...classes('modal-button')}>

--- a/packages/ndla-ui/src/LearningPaths/LearningPathMenuModalWrapper.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathMenuModalWrapper.tsx
@@ -40,7 +40,6 @@ const ModalWrapperComponent = ({ innerWidth, children }: ModalWrapperProps) => {
     return (
       <Modal
         backgroundColor="grey"
-        animation="slide-up"
         animationDuration={200}
         size="fullscreen"
         activateButton={


### PR DESCRIPTION
https://trello.com/c/B4FRVrAQ/123-lagring-av-ny-mappe-i-dialogvindu-p%C3%A5-mobil-er-litt-lite-intuitivt
https://trello.com/c/KzSByUCq/138-mobil-n%C3%A5r-jeg-skal-hjertemerke-en-ressurs-og-legge-den-i-mappe-er-det-kronglete-%C3%A5-lage-ny-mappe-det-kommer-automatisk-opp-en-dia

Erstatter slideUp-animasjonen med default zoomIn, da den skapte masse problemer som ikke var så enkle å løse. De ser ganske like ut, men både jeg og Henrik mener at zoomIn er mindre desorienterende enn slideUp. Kanskje en forbedring?

Det ser ikke ut som at dette påvirker desktop i det hele tatt, som er et drømmescenario. Hadde dog vært fint om noen kunne testet dette med en Android-emulator.