### PR TITLE
Hide frontpage illustration from screen reader

### DIFF
--- a/packages/ndla-ui/src/Frontpage/FrontpageHeader.tsx
+++ b/packages/ndla-ui/src/Frontpage/FrontpageHeader.tsx
@@ -61,7 +61,7 @@ const FrontpageHeader = ({ locale, showHeader = true, children, t }: FrontPageHe
         <SvgLogo locale={locale} />
       </StyledLogo>
       {showHeader && (
-        <HeaderIllustrationWrapper>
+        <HeaderIllustrationWrapper aria-hidden="true">
           <FrontpageHeaderIllustration />
         </HeaderIllustrationWrapper>
       )}


### PR DESCRIPTION
Unødvendig informasjon, den er dekorativ og bør skjules.