### PR TITLE
Dont forward custom props to ButtonV2

### DIFF
--- a/packages/button/src/IconButtonV2.tsx
+++ b/packages/button/src/IconButtonV2.tsx
@@ -27,7 +27,9 @@ interface StyledButtonProps extends ButtonProps {
   svgSize: number;
 }
 
-const StyledButton = styled(Button)<StyledButtonProps>`
+const shouldForwardProp = (name: string) => name !== 'svgSize';
+
+const StyledButton = styled(Button, { shouldForwardProp })<StyledButtonProps>`
   border-radius: 100%;
   padding: ${({ svgSize }) => spacingUnit * (svgSize > spacingUnit ? 0.5 : 0.25)}px;
   line-height: 1;

--- a/packages/ndla-ui/src/LanguageSelector/LanguageSelector.tsx
+++ b/packages/ndla-ui/src/LanguageSelector/LanguageSelector.tsx
@@ -115,7 +115,9 @@ interface StyledButtonProps {
   inverted?: boolean;
 }
 
-const StyledButton = styled(Button)<StyledButtonProps>`
+const shouldForwardProp = (name: string) => name !== 'outline';
+
+const StyledButton = styled(Button, { shouldForwardProp })<StyledButtonProps>`
   border-color: ${({ inverted, outline }) =>
     outline ? (inverted ? colors.white : colors.brand.primary) : 'transparent'};
 `;
@@ -139,6 +141,7 @@ const LanguageSelector = ({ currentLanguage, outline, center, inverted, alwaysVi
         </StyledSpan>
         <ChevronDown />
       </StyledButton>
+
       {isOpen && (
         <FocusTrapReact
           active


### PR DESCRIPTION
Fjerner feilmeldinger som oppsto fordi custom props ble videresendt til button.

Kan testes ved åpne ?path=/story/enkle-komponenter--knapper-beta og sjekke at feilmeldinger har forsvunnet