### PR TITLE
BreadCrumbWCAG

### DIFF
--- a/packages/ndla-ui/src/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/ndla-ui/src/Breadcrumb/BreadcrumbItem.tsx
@@ -70,10 +70,7 @@ const StyledChevron = styled(ChevronRight)`
 const StyledSafeLink = styled(SafeLink)`
   color: inherit;
 `;
-const StyledSafeLinkLast = styled(SafeLink)`
-  color: inherit;
-  box-shadow: none;
-`;
+
 interface Props {
   item: IndexedBreadcrumbItem;
   autoCollapse?: boolean;
@@ -94,15 +91,17 @@ const BreadcrumbItem = forwardRef<any, Props>(
 
     const { to, name, index } = item;
     const isLast = index === totalCount - 1;
-    return (
+    return isLast ? (
+      <StyledListItem ref={liRef} autoCollapse={autoCollapse} aria-current="page">
+        <CollapseContainer autoCollapse={autoCollapse}>
+          <span>{name}</span>
+        </CollapseContainer>
+      </StyledListItem>
+    ) : (
       <StyledListItem ref={liRef} autoCollapse={autoCollapse}>
         <CollapseContainer autoCollapse={autoCollapse}>
           {renderItem ? (
             renderItem(item, totalCount)
-          ) : isLast ? (
-            <StyledSafeLinkLast to="./" aria-current="page">
-              <span>{name}</span>
-            </StyledSafeLinkLast>
           ) : (
             <StyledSafeLink to={to}>
               <span>{name}</span>

--- a/packages/ndla-ui/src/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/ndla-ui/src/Breadcrumb/BreadcrumbItem.tsx
@@ -70,7 +70,10 @@ const StyledChevron = styled(ChevronRight)`
 const StyledSafeLink = styled(SafeLink)`
   color: inherit;
 `;
-
+const StyledSafeLinkLast = styled(SafeLink)`
+  color: inherit;
+  box-shadow: none;
+`;
 interface Props {
   item: IndexedBreadcrumbItem;
   autoCollapse?: boolean;
@@ -97,7 +100,9 @@ const BreadcrumbItem = forwardRef<any, Props>(
           {renderItem ? (
             renderItem(item, totalCount)
           ) : isLast ? (
-            <span>{name}</span>
+            <StyledSafeLinkLast to="./" aria-current="page">
+              <span>{name}</span>
+            </StyledSafeLinkLast>
           ) : (
             <StyledSafeLink to={to}>
               <span>{name}</span>

--- a/packages/ndla-ui/src/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/ndla-ui/src/Breadcrumb/BreadcrumbItem.tsx
@@ -91,17 +91,13 @@ const BreadcrumbItem = forwardRef<any, Props>(
 
     const { to, name, index } = item;
     const isLast = index === totalCount - 1;
-    return isLast ? (
-      <StyledListItem ref={liRef} autoCollapse={autoCollapse} aria-current="page">
-        <CollapseContainer autoCollapse={autoCollapse}>
-          <span>{name}</span>
-        </CollapseContainer>
-      </StyledListItem>
-    ) : (
-      <StyledListItem ref={liRef} autoCollapse={autoCollapse}>
+    return (
+      <StyledListItem ref={liRef} autoCollapse={autoCollapse} aria-current={isLast ? 'page' : undefined}>
         <CollapseContainer autoCollapse={autoCollapse}>
           {renderItem ? (
             renderItem(item, totalCount)
+          ) : isLast ? (
+            <span>{name}</span>
           ) : (
             <StyledSafeLink to={to}>
               <span>{name}</span>

--- a/packages/ndla-ui/src/Breadcrumb/HomeBreadcrumb.tsx
+++ b/packages/ndla-ui/src/Breadcrumb/HomeBreadcrumb.tsx
@@ -41,8 +41,9 @@ const StyledRightChevron = styled(ChevronRight)<ThemeProps>`
   color: ${({ light }) => (light ? colors.white : colors.text.primary)};
   margin: ${spacing.xxsmall};
 `;
-const StyledSpan = styled.span<ThemeProps>`
+const StyledSafeLinkLast = styled(SafeLink)<ThemeProps>`
   color: ${({ light }) => (light ? colors.white : colors.text.primary)};
+  box-shadow: none;
 `;
 const StyledSafeLink = styled(SafeLink)<ThemeProps>`
   color: ${({ light }) => (light ? colors.white : colors.text.primary)};
@@ -56,7 +57,11 @@ interface Props {
 const HomeBreadcrumb = ({ items, light }: Props) => {
   const renderItem = (item: IndexedBreadcrumbItem, totalCount: number) => {
     if (item.index === totalCount - 1) {
-      return <StyledSpan light={light}>{item.name}</StyledSpan>;
+      return (
+        <StyledSafeLinkLast to="./" aria-current="page" light={light}>
+          {item.name}
+        </StyledSafeLinkLast>
+      );
     }
     if (item.index === 0) {
       return (

--- a/packages/ndla-ui/src/Breadcrumb/HomeBreadcrumb.tsx
+++ b/packages/ndla-ui/src/Breadcrumb/HomeBreadcrumb.tsx
@@ -41,9 +41,8 @@ const StyledRightChevron = styled(ChevronRight)<ThemeProps>`
   color: ${({ light }) => (light ? colors.white : colors.text.primary)};
   margin: ${spacing.xxsmall};
 `;
-const StyledSafeLinkLast = styled(SafeLink)<ThemeProps>`
+const StyledSpan = styled.span<ThemeProps>`
   color: ${({ light }) => (light ? colors.white : colors.text.primary)};
-  box-shadow: none;
 `;
 const StyledSafeLink = styled(SafeLink)<ThemeProps>`
   color: ${({ light }) => (light ? colors.white : colors.text.primary)};
@@ -57,11 +56,7 @@ interface Props {
 const HomeBreadcrumb = ({ items, light }: Props) => {
   const renderItem = (item: IndexedBreadcrumbItem, totalCount: number) => {
     if (item.index === totalCount - 1) {
-      return (
-        <StyledSafeLinkLast to="./" aria-current="page" light={light}>
-          {item.name}
-        </StyledSafeLinkLast>
-      );
+      return <StyledSpan light={light}>{item.name}</StyledSpan>;
     }
     if (item.index === 0) {
       return (


### PR DESCRIPTION
gjorde siste element i brødsmulestien om til en lenke og la itl ariacurrent for skjermlesere.


?path=/story/sammensatte-moduler--brødsmulesti

Kan nå tabbes gjennom hele. Skjermlesere hopper ikke over siden man befinner seg på. 