### PR TITLE
Loadingknapp. Riktig select i trestruktur ved enterklikk.

### DIFF
--- a/packages/button/src/LoadingButton.tsx
+++ b/packages/button/src/LoadingButton.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Spinner } from '@ndla/icons';
+import React from 'react';
+import { forwardRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import Button, { ButtonProps } from './ButtonV2';
+
+interface Props extends ButtonProps {
+  loading?: boolean;
+}
+
+const LoadingButton = forwardRef<HTMLButtonElement, Props>(({ loading, children, ...rest }, ref) => {
+  const { t } = useTranslation();
+
+  return (
+    <Button disabled={loading} aria-live="assertive" {...rest} ref={ref}>
+      {loading && <Spinner size="normal" margin="0" aria-label={t('loading')} />}
+      {children}
+    </Button>
+  );
+});
+
+export default LoadingButton;

--- a/packages/button/src/index.ts
+++ b/packages/button/src/index.ts
@@ -13,6 +13,7 @@ export { default as MultiButton } from './MultiButton';
 export { default as CloseButton } from './CloseButton';
 export { default as IconButton, convertSizeForSVG } from './IconButton';
 export { default as IconButtonV2 } from './IconButtonV2';
+export { default as LoadingButton } from './LoadingButton';
 export { default as MenuButton } from './MenuButton';
 export type { MenuItemProps } from './MenuButton';
 export { default as IconButtonDualStates } from './IconButtonDualStates';

--- a/packages/ndla-modal/src/ModalCloseButton.tsx
+++ b/packages/ndla-modal/src/ModalCloseButton.tsx
@@ -6,17 +6,15 @@
  *
  */
 
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import styled from '@emotion/styled';
 
 import { useTranslation } from 'react-i18next';
 import { Cross } from '@ndla/icons/action';
 import { colors } from '@ndla/core';
 
-interface Props {
+interface Props extends HTMLAttributes<HTMLButtonElement> {
   title?: string;
-  onClick: () => void;
-  className?: string;
 }
 
 const StyledButton = styled.button`
@@ -35,10 +33,10 @@ const StyledCross = styled(Cross)`
   width: 24px;
 `;
 
-const ModalClose = ({ title, onClick, className = '' }: Props) => {
+const ModalClose = ({ title, ...rest }: Props) => {
   const { t } = useTranslation();
   return (
-    <StyledButton onClick={onClick} data-cy="close-modal-button" className={className} aria-label={t('close')}>
+    <StyledButton data-cy="close-modal-button" aria-label={t('close')} {...rest}>
       <StyledCross title={title} />
     </StyledButton>
   );

--- a/packages/ndla-ui/src/TreeStructure/ComboboxButton.tsx
+++ b/packages/ndla-ui/src/TreeStructure/ComboboxButton.tsx
@@ -53,12 +53,12 @@ interface Props {
   label?: string;
   focusedFolder?: FolderType;
   selectedFolder?: FolderType;
-  setSelectedFolder: (folder?: FolderType) => void;
+  setSelectedFolder: (folder: FolderType) => void;
   onToggleTree: (open: boolean) => void;
   flattenedFolders: FolderType[];
   onOpenFolder: (id: string) => void;
   onCloseFolder: (id: string) => void;
-  setFocusedFolder: (folder?: FolderType) => void;
+  setFocusedFolder: (folder: FolderType) => void;
 }
 
 const ComboboxButton = forwardRef<HTMLButtonElement, Props>(
@@ -82,7 +82,7 @@ const ComboboxButton = forwardRef<HTMLButtonElement, Props>(
 
     const onKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
       if (e.key === 'Enter') {
-        if (showTree) {
+        if (showTree && focusedFolder) {
           setSelectedFolder(focusedFolder);
         }
         return;

--- a/packages/ndla-ui/src/TreeStructure/FolderItem.tsx
+++ b/packages/ndla-ui/src/TreeStructure/FolderItem.tsx
@@ -117,7 +117,6 @@ const FolderItem = ({
   selectedFolder,
   onCloseFolder,
   onOpenFolder,
-  onSelectFolder,
   setFocusedFolder,
   setSelectedFolder,
   targetResource,
@@ -143,7 +142,6 @@ const FolderItem = ({
       if (selected) {
         closeTree();
       }
-      onSelectFolder?.(id);
     }
   };
 

--- a/packages/ndla-ui/src/TreeStructure/index.ts
+++ b/packages/ndla-ui/src/TreeStructure/index.ts
@@ -7,6 +7,6 @@
  */
 
 import TreeStructure from './TreeStructure';
-export type { FolderType, TreeStructureMenuProps } from './types';
+export type { FolderType } from './types';
 export type { TreeStructureProps } from './TreeStructure';
 export { TreeStructure };

--- a/packages/ndla-ui/src/TreeStructure/types.ts
+++ b/packages/ndla-ui/src/TreeStructure/types.ts
@@ -6,9 +6,8 @@
  *
  */
 
-import { MouseEvent, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { IFolder, IResource } from '@ndla/types-learningpath-api';
-import { MenuItemProps } from '@ndla/button';
 
 export interface FolderType extends IFolder {
   icon?: ReactNode;
@@ -29,13 +28,8 @@ export type NewFolderInputFunc = ({
   onCreate: OnCreatedFunc;
 }) => ReactNode;
 
-export interface TreeStructureMenuProps extends Omit<MenuItemProps, 'onClick'> {
-  onClick: (e: MouseEvent<HTMLDivElement> | undefined, folder: FolderType) => void;
-}
-
 export interface CommonTreeStructureProps {
   loading?: boolean;
-  onSelectFolder?: (id: string) => void;
   targetResource?: IResource;
   type: TreeStructureType;
 }

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -252,6 +252,6 @@ export { SnackbarProvider, useSnack, BaseSnack, DefaultSnackbar } from './SnackB
 export type { Snack, SnackContext } from './SnackBar';
 export { InfoBlock } from './InfoBlock';
 export { TreeStructure } from './TreeStructure';
-export type { FolderType, TreeStructureProps, TreeStructureMenuProps } from './TreeStructure';
+export type { FolderType, TreeStructureProps } from './TreeStructure';
 
 export { SearchField, SearchResultList, SearchResultItem, ActiveFilters, ToggleSearchButton } from './Search';


### PR DESCRIPTION
Hva som er nytt:
- Ved klikk på enter i trestruktur skal onSelectFolder nå trigges slik at skjemaet i modalen i ndla-frontend blir oppdatert.
- Har laget en ny komponent `LoadingButton` som er en enkel wrapper rundt ButtonV2 med all funksjonalitet, men med innebygd spinner og loading prop.
- Eksponerer flere props fra ModalCloseButton.