### PR TITLE
Disable folder input autocomplete

### DIFF
--- a/packages/ndla-ui/src/MyNdla/Resource/FolderInput.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/FolderInput.tsx
@@ -73,6 +73,7 @@ const FolderInput = forwardRef<HTMLInputElement, Props>(({ loading, error, onClo
 
   return (
     <StyledInput
+      autoComplete="off"
       white
       error={error}
       aria-disabled={loading ? true : undefined}


### PR DESCRIPTION
Fikser https://trello.com/c/YWWsevhD/280-rare-forslag-til-mappenavn

Skrur av autocomplete på mappe-input.