### PR TITLE
Forhindrer at gradering av innhold i faktaboks stopper 20px over bunn.

### DIFF
--- a/packages/ndla-ui/src/FactBox/component.factbox.scss
+++ b/packages/ndla-ui/src/FactBox/component.factbox.scss
@@ -23,7 +23,7 @@ $padding-bottom: 17px;
       text-align: center;
       position: absolute;
       top: 0;
-      bottom: 20px;
+      bottom: 0;
       right: 0;
       width: 99%;
       margin: 0.5% 0.5% 0 0.5%;


### PR DESCRIPTION
Fixes NDLANO/Issues#3305

Sjekk feks https://designmanual.ndla.no/?path=/story/enkle-komponenter--faktaboks og sjå at graderinga ikkje går heilt ned
Sammenlign med pr-installasjon.