### PR TITLE
Update IconButtonDualState usage to use correct ButtonV2 colors

### DIFF
--- a/packages/designmanual/stories/molecules/MyNdlaAddToFavoritesExample.tsx
+++ b/packages/designmanual/stories/molecules/MyNdlaAddToFavoritesExample.tsx
@@ -226,7 +226,7 @@ const MyNdlaAddToFavoritesExample = ({ isLoggedIn = true, resource = true }: Fav
           active={isFavorite}
           size="small"
           variant="ghost"
-          shape="pill"
+          colorTheme="light"
           onClick={() => setIsOpen(!isOpen)}
         />
         {isOpen && (
@@ -251,7 +251,7 @@ const MyNdlaAddToFavoritesExample = ({ isLoggedIn = true, resource = true }: Fav
           active={isFavorite}
           size="small"
           variant="ghost"
-          shape="pill"
+          colorTheme="light"
           onClick={() => setIsOpen(!isOpen)}
         />
         {isOpen && (

--- a/packages/ndla-ui/src/Article/ArticleFavoritesButton.tsx
+++ b/packages/ndla-ui/src/Article/ArticleFavoritesButton.tsx
@@ -31,8 +31,8 @@ export const ArticleFavoritesButton = ({ isFavorite, onToggleAddToFavorites, art
         inactiveIcon={<HeartOutline />}
         active={isFavorite}
         size="small"
+        colorTheme="light"
         variant="ghost"
-        shape="pill"
         onClick={() => onToggleAddToFavorites(articleId, !isFavorite)}
       />
     </Tooltip>


### PR DESCRIPTION
Fikser en feil der hjerteknapp ikke lenger har riktig farger etter bruk av ButtonV2. Feilen vises på https://designmanual.ndla.no/?path=/story/min-ndla--add-to-favorites

Se /?path=/story/min-ndla--add-to-favorites for riktig visning i PR-instans