### PR TITLE
More correct heading levels on topic pages

### DIFF
--- a/packages/ndla-ui/src/Navigation/NavigationBox.tsx
+++ b/packages/ndla-ui/src/Navigation/NavigationBox.tsx
@@ -180,8 +180,11 @@ export type ItemProps = {
   isAdditionalResource?: boolean;
   isRestrictedResource?: boolean;
 };
+
+type HeadingType = 'h1' | 'h2' | 'h3';
 type Props = {
   heading?: string;
+  headingType?: HeadingType;
   colorMode?: 'dark' | 'light' | 'greyLightest' | 'greyLighter';
   isButtonElements?: boolean;
   items: ItemProps[];
@@ -204,13 +207,15 @@ export const NavigationBox = ({
   listDirection = 'horizontal',
   invertedStyle,
   onToggleAdditionalResources = () => {},
+  headingType = 'h2',
 }: Props) => {
+  const Heading = StyledHeading.withComponent(headingType);
   const { t } = useTranslation();
   const ListElementType = isButtonElements ? Button : SafeLinkButton;
   return (
     <StyledWrapper>
       <StyledHeadingWrapper>
-        {heading && <StyledHeading invertedStyle={invertedStyle}>{heading}</StyledHeading>}
+        {heading && <Heading invertedStyle={invertedStyle}>{heading}</Heading>}
         {hasAdditionalResources && (
           <Switch
             id={uuid()}

--- a/packages/ndla-ui/src/Topic/Topic.tsx
+++ b/packages/ndla-ui/src/Topic/Topic.tsx
@@ -118,7 +118,7 @@ const TopicHeaderOverlay = styled.div`
   }
 `;
 
-const TopicHeading = styled.h1<InvertItProps>`
+const TopicHeading = styled.h2<InvertItProps>`
   margin: ${spacing.medium} 0 0;
   font-weight: ${fonts.weight.bold};
   display: flex;
@@ -360,6 +360,7 @@ const Topic = ({
               {subTopics && subTopics.length !== 0 && (
                 <StyledNavigationBoxWrapper>
                   <NavigationBox
+                    headingType="h3"
                     colorMode="light"
                     heading={t('navigation.topics')}
                     items={subTopics}


### PR DESCRIPTION
Relatert til, men fikser ikke, https://github.com/NDLANO/Issues/issues/3225

Jeg er usikker på om dette er "riktig" med tanke på emner og underemner. Skal et underemne være en h3, fordi emnet det tilhører er en h2, eller skal begge være h2? Dette er uansett mer riktig enn nåværende løsning, der alt er h1.