### PR TITLE
Make a more accessible version of the Input component

### DIFF
--- a/packages/ndla-forms/src/InputV2.tsx
+++ b/packages/ndla-forms/src/InputV2.tsx
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { forwardRef, HTMLProps, ReactElement, ReactNode, useEffect } from 'react';
+import styled from '@emotion/styled';
+import { css, SerializedStyles } from '@emotion/core';
+import { colors, fonts, misc, spacing, spacingUnit } from '@ndla/core';
+import { useForwardedRef } from '@ndla/util';
+
+interface BaseInputProps {
+  before?: ReactNode;
+  after?: ReactNode;
+  white?: boolean;
+  error?: string;
+  customCss?: SerializedStyles;
+  label: string;
+  labelHidden?: boolean;
+  children: ReactElement;
+  name: string;
+  className?: string;
+}
+
+const Wrapper = styled.div`
+  display: flex;
+`;
+
+interface FormWarningTextProps {
+  withLabel?: boolean;
+}
+
+const shouldForwardError = (prop: string) => prop !== 'withLabel';
+
+const ErrorText = styled('span', { shouldForwardProp: shouldForwardError })<FormWarningTextProps>`
+  font-family: ${fonts.sans};
+  color: ${colors.support.red};
+  ${fonts.sizes(14, 1.1)};
+  padding-left: ${(p) => p.withLabel && `${spacingUnit & 4}px`};
+`;
+
+interface StyledLabelProps {
+  labelHidden: boolean;
+}
+
+const shouldForwardLabel = (p: string) => p !== 'labelHidden';
+
+const StyledLabel = styled('label', { shouldForwardProp: shouldForwardLabel })<StyledLabelProps>`
+  width: ${spacingUnit * 4}px;
+  max-width: ${spacingUnit * 4}px;
+  padding: 20px ${spacing.small} ${spacing.small} 0;
+  font-weight: ${fonts.weight.semibold};
+  ${fonts.sizes(14, 1.1)};
+  ${(p) =>
+    p.labelHidden &&
+    css`
+      border: 0;
+      clip: rect(0 0 0 0);
+      height: 1px;
+      margin: -1px;
+      overflow: hidden;
+      padding: 0;
+      position: absolute;
+      width: 1px;
+    `};
+`;
+
+interface StyledInputWrapperProps {
+  white?: boolean;
+}
+
+const InputWrapper = styled.div<StyledInputWrapperProps>`
+  display: flex;
+  flex-wrap: wrap;
+  flex-grow: 1;
+  background: ${(p) => (p.white ? colors.white : colors.brand.greyLightest)};
+  align-items: center;
+  justify-content: flex-start;
+  border: 1px solid ${colors.brand.greyLighter};
+  transition: border-color 100ms ease;
+  border-radius: ${misc.borderRadius};
+  min-height: ${spacing.large};
+  padding-right: ${spacing.small};
+
+  &:focus-within {
+    border-color: ${colors.brand.primary};
+  }
+
+  input,
+  textarea {
+    width: inherit;
+    font-weight: ${fonts.weight.normal};
+    color: ${colors.text.primary};
+    ${fonts.sizes(18, 1.3)};
+    background: none;
+    border: 0;
+    display: flex;
+    flex-grow: 1;
+    &:focus {
+      appearance: none;
+      outline: none;
+    }
+  }
+
+  input {
+    padding: ${spacing.xsmall} ${spacing.small};
+  }
+
+  textarea {
+    padding: 0 ${spacing.small};
+    height: 20px;
+    margin: 14px 0;
+    resize: none;
+  }
+
+  .c-icon {
+    width: 24px;
+    height: 24px;
+  }
+`;
+
+const BaseInput = ({
+  before,
+  after,
+  white,
+  error,
+  label,
+  children,
+  customCss,
+  labelHidden = false,
+  name,
+  className,
+}: BaseInputProps) => {
+  return (
+    <>
+      <Wrapper css={customCss}>
+        <StyledLabel labelHidden={labelHidden} htmlFor={name}>
+          {label}
+        </StyledLabel>
+        <InputWrapper white={white} className={className}>
+          {before}
+          {children}
+          {after}
+        </InputWrapper>
+      </Wrapper>
+      {error && (
+        <ErrorText withLabel={!labelHidden} id={`${name}-error`}>
+          {error}
+        </ErrorText>
+      )}
+    </>
+  );
+};
+
+export interface InputProps
+  extends Omit<BaseInputProps, 'children'>,
+    Omit<HTMLProps<HTMLInputElement>, 'label' | 'name'> {}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ before, after, white, error, customCss, label, labelHidden, name, className, ...rest }: InputProps, ref) => {
+    return (
+      <BaseInput
+        before={before}
+        after={after}
+        white={white}
+        error={error}
+        customCss={customCss}
+        labelHidden={labelHidden}
+        name={name}
+        className={className}
+        label={label}>
+        <input ref={ref} name={name} {...rest} aria-describedby={`${name}-error`} />
+      </BaseInput>
+    );
+  },
+);
+
+export interface TextAreProps
+  extends Omit<BaseInputProps, 'children'>,
+    Omit<HTMLProps<HTMLTextAreaElement>, 'label' | 'name'> {}
+
+export const TextArea = forwardRef<HTMLTextAreaElement, TextAreProps>(
+  ({ before, after, white, error, label, customCss, labelHidden, name, className, ...rest }, ref) => {
+    const forwardedRef = useForwardedRef(ref);
+
+    useEffect(() => {
+      if (forwardedRef.current) {
+        forwardedRef.current.style.height = '0px';
+        forwardedRef.current.style.height = `${forwardedRef.current.scrollHeight}px`;
+      }
+    });
+
+    return (
+      <BaseInput
+        before={before}
+        after={after}
+        white={white}
+        error={error}
+        customCss={customCss}
+        label={label}
+        name={name}
+        className={className}
+        labelHidden={labelHidden}>
+        <textarea name={name} ref={forwardedRef} {...rest} aria-describedby={`${name}-error`} />
+      </BaseInput>
+    );
+  },
+);

--- a/packages/ndla-forms/src/index.ts
+++ b/packages/ndla-forms/src/index.ts
@@ -12,6 +12,7 @@ export * from './index-javascript';
 export type { InputProps, TextAreaProps } from './Input';
 export { default as PopUpWrapper } from './PopupWrapper';
 export { Input, TextArea } from './Input';
+export { Input as InputV2, TextArea as TextAreaV2 } from './InputV2';
 export { default as FieldHeader } from './FieldHeader';
 export { default as FieldSection } from './FieldSection';
 export { default as FieldSplitter } from './FieldSplitter';

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -19,3 +19,4 @@ export { printPage } from './printPage';
 export { default as joinArrayWithConjunction } from './joinArrayWithConjunction';
 export { parseMarkdown } from './markdownHelpers';
 export { validateTranslationFiles } from './translationValidation';
+export { default as useForwardedRef } from './useForwardedRef';

--- a/packages/util/src/useForwardedRef.ts
+++ b/packages/util/src/useForwardedRef.ts
@@ -1,0 +1,17 @@
+import { ForwardedRef, useEffect, useRef } from 'react';
+
+const useForwardedRef = <T>(ref?: ForwardedRef<T>) => {
+  const innerRef = useRef<T | null>(null);
+
+  useEffect(() => {
+    if (!ref) return;
+    if (typeof ref === 'function') {
+      ref(innerRef.current);
+    } else {
+      ref.current = innerRef.current;
+    }
+  });
+  return innerRef;
+};
+
+export default useForwardedRef;


### PR DESCRIPTION
`Input`- og `TextArea`-komponentene har lenge ligget dårlig an når det gjelder tilgjengelighet. Hverken label eller feilmelding har vært koblet opp mot input-feltet. Denne komponenten tvinger deg til å ta hensyn til det, og vil strengt tatt dekke alle behov vi har i ndla-frontend gitt at vi legger på litt ekstra styling. Hvis vi legger inn litt ekstra innsats kan denne også erstatte en del av de semi-korrekte inputene vi har i ED. Tar gjerne litt tilbakemelding. Det mest hårete i koden er `useForwardedRef`, som lar deg ta i bruk en ref som blir forwarded. Dette er vanligvis ikke mulig uten litt magi.

Grunnen til at jeg lagde en ny komponent framfor å modifisere den nåværende er at vi her vil kreve fler props, som vil være breaking. Kan eventuelt ta oppgraderingsjobben, men da må vi plutselig begynne å ta hensyn til steder der vi definerer label utenfor komponenten. 