### PR TITLE
Add translations for user info support

### DIFF
--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -978,6 +978,8 @@ const messages = {
       teaching: 'Teaching group',
       other: 'Other groups',
     },
+    wrongUserInfoDisclaimer:
+      'If any information is wrong, it must be updated by the host organization/school owner the user belongs to. An overview of available user support can be found here: ',
   },
   checkOutNewFeature: 'New feature',
   slateBlockMenu: {

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -976,6 +976,8 @@ const messages = {
       teaching: 'Undervisningsgruppe',
       other: 'Andre grupper',
     },
+    wrongUserInfoDisclaimer:
+      'Dersom informasjon er feil, så må dette oppdateres av vertsorganisasjon/skoleeier som brukeren tilhører. Oversikt over brukerstøtte finnes her: ',
   },
   checkOutNewFeature: 'Sjekk ut ny funksjonalitet',
   slateBlockMenu: {

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -977,6 +977,8 @@ const messages = {
       teaching: 'Undervisningsgruppe',
       other: 'Andre grupper',
     },
+    wrongUserInfoDisclaimer:
+      'Dersom informasjon er feil, så må dette oppdaterast av vertsorganisasjon/skuleeigar som brukaren tilhøyrar. Oversikt over brukarstøtte finst her: ',
   },
   checkOutNewFeature: 'Sjekk ut ny funksjonalitet',
   slateBlockMenu: {

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -978,7 +978,7 @@ const messages = {
       other: 'Eará joavkkut',
     },
     wrongUserInfoDisclaimer:
-      'Dersom informasjon er feil, så må dette oppdaterast av vertsorganisasjon/skuleeigar som brukaren tilhøyrar. Oversikt over brukarstøtte finst her: ',
+      'Jus leat boasttudieđut, de ferte lágideaddjiorganisašuvdna/skuvlaeaiggát masá geavaheaddji gullá ođasmahttit dan. Visogovva geavaheaddjidoarjaga ektui gávnnat dás: ',
   },
   checkOutNewFeature: 'Iskka ođđa doaibmilvuođa',
   slateBlockMenu: {

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -977,6 +977,8 @@ const messages = {
       teaching: 'Oahpahusjoavku',
       other: 'Eará joavkkut',
     },
+    wrongUserInfoDisclaimer:
+      'Dersom informasjon er feil, så må dette oppdaterast av vertsorganisasjon/skuleeigar som brukaren tilhøyrar. Oversikt over brukarstøtte finst her: ',
   },
   checkOutNewFeature: 'Iskka ođđa doaibmilvuođa',
   slateBlockMenu: {

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -977,6 +977,8 @@ const messages = {
       teaching: 'Undervisningsgruppe',
       other: 'Andre grupper',
     },
+    wrongUserInfoDisclaimer:
+      'Dersom informasjon er feil, så må dette oppdaterast av vertsorganisasjon/skuleeigar som brukaren tilhøyrar. Oversikt over brukarstøtte finst her: ',
   },
   checkOutNewFeature: 'Sjekk ut ny funksjonalitet',
   slateBlockMenu: {


### PR DESCRIPTION
https://trello.com/c/c6YQBcqW/219-p%C3%A5-slutten-av-informasjonen-om-hva-feide-henter-legger-vi-til-tekst
Korresponderende PR kommer i ndla-frontend