### PR TITLE
Add skiptocontentid to film topic navigation. 

### DIFF
--- a/packages/ndla-ui/src/NDLAFilm/CategorySelect.tsx
+++ b/packages/ndla-ui/src/NDLAFilm/CategorySelect.tsx
@@ -148,7 +148,7 @@ const CategorySelect = ({ resourceTypes, resourceTypeSelected, ariaControlId, on
   return (
     <DropdownContainer className="u-12/12">
       <DropdownButton
-        aria-expanded={!resourceTypesIsOpen}
+        aria-expanded={!!resourceTypesIsOpen}
         aria-controls="selectCategory"
         type="button"
         tabIndex={resourceTypesIsOpen ? -1 : 0}

--- a/packages/ndla-ui/src/NDLAFilm/FilmMovieSearch.tsx
+++ b/packages/ndla-ui/src/NDLAFilm/FilmMovieSearch.tsx
@@ -61,6 +61,7 @@ interface Props {
   resourceTypeSelected?: MovieResourceType;
   resourceTypes: MovieResourceType[];
   ariaControlId: string;
+  skipToContentId?: string;
 }
 
 const FilmMovieSearch = ({
@@ -69,13 +70,16 @@ const FilmMovieSearch = ({
   resourceTypes,
   resourceTypeSelected,
   ariaControlId,
+  skipToContentId,
 }: Props) => {
   const { t } = useTranslation();
   return (
     <FilmMovieSearchContainer>
       <OneColumn>
         <TopicNavigation>
-          <StyledHeadingH2 className="u-12/12 u-4/12@tablet">{t('ndlaFilm.subjectsInMovies')}:</StyledHeadingH2>
+          <StyledHeadingH2 id={skipToContentId} className="u-12/12 u-4/12@tablet">
+            {t('ndlaFilm.subjectsInMovies')}:
+          </StyledHeadingH2>
           <nav className="u-12/12 u-8/12@tablet">
             <ul>
               {topics.map((topic) => (


### PR DESCRIPTION
Ved åpning av ndla film-forside og trykk på "hopp til innhold" flyttes nå fokus til ytterste diven på siden. Dette fører til at hele sidens innhold leses opp. Legger derfor til støtte for å legge dette på menyen for film-emner. Ellers fikset jeg en bug på aria-expanded som var true når knappen var lukket.

Er relatert til https://github.com/NDLANO/ndla-frontend/pull/1115