### PR TITLE
Sub examples of button is no longer added to storybook sidebar

### DIFF
--- a/packages/button/src/Button.stories.mdx
+++ b/packages/button/src/Button.stories.mdx
@@ -4,7 +4,7 @@ import { defaultParameters } from '../../designmanual/stories/defaults';
 import ButtonV2 from './ButtonV2';
 
 <Meta
-  title="Enkle komponenter/Button"
+  title="Enkle komponenter/Knapper/Button"
   component={ButtonV2}
   parameters={{
     ...defaultParameters,
@@ -21,7 +21,7 @@ export const Template = (args) => <ButtonV2 {...args} />;
 
 <Canvas>
   <Story
-    name="Default"
+    name="Button"
     args={{
       colorTheme: 'primary',
       children: 'Button',
@@ -36,57 +36,24 @@ export const Template = (args) => <ButtonV2 {...args} />;
 
 ### Props
 
-<ArgsTable story="Default" />
+<ArgsTable story="Button" />
 
 # Varianter
 
 ## Ghost
 
 <Canvas>
-  <Story
-    name="Ghost"
-    args={{
-      colorTheme: 'light',
-      children: 'Button',
-      size: 'normal',
-      variant: 'ghost',
-      shape: 'pill',
-      fontWeight: 'normal',
-    }}>
-    {Template.bind({})}
-  </Story>
+  <ButtonV2 colorTheme="light" children="Button" variant="ghost" shape="pill" />
 </Canvas>
 
 ## Outline
 
 <Canvas>
-  <Story
-    name="Outline"
-    args={{
-      colorTheme: 'primary',
-      children: 'Button',
-      size: 'normal',
-      variant: 'outline',
-      shape: 'normal',
-      fontWeight: 'normal',
-    }}>
-    {Template.bind({})}
-  </Story>
+  <ButtonV2 children="Button" variant="outline" />
 </Canvas>
 
 ## Link
 
 <Canvas>
-  <Story
-    name="Link"
-    args={{
-      colorTheme: 'primary',
-      children: 'Link',
-      size: 'normal',
-      variant: 'link',
-      shape: 'normal',
-      fontWeight: 'normal',
-    }}>
-    {Template.bind({})}
-  </Story>
+  <ButtonV2 children="Link" variant="link" />
 </Canvas>

--- a/packages/button/src/IconButton.stories.tsx
+++ b/packages/button/src/IconButton.stories.tsx
@@ -13,7 +13,7 @@ import { defaultParameters } from '../../designmanual/stories/defaults';
 import IconButtonV2 from './IconButtonV2';
 
 export default {
-  title: 'Enkle komponenter/IconButton',
+  title: 'Enkle komponenter/Knapper/IconButton',
   component: IconButtonV2,
   parameters: {
     ...defaultParameters,

--- a/packages/button/src/MenuButton.stories.tsx
+++ b/packages/button/src/MenuButton.stories.tsx
@@ -13,7 +13,7 @@ import { defaultParameters } from '../../designmanual/stories/defaults';
 import MenuButton from './MenuButton';
 
 export default {
-  title: 'Enkle komponenter/MenuButton',
+  title: 'Enkle komponenter/Knapper/MenuButton',
   component: MenuButton,
   parameters: {
     ...defaultParameters,

--- a/packages/button/src/MultiButton.stories.tsx
+++ b/packages/button/src/MultiButton.stories.tsx
@@ -17,7 +17,7 @@ const Wrapper = styled.div`
 `;
 
 export default {
-  title: 'Enkle komponenter/MultiButton',
+  title: 'Enkle komponenter/Knapper/MultiButton',
   component: MultiButton,
   parameters: {
     ...defaultParameters,


### PR DESCRIPTION
Noen ganger er ting bare enklere enn man skulle trodd. Fant nå ut hvordan man unngår at undereksempler i Button ikke vises i sidemenyen. Komponent-eksempler kan rendres direkte i `<Canvas>` 🤦 
 
Ny struktur:
![image](https://user-images.githubusercontent.com/17144211/202714206-62d0265f-b1a4-4b53-b594-0564da03897b.png)

Gammel struktur:
![image](https://user-images.githubusercontent.com/17144211/202714255-29324b2a-f89c-4d7e-82fc-669b777ec199.png)
