### PR TITLE
Add beta subject to subject types

### DIFF
--- a/packages/ndla-ui/src/Frontpage/FrontpageAllSubjects.tsx
+++ b/packages/ndla-ui/src/Frontpage/FrontpageAllSubjects.tsx
@@ -203,6 +203,17 @@ const FrontpageAllSubjects = ({
                 <MessageBox>{category.message}</MessageBox>
               </MessageBoxWrapper>
             )}
+            {category.name === t('subjectCategories.beta') && (
+              <MessageBoxWrapper>
+                <MessageBox>{t('messageBoxInfo.frontPageBeta')}</MessageBox>
+                <MessageBox>{category.message}</MessageBox>
+              </MessageBoxWrapper>
+            )}
+            {category.name === t('subjectCategories.archive') && (
+              <MessageBoxWrapper>
+                <MessageBox>{t('messageBoxInfo.frontPageExpired')}</MessageBox>
+              </MessageBoxWrapper>
+            )}
             {renderList(category.subjects, onNavigate, onToggleSubject, subjectViewType, selectedSubjects)}
           </>
         ),

--- a/packages/ndla-ui/src/Frontpage/FrontpageAllSubjects.tsx
+++ b/packages/ndla-ui/src/Frontpage/FrontpageAllSubjects.tsx
@@ -6,7 +6,6 @@ import SafeLink from '@ndla/safelink';
 import { colors, fonts, mq, breakpoints } from '@ndla/core';
 import { MessageBox } from '../Messages';
 import { ToggleItem } from '../Filter';
-import constants from '../model';
 
 const StyledWrapper = styled.nav`
   margin: 32px 0 0;
@@ -84,6 +83,7 @@ type categoryProps = {
   type?: string;
   name?: string;
   visible?: boolean;
+  message?: string;
   subjects: subjectProps[];
 };
 
@@ -198,20 +198,11 @@ const FrontpageAllSubjects = ({
         title: category.name || t(`subjectCategories.${category.type}`),
         content: (
           <>
-            {/* Should be persistent til fall 2022 */}
-            {(category.name === t('subjectCategories.beta') ||
-              category.type === constants.subjectCategories.BETA_SUBJECTS) && (
+            {category.message && (
               <MessageBoxWrapper>
-                <MessageBox>{t('messageBoxInfo.frontPageBeta')}</MessageBox>
+                <MessageBox>{category.message}</MessageBox>
               </MessageBoxWrapper>
             )}
-            {(category.name === t('subjectCategories.archive') ||
-              category.type === constants.subjectCategories.ARCHIVE_SUBJECTS) && (
-              <MessageBoxWrapper>
-                <MessageBox>{t('messageBoxInfo.frontPageExpired')}</MessageBox>
-              </MessageBoxWrapper>
-            )}
-
             {renderList(category.subjects, onNavigate, onToggleSubject, subjectViewType, selectedSubjects)}
           </>
         ),

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -113,6 +113,7 @@ const messages = {
     [subjectTypes.RESOURCE_COLLECTION]: 'Other resources',
   },
   subjectTypes: {
+    [subjectTypes.BETA_SUBJECT]: 'Betafag',
     [subjectTypes.SUBJECT]: 'Subject',
     [subjectTypes.RESOURCE_COLLECTION]: 'Resource collection',
   },

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -113,6 +113,7 @@ const messages = {
     [subjectTypes.RESOURCE_COLLECTION]: 'Andre ressurser',
   },
   subjectTypes: {
+    [subjectTypes.BETA_SUBJECT]: 'Betafag',
     [subjectTypes.SUBJECT]: 'Fag',
     [subjectTypes.RESOURCE_COLLECTION]: 'Ressurssamling',
   },

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -113,6 +113,7 @@ const messages = {
     [subjectTypes.RESOURCE_COLLECTION]: 'Andre ressursar',
   },
   subjectTypes: {
+    [subjectTypes.BETA_SUBJECT]: 'Betafag',
     [subjectTypes.SUBJECT]: 'Fag',
     [subjectTypes.RESOURCE_COLLECTION]: 'Ressurssamling',
   },

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -113,6 +113,7 @@ const messages = {
     [subjectTypes.RESOURCE_COLLECTION]: 'Eará resurssat',
   },
   subjectTypes: {
+    [subjectTypes.BETA_SUBJECT]: 'Betafága',
     [subjectTypes.SUBJECT]: 'Fága',
     [subjectTypes.RESOURCE_COLLECTION]: 'Resursačoakkáldat',
   },

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -113,6 +113,7 @@ const messages = {
     [subjectTypes.RESOURCE_COLLECTION]: 'Andre ressurser',
   },
   subjectTypes: {
+    [subjectTypes.BETA_SUBJECT]: 'Betafag',
     [subjectTypes.SUBJECT]: 'Fag',
     [subjectTypes.RESOURCE_COLLECTION]: 'Ressurssamling',
   },

--- a/packages/ndla-ui/src/model/SubjectTypes.ts
+++ b/packages/ndla-ui/src/model/SubjectTypes.ts
@@ -6,5 +6,6 @@
  *
  */
 
+export const BETA_SUBJECT = 'betaSubject';
 export const SUBJECT = 'subject';
 export const RESOURCE_COLLECTION = 'resourceCollection';


### PR DESCRIPTION
NDLANO/Issues#2671

Lager skille mellom kommende fag og betafag. Handler om at kommende fag er i forbindelse med ny læreplan, mens betafag er fag under arbeid hos NDLA.

Forenkler også visning av faggrupper på forsida.