### PR TITLE
Prevent large menubuttons in list resource. Better image scaling in block resource.

### DIFF
--- a/packages/ndla-ui/src/Resource/BlockResource.tsx
+++ b/packages/ndla-ui/src/Resource/BlockResource.tsx
@@ -89,6 +89,8 @@ const ImageWrapper = styled.div`
   overflow: hidden;
   align-items: center;
   img {
+    object-fit: cover;
+    aspect-ratio: 4/3;
     min-width: 100%;
   }
 `;

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -106,6 +106,7 @@ const TagsandActionMenu = styled.div<TagsAndActionProps>`
   grid-template-columns: 1fr auto auto;
   align-items: center;
   align-self: flex-start;
+  justify-items: flex-end;
   margin: -${spacing.small} -${(props) => (props.hasMenuButton ? spacing.small : 0)} 0 0;
   ${mq.range({ until: breakpoints.mobileWide })} {
     margin: 0 -${(props) => (props.hasMenuButton ? spacing.small : 0)} -${spacing.small} 0;


### PR DESCRIPTION
To små feilrettinger relatert til https://github.com/NDLANO/ndla-frontend/pull/1167.

1. Som oppdaget i PR over så vokste menubutton seg gigantisk i ressurs på mobilvisning dersom tags ikke finnes. Dette er nå løst ved å aligne items til høyre med flex-end
2. Oppdaget samtidig at blokkressurs ved blokkvisning ikke hadde konsekvent høyde. Dette skal nå fungere bedre etter at aspect-ratio er satt på bildet. Object-fit sørger for at bildet holder sitt opprinnelige størrelsesforhold og ikke forvrenges. 

Relatert til punkt 2 oppdaget jeg at svært lavoppløste bilder. Altså bilder med pikselbredde som er smalere enn blokkressursen fungerer dårlig, men dette tar vi senere.