### PR TITLE
Make it possible to pass skipToContentId to LearningPathInformation

### DIFF
--- a/packages/ndla-ui/src/LearningPaths/LearningPathInformation.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathInformation.tsx
@@ -66,18 +66,19 @@ interface Props {
   description?: string;
   title: string;
   invertedStyle?: boolean;
+  id?: string;
   license?: {
     license: string;
   };
 }
 
-export const LearningPathInformation = ({ description, title, license, invertedStyle }: Props) => {
+export const LearningPathInformation = ({ description, title, license, invertedStyle, id }: Props) => {
   const { rights } = getLicenseByAbbreviation(license?.license || '', 'nb');
   return (
     <section className="o-wrapper">
       <StyledWrapper invertedStyle={invertedStyle} className="c-article">
         <LicenseWrapper>
-          <StyledHeader>{title}</StyledHeader>
+          <StyledHeader id={id}>{title}</StyledHeader>
           <LicenseByline licenseRights={rights} color={colors.brand.tertiary} />
         </LicenseWrapper>
         {description && <div dangerouslySetInnerHTML={{ __html: description }} />}


### PR DESCRIPTION
Relatert til https://github.com/NDLANO/Issues/issues/3253
Artikler / faktiske steg går greit, men vi tar ikke hensyn til introduksjoner og ting som ikke har artikkel.