### PR TITLE
Hide beta cursor from screen readers

### DIFF
--- a/packages/ndla-ui/src/Frontpage/FrontpageProgramMenu.tsx
+++ b/packages/ndla-ui/src/Frontpage/FrontpageProgramMenu.tsx
@@ -119,7 +119,7 @@ const FrontpageProgramMenu = ({ programItems, subjectCategories, showBetaCursor 
           <StyledMenuItem>{t('frontpageMenu.allsubjects')}</StyledMenuItem>
         </Button>
         {showBetaCursor && (
-          <CursorPlaceholder>
+          <CursorPlaceholder aria-hidden="true">
             <CursorWrapper>
               <LeftCursor hide={showSubjects} />
               <CursorTextWrapper>


### PR DESCRIPTION
Den gir ekstra-informasjon om hva som finnes bak "alle fag", men det er forvirrende at den leses opp etterpå. Da tenker jeg det er like greit å skjule den.