### PR TITLE
Fix error caused by illegal html props and missing keys

### DIFF
--- a/packages/button/src/IconButtonDualStates.tsx
+++ b/packages/button/src/IconButtonDualStates.tsx
@@ -23,7 +23,9 @@ interface StyledIconButtonProps {
   active: boolean;
 }
 
-const StyledIconButton = styled(IconButton)<StyledIconButtonProps>`
+const shouldForwardProp = (name: string) => name !== 'active';
+
+const StyledIconButton = styled(IconButton, { shouldForwardProp })<StyledIconButtonProps>`
   svg {
     transition: opacity ${animations.durations.fast} ease;
     &:first-of-type {

--- a/packages/ndla-ui/src/Resource/resourceComponents.tsx
+++ b/packages/ndla-ui/src/Resource/resourceComponents.tsx
@@ -185,12 +185,10 @@ export const TopicList = ({ topics }: TopicListProps) => {
   return (
     <StyledTopicList aria-label={t('navigation.topics')}>
       {topics.map((topic, i) => (
-        <>
-          <StyledTopicListElement key={topic}>
-            {topic}
-            {i !== topics.length - 1 && <StyledTopicDivider aria-hidden="true">•</StyledTopicDivider>}
-          </StyledTopicListElement>
-        </>
+        <StyledTopicListElement key={topic}>
+          {topic}
+          {i !== topics.length - 1 && <StyledTopicDivider aria-hidden="true">•</StyledTopicDivider>}
+        </StyledTopicListElement>
       ))}
     </StyledTopicList>
   );


### PR DESCRIPTION
Fjerner feilmeldinger grunnet active-prop som er ugyldig og manglende key i liste grunnet en tom fragment.