### PR TITLE
Disable autofocus in treestructure. Support blank links in resources

### DIFF
--- a/packages/ndla-ui/src/Resource/BlockResource.tsx
+++ b/packages/ndla-ui/src/Resource/BlockResource.tsx
@@ -33,6 +33,7 @@ interface BlockResourceProps {
   description?: string;
   menuItems?: MenuItemProps[];
   isLoading?: boolean;
+  targetBlank?: boolean;
 }
 
 const BlockElementWrapper = styled.div`
@@ -141,6 +142,7 @@ const BlockResource = ({
   description,
   menuItems,
   isLoading,
+  targetBlank,
 }: BlockResourceProps) => {
   const linkRef = useRef<HTMLAnchorElement>(null);
 
@@ -157,7 +159,7 @@ const BlockResource = ({
       </ImageWrapper>
       <BlockInfoWrapper>
         <TopicAndTitleLoader loading={isLoading}>
-          <ResourceTitleLink title={title} to={link} ref={linkRef}>
+          <ResourceTitleLink title={title} target={targetBlank ? '_blank' : undefined} to={link} ref={linkRef}>
             <ResourceTitle>{title}</ResourceTitle>
           </ResourceTitleLink>
         </TopicAndTitleLoader>

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -124,6 +124,7 @@ export interface ListResourceProps {
   description?: string;
   menuItems?: MenuItemProps[];
   isLoading?: boolean;
+  targetBlank?: boolean;
 }
 
 interface ListResourceImageProps {
@@ -192,6 +193,7 @@ const ListResource = ({
   description,
   menuItems,
   isLoading = false,
+  targetBlank,
 }: ListResourceProps) => {
   const showDescription = description !== undefined;
   const imageType = showDescription ? 'normal' : 'compact';
@@ -209,7 +211,7 @@ const ListResource = ({
       </StyledImageWrapper>
       <TopicAndTitleWrapper>
         <TopicAndTitleLoader loading={isLoading}>
-          <ResourceTitleLink to={link} ref={linkRef}>
+          <ResourceTitleLink to={link} target={targetBlank ? '_blank' : undefined} ref={linkRef}>
             <ResourceTitle>{title}</ResourceTitle>
           </ResourceTitleLink>
           <TopicList topics={topics} />

--- a/packages/ndla-ui/src/TreeStructure/FolderItem.tsx
+++ b/packages/ndla-ui/src/TreeStructure/FolderItem.tsx
@@ -151,10 +151,12 @@ const FolderItem = ({
       if (type === 'navigation') {
         ref.current?.focus();
       }
-      ref.current?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'nearest',
-      });
+      if (type === 'picker') {
+        ref.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+        });
+      }
     }
   }, [focusedFolder, ref, id, isCreatingFolder, type]);
 
@@ -181,7 +183,6 @@ const FolderItem = ({
       onKeyDown={(e: KeyboardEvent<HTMLElement>) => {
         if (e.key === 'Enter') {
           setSelectedFolder(folder);
-          setFocusedFolder(folder);
           return;
         }
         arrowNavigation(e, id, visibleFolders, setFocusedFolder, onOpenFolder, onCloseFolder);


### PR DESCRIPTION
Fikser to ting:
- Navigasjonsvarianten av trestruktur vil ikke lenger autofokusere valgt lenke ved trykk. Dette for å ikke komme i konflikt med ønsket fokus for tilgjengelighet.
- I noen tilfeller gir det mening å åpne ressurser automatisk i nytt vindu. Legger derfor til støtte for target blank på liste og blokkressurs.