### PR TITLE
Hide all icons from screen reader

### DIFF
--- a/packages/ndla-icons/src/Icon.tsx
+++ b/packages/ndla-icons/src/Icon.tsx
@@ -14,6 +14,7 @@ export interface Props {
   role?: string;
   onClick?: () => void;
   style?: {}; // eslint-disable-line
+  ariaHidden?: boolean;
 }
 const IconBase = ({
   children,
@@ -25,6 +26,7 @@ const IconBase = ({
   description,
   width,
   height,
+  ariaHidden = true,
   className,
   ...props
 }: Props) => {
@@ -34,7 +36,7 @@ const IconBase = ({
   return (
     <svg
       fill="currentColor"
-      aria-hidden="true"
+      aria-hidden={ariaHidden}
       preserveAspectRatio="xMidYMid meet"
       height={height || computedSize}
       width={width || computedSize}

--- a/packages/ndla-icons/src/Icon.tsx
+++ b/packages/ndla-icons/src/Icon.tsx
@@ -34,6 +34,7 @@ const IconBase = ({
   return (
     <svg
       fill="currentColor"
+      aria-hidden="true"
       preserveAspectRatio="xMidYMid meet"
       height={height || computedSize}
       width={width || computedSize}


### PR DESCRIPTION
Nå leser skjermleseren opp "image" hver gang den kommer over et ikon, uten å faktisk forklare hva det er. Jeg tror det er god praksis å ignorere ikoner fullstendig by default. 