### PR TITLE
Hotfixes for min ndla

### DIFF
--- a/packages/ndla-ui/src/Resource/BlockResource.tsx
+++ b/packages/ndla-ui/src/Resource/BlockResource.tsx
@@ -163,7 +163,7 @@ const BlockResource = ({
   resourceTypes,
 }: Props) => {
   const linkRef = useRef<HTMLAnchorElement>(null);
-  const firstResourceType = resourceTypes?.[0].id ?? '';
+  const firstResourceType = resourceTypes?.[0]?.id ?? '';
   const Title = ResourceTitle.withComponent(headingLevel);
 
   const handleClick = () => {

--- a/packages/ndla-ui/src/TreeStructure/TreeStructure.tsx
+++ b/packages/ndla-ui/src/TreeStructure/TreeStructure.tsx
@@ -18,7 +18,7 @@ import { CommonTreeStructureProps, FolderType, NewFolderInputFunc, TreeStructure
 import ComboboxButton from './ComboboxButton';
 import AddFolderButton from './AddFolderButton';
 
-export const MAX_LEVEL_FOR_FOLDERS = 4;
+export const MAX_LEVEL_FOR_FOLDERS = 5;
 
 const StyledLabel = styled.label`
   font-weight: ${fonts.weight.semibold};


### PR DESCRIPTION
Et manglende spørsmålstegn gjorde at blockresource krasjet i noen tilfeller. Ellers har maks mappedybde blitt økt til fem for å matche backend og mappevisning.