### PR TITLE
Add aria-assertive to copy buttons to announce the copy action

### DIFF
--- a/packages/ndla-ui/src/Article/ArticleByline.tsx
+++ b/packages/ndla-ui/src/Article/ArticleByline.tsx
@@ -150,6 +150,7 @@ const ArticleByline = ({
             size="small"
             borderShape="rounded"
             outline
+            aria-live="assertive"
             data-copy-string={copyPageUrlLink}
             copyNode={t('article.copyPageLinkCopied')}>
             {t('article.copyPageLink')}

--- a/packages/ndla-ui/src/Article/ArticleSideBar.tsx
+++ b/packages/ndla-ui/src/Article/ArticleSideBar.tsx
@@ -89,6 +89,7 @@ const ArticleSideBar = ({
             size="small"
             width="full"
             outline
+            aria-live="assertive"
             copyNode={t('article.copyPageLinkCopied')}
             data-copy-string={copyPageUrlLink}>
             {t('article.copyPageLink')}


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3233

Kan sjekkes med skjermleser. Når man klikker på en "kopier"-knapp annonserer skjermleseren at lenken er kopiert.