### PR TITLE
Add support for action buttons in concept image modal

### DIFF
--- a/packages/designmanual/stories/molecules/NotionBlock.tsx
+++ b/packages/designmanual/stories/molecules/NotionBlock.tsx
@@ -14,6 +14,7 @@ import { initArticleScripts } from '@ndla/article-scripts';
 import { uuid } from '@ndla/util';
 //@ts-ignore
 import { useRunOnlyOnce } from '../article/useRunOnlyOnce';
+import Button from '../../../button/src';
 
 const conceptData = {
   image: {
@@ -39,6 +40,12 @@ const conceptData = {
         rightsholders: [{ name: 'NTB Scanpix', type: 'Supplier' }],
         origin: 'http://www.scanpix.no',
       },
+      licenseButtons: (
+        <>
+          <Button outline>Kildehenvisning</Button>
+          <Button outline>Last ned bildet</Button>
+        </>
+      ),
       resource: 'image',
       image: {
         src: 'https://api.staging.ndla.no/image-api/raw/20081209-095942-ag_0.jpg',

--- a/packages/ndla-ui/src/Notion/FigureNotion.tsx
+++ b/packages/ndla-ui/src/Notion/FigureNotion.tsx
@@ -30,6 +30,7 @@ interface Props {
   hideFigCaption?: boolean;
   hideIconsAndAuthors?: boolean;
   figureType?: FigureType;
+  licenseButtons?: ReactNode;
 }
 
 const FigureNotion = ({
@@ -44,6 +45,7 @@ const FigureNotion = ({
   hideFigCaption,
   hideIconsAndAuthors,
   figureType,
+  licenseButtons,
 }: Props) => {
   const { t, i18n } = useTranslation();
   const license = getLicenseByAbbreviation(licenseString, i18n.language);
@@ -84,8 +86,9 @@ const FigureNotion = ({
                   source: t('source'),
                   learnAboutLicenses: t('license.learnMore'),
                   title: t('title'),
-                }}
-              />
+                }}>
+                {licenseButtons}
+              </FigureLicenseDialog>
             </FigureCaption>
           ) : (
             <BottomBorder />

--- a/packages/ndla-ui/src/Notion/NotionVisualElement.tsx
+++ b/packages/ndla-ui/src/Notion/NotionVisualElement.tsx
@@ -30,6 +30,7 @@ export type NotionVisualElementType = {
     src: string;
     alt?: string;
   };
+  licenseButtons?: ReactNode;
 };
 
 interface Props {
@@ -64,6 +65,7 @@ const NotionVisualElement = ({ visualElement, id, figureId }: Props) => {
       title={visualElement.title ?? ''}
       copyright={visualElement.copyright}
       licenseString={visualElement.copyright?.license?.license ?? ''}
+      licenseButtons={visualElement.licenseButtons}
       type={type}>
       {visualElement.image?.src ? (
         <img src={visualElement.image?.src} alt={visualElement.image.alt} />


### PR DESCRIPTION
Relatert til NDLANO/Issues#3151

Legger til støtte for å sende inn buttons til bildelisens-modal i forklaringsblokk. Har i eksempelkoden lagt inn to dummyknapper. Se øverste eksempel på /?path=/story/sammensatte-moduler--blokkvisning-begrepsforklaring
<details>
    <summary>Bilde</summary>
<img width="676" alt="image" src="https://user-images.githubusercontent.com/17144211/186081231-eb8644ec-8bf0-4629-946e-8e479f8989dc.png"></details>

Kommer PR på article-converter etterpå