### PR TITLE
Navn og UU på kopi av overskrift i artikkel.

### DIFF
--- a/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
+++ b/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
@@ -14,6 +14,10 @@ import { useTranslation } from 'react-i18next';
 import Tooltip from '@ndla/tooltip';
 import { copyTextToClipboard } from '@ndla/util';
 
+const ContainerDiv = styled.div`
+  position: relative;
+`;
+
 const IconButton = styled.button`
   position: absolute;
   left: -3em;
@@ -28,13 +32,11 @@ const IconButton = styled.button`
     width: 30px;
     height: 30px;
   }
-`;
 
-const ContainerDiv = styled.div`
-  position: relative;
-  &:hover button {
+  ${ContainerDiv}:hover &,
+  &:focus, &:focus-visible, &:active {
     cursor: pointer;
-    opacity: 0.5;
+    opacity: 1;
   }
 `;
 
@@ -54,12 +56,12 @@ interface CopyButtonProps {
 const CopyButton = ({ onClick, title, tooltip, content }: CopyButtonProps) => {
   return (
     <div>
-      <IconButton onClick={onClick} data-title={title}>
-        <Tooltip tooltip={tooltip}>
+      <Tooltip tooltip={tooltip}>
+        <IconButton onClick={onClick} data-title={title} aria-label={`${tooltip}: ${title}`}>
           <Link title={''} />
-        </Tooltip>
-      </IconButton>
-      <h2 id={title} tabIndex={0} dangerouslySetInnerHTML={{ __html: content || '' }} />
+        </IconButton>
+      </Tooltip>
+      <h2 id={title} tabIndex={-1} dangerouslySetInnerHTML={{ __html: content || '' }} />
     </div>
   );
 };

--- a/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
+++ b/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
@@ -13,6 +13,7 @@ import { Link } from '@ndla/icons/common';
 import { useTranslation } from 'react-i18next';
 import Tooltip from '@ndla/tooltip';
 import { copyTextToClipboard } from '@ndla/util';
+import { colors } from '@ndla/core';
 
 const ContainerDiv = styled.div`
   position: relative;
@@ -27,6 +28,7 @@ const IconButton = styled.button`
   z-index: 1;
   transition: 0.2s;
   opacity: 0;
+  color: ${colors.brand.grey};
 
   & svg {
     width: 30px;


### PR DESCRIPTION
Fikser
https://trello.com/c/pB2h6lWQ/15-uu-knapp-for-lenker-til-h2-gir-ingen-navn-eller-antydning-hva-den-gj%C3%B8r
https://trello.com/c/UtALbg1J/19-knapp-ved-headinger-i-artikler-m%C3%A5-f%C3%A5-navn

Knapp for kopiering av lenke til overskrift hadde manglende beskrivelse, spesielt for skjermlesere.

Endringer:
- anchor-knapp har nå aria-label på format: "Kopier lenke til overskrift: Navn på overskrift".
- Overskrift kan ikke lenger tabbes til. Det er ikke nødvendig å både kunne tabbe til anchor og h2.

Hvordan teste:
- link ndla-ui inn i article-converter og ndla-frontend.
- spinn opp lokalt oppsett med graphql-api, article-converter og ndla-frontend.
- Sjekk ut feks http://localhost:3000/article/31044
- Se at riktig aria-label finnes og at tabbing fungerer som forventet. Test evt med skjermleser også.