### PR TITLE
Prevent tags overflowing ListCard

### DIFF
--- a/packages/button/src/AddButton.tsx
+++ b/packages/button/src/AddButton.tsx
@@ -13,10 +13,11 @@ import { Plus } from '@ndla/icons/action';
 import { Button, ButtonProps } from './Button';
 
 const AddIconBorder = styled.div`
-  height: 40px;
-  width: 40px;
   display: flex;
   align-items: center;
+  height: 40px;
+  width: 40px;
+  aspect-ratio: 1;
   justify-content: center;
   border: 1px solid ${colors.brand.tertiary};
   border-radius: 50%;
@@ -25,6 +26,7 @@ const AddIconBorder = styled.div`
 
 const TextWrapper = styled.span`
   color: ${colors.brand.primary};
+  white-space: nowrap;
   align-items: center;
   display: flex;
   ${fonts.weight.semibold}

--- a/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
@@ -182,7 +182,7 @@ const Folder = ({ id, link, title, subFolders, subResources, type = 'list', menu
           <FolderOutlined aria-label={t('myNdla.folder.folder')} />
         </IconWrapper>
         <StyledLink to={link} ref={linkRef}>
-          <FolderTitle>{title}</FolderTitle>
+          <FolderTitle title={title}>{title}</FolderTitle>
         </StyledLink>
       </TitleWrapper>
       <MenuWrapper>

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -27,7 +27,7 @@ import { contentTypeMapping } from '../model/ContentType';
 const ListResourceWrapper = styled.div`
   flex: 1;
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto minmax(50px, 1fr) auto;
   grid-template-areas:
     'image  topicAndTitle   tags'
     'image  description     description';
@@ -100,8 +100,8 @@ interface TagsAndActionProps {
 }
 
 const TagsandActionMenu = styled.div<TagsAndActionProps>`
-  box-sizing: content-box;
   grid-area: tags;
+  box-sizing: content-box;
   display: grid;
   grid-template-columns: 1fr auto auto;
   align-items: center;
@@ -111,10 +111,14 @@ const TagsandActionMenu = styled.div<TagsAndActionProps>`
   ${mq.range({ until: breakpoints.mobileWide })} {
     margin: 0 -${(props) => (props.hasMenuButton ? spacing.small : 0)} -${spacing.small} 0;
   }
+  overflow: hidden;
 `;
 
 const TopicAndTitleWrapper = styled.div`
   grid-area: topicAndTitle;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 `;
 
 interface ListResourceImageProps {

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -239,7 +239,7 @@ const ListResource = ({
       <TopicAndTitleWrapper>
         <TypeAndTitleLoader loading={isLoading}>
           <StyledLink to={link} target={targetBlank ? '_blank' : undefined} ref={linkRef}>
-            <Title>{title}</Title>
+            <Title title={title}>{title}</Title>
           </StyledLink>
           <ResourceTypeList resourceTypes={resourceTypes} />
         </TypeAndTitleLoader>

--- a/packages/ndla-ui/src/Resource/resourceComponents.tsx
+++ b/packages/ndla-ui/src/Resource/resourceComponents.tsx
@@ -187,7 +187,7 @@ export const ResourceTypeList = ({ resourceTypes }: ResourceTypeListProps) => {
     <StyledResourceTypeList aria-label={t('navigation.topics')}>
       {resourceTypes.map((resource, i) => (
         <StyledResourceListElement key={resource.id}>
-          {resource.name}og mye mye mer
+          {resource.name}
           {i !== resourceTypes.length - 1 && <StyledTopicDivider aria-hidden="true">•</StyledTopicDivider>}
         </StyledResourceListElement>
       ))}

--- a/packages/ndla-ui/src/Resource/resourceComponents.tsx
+++ b/packages/ndla-ui/src/Resource/resourceComponents.tsx
@@ -26,9 +26,7 @@ export const ResourceTitleLink = styled(SafeLink)`
 `;
 
 export const ResourceTitle = styled.h2`
-  min-width: 50px;
   margin: 0;
-  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   // Unfortunate css needed for multi-line text overflow ellipsis.
@@ -81,6 +79,7 @@ const StyledTopicDivider = styled.span`
 `;
 
 const StyledResourceListElement = styled.li`
+  white-space: nowrap;
   ${fonts.sizes(12)};
   margin: 0;
   line-height: 1.5;
@@ -188,7 +187,7 @@ export const ResourceTypeList = ({ resourceTypes }: ResourceTypeListProps) => {
     <StyledResourceTypeList aria-label={t('navigation.topics')}>
       {resourceTypes.map((resource, i) => (
         <StyledResourceListElement key={resource.id}>
-          {resource.name}
+          {resource.name}og mye mye mer
           {i !== resourceTypes.length - 1 && <StyledTopicDivider aria-hidden="true">•</StyledTopicDivider>}
         </StyledResourceListElement>
       ))}


### PR DESCRIPTION
Økt responsitivitet på blokk og listevisning av ressurs. Har også sørget for at ny mappe-knappen alltid er en perfekt sirkel.
Fikser en feil der tags flyter over tittel.

Anbefaler å både sjekke designmanual og linke inn i https://github.com/NDLANO/ndla-frontend/pull/1174