### PR TITLE
Breadcrumb fixes

### DIFF
--- a/packages/button/src/MenuButton.tsx
+++ b/packages/button/src/MenuButton.tsx
@@ -36,8 +36,10 @@ const StyledMenuButton = styled(MenuButtonReach, { shouldForwardProp })<StyledBu
   &:active,
   &:focus,
   &:focus-within {
-    background-color: ${colors.brand.light};
     color: ${colors.brand.primary};
+    ${() => StyledHorizontalMenu} {
+      background-color: ${colors.brand.light};
+    }
   }
 
   svg {
@@ -45,6 +47,11 @@ const StyledMenuButton = styled(MenuButtonReach, { shouldForwardProp })<StyledBu
     height: ${({ svgSize }) => svgSize}px;
     fill: ${colors.brand.secondary};
   }
+`;
+
+const StyledHorizontalMenu = styled(HorizontalMenu)`
+  border-radius: 100%;
+  transition: ${misc.transition.default};
 `;
 
 const StyledMenuItems = styled(MenuItems)`
@@ -115,7 +122,7 @@ export const MenuButton = ({
         }} // Prevent redirect from triggering when placed inside <a>
         {...rest}>
         {children}
-        {!hideMenuIcon && <HorizontalMenu />}
+        {!hideMenuIcon && <StyledHorizontalMenu />}
       </StyledMenuButton>
       <MenuPopover
         onKeyDown={(e) => {

--- a/packages/ndla-ui/src/Breadcrumb/ActionBreadcrumb.tsx
+++ b/packages/ndla-ui/src/Breadcrumb/ActionBreadcrumb.tsx
@@ -23,7 +23,6 @@ const StyledRightChevron = styled(ChevronRight)`
 `;
 
 const StyledSpan = styled.span`
-  color: ${colors.text.primary};
   font-weight: ${fonts.weight.bold};
 `;
 
@@ -54,7 +53,7 @@ const ActionBreadcrumb = ({ items, actionItems }: Props) => {
     }
     if (item.index === totalCount - 1 && actionItems.length > 0) {
       return (
-        <StyledMenuButton menuItems={actionItems} size="small">
+        <StyledMenuButton menuItems={actionItems} alignRight size="small">
           <StyledSpan title={item.name}>{item.name}</StyledSpan>
         </StyledMenuButton>
       );

--- a/packages/ndla-ui/src/Breadcrumb/Breadcrumb.tsx
+++ b/packages/ndla-ui/src/Breadcrumb/Breadcrumb.tsx
@@ -67,7 +67,7 @@ const Breadcrumb = ({
         el.setMaxWidth('40px');
       }
     });
-  }, [size]);
+  }, [size, items]);
 
   return (
     <BreadcrumbNav ref={containerRef} aria-label={t('breadcrumb.breadcrumb')}>
@@ -77,11 +77,20 @@ const Breadcrumb = ({
             autoCollapse={autoCollapse}
             renderItem={renderItem}
             renderSeparator={renderSeparator}
-            ref={(element) =>
-              element === null || (!collapseFirst && index === 0) || (!collapseLast && index === items.length - 1)
-                ? breadcrumbItemRefs.delete(item.to)
-                : breadcrumbItemRefs.set(item.to, element)
-            }
+            ref={(element) => {
+              if (
+                element === null ||
+                (!collapseFirst && index === 0) ||
+                (!collapseLast && index === items.length - 1)
+              ) {
+                if (element) {
+                  element.setMaxWidth('none');
+                }
+                breadcrumbItemRefs.delete(item.to);
+              } else {
+                breadcrumbItemRefs.set(item.to, element);
+              }
+            }}
             key={typeof item.to === 'string' ? item.to : item.to.pathname}
             totalCount={items.length}
             item={{ ...item, index }}


### PR DESCRIPTION
Fixes NDLANO/Issues#3282

To feilrettinger på brødsmulestier:
- Når antallet breadcrumbs endres skal resize trigges. (Kan kun testes på ndla-frontend)
- Tilbakestilt designet på siste elementet i ActionBreadcrumb (versjonen for min ndla) slik at den får blå tekst og bakgrunn på ikon ved hover

Vi har fortsett en utfordring med at outline har offset på et par piksler og blir skjult alle steder vi har overflow hidden. Dette må vi gruble litt på, for det å sette padding overalt er ikke en god løsning på lang sikt. Merkes ved at outline blir kuttet ved tabbing gjennom elementer