### PR TITLE
Stop relying on activeElement for input blurring, as Safari does not support it properly

### DIFF
--- a/packages/ndla-ui/src/Frontpage/FrontpageSearch.tsx
+++ b/packages/ndla-ui/src/Frontpage/FrontpageSearch.tsx
@@ -146,13 +146,6 @@ const FrontpageSearch = ({
   }, [inputHasFocus]);
 
   const onBlur = () => {
-    setTimeout(() => {
-      if (searchFieldRef.current) {
-        if (!searchFieldRef.current.contains(document.activeElement)) {
-          onInputBlur();
-        }
-      }
-    }, 0);
     // This is needed when user tabs out of field
     if (!searchFieldValue) {
       onInputBlur();

--- a/packages/ndla-ui/src/Search/SearchField.tsx
+++ b/packages/ndla-ui/src/Search/SearchField.tsx
@@ -134,8 +134,7 @@ const SearchField = ({
             onChange('');
             onFocus?.();
             inputRef?.current?.focus();
-          }}
-          onBlur={onBlur}>
+          }}>
           {t('welcomePage.resetSearch')}
         </button>
       )}


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3343
Fixes https://github.com/NDLANO/Issues/issues/3317

Vi har hatt en lignende feil i trestruktur tidligere. I håp om at dette treffer fremtidige luringer:
Apple anser ikke knapper som noe som kan være "activeElement". Dette gjelder hele Apple-økosystemet. De mener at en bruker forventer at et input skal beholde fokus uavhengig av om man trykker på en knapp eller ei. Løsninger som dette vil med andre ord ikke fungere. Dere kan lese rasjonalet (og en spenstig krangel) her: https://bugs.webkit.org/show_bug.cgi?id=22261

Løser det ved å fjerne kodesnutten. Har ikke sett noen umiddelbare problemer med løsningen, men blir heller ikke sjokkert om det er et edge case som ikke lenger dekkes her. Søkesleeven fortjener egentlig litt ekstra kjærlighet uansett, så man kan muligens se nærmere på dette i en omskrivningsoppgave.