### PR TITLE
Fallback to overflow auto if overlay is not supported

### DIFF
--- a/packages/ndla-ui/src/TagSelector/Control.tsx
+++ b/packages/ndla-ui/src/TagSelector/Control.tsx
@@ -19,6 +19,7 @@ const StyledTagSelectorControl = styled.div`
   align-items: center;
   margin: ${spacing.xxsmall};
 
+  overflow: auto;
   overflow: overlay;
   ${utils.scrollbar}
 `;

--- a/packages/ndla-ui/src/TagSelector/MenuList.tsx
+++ b/packages/ndla-ui/src/TagSelector/MenuList.tsx
@@ -13,6 +13,7 @@ import { MenuListProps } from 'react-select';
 import { TagType } from './types';
 
 export const StyledMenuList = styled.div`
+  overflow: auto;
   overflow: overlay;
   ${utils.scrollbar}
   display: flex;

--- a/packages/ndla-ui/src/TreeStructure/TreeStructure.tsx
+++ b/packages/ndla-ui/src/TreeStructure/TreeStructure.tsx
@@ -61,6 +61,7 @@ const ScrollableDiv = styled.div<ScrollableDivProps>`
   ${({ type }) =>
     type === 'picker' &&
     css`
+      overflow: auto;
       overflow: overlay;
       ${utils.scrollbar}
     `}


### PR DESCRIPTION
Delvis relatert til https://trello.com/c/Dv9E6kDo/262-ny-versjon-p%C3%A5-test-6oktober-n%C3%A5r-man-skal-legge-p%C3%A5-tags-kommer-en-lang-liste-med-alle-tags-opp-jeg-ville-skrive-selv-hvis-jeg-vel. Firefox støtter ikke overflow: overlay og må derfor fallbacke til auto