### PR TITLE
Add lodash import rule to eslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "i18next": "^21.9.2",
     "jest": "^27.5.1",
     "lerna": "^5.6.2",
+    "lodash": "^4.17.20",
     "mini-css-extract-plugin": "^0.5.0",
     "mkdirp": "^0.5.1",
     "prettier": "^2.3.2",

--- a/packages/eslint-config-ndla/base.js
+++ b/packages/eslint-config-ndla/base.js
@@ -20,7 +20,7 @@ module.exports = {
   ],
   root: true,
   parser: '@babel/eslint-parser',
-  plugins: ['react', 'react-hooks', 'import', 'jsx-a11y'],
+  plugins: ['react', 'react-hooks', 'import', 'jsx-a11y', 'lodash'],
 
   env: {
     browser: true,
@@ -126,6 +126,8 @@ module.exports = {
     'import/no-webpack-loader-syntax': 'error',
     'import/order': ['warn', { groups: [['builtin', 'external', 'internal']] }],
     'import/no-cycle': ['warn', { maxDepth: Infinity }],
+
+    'lodash/import-scope': [2, 'method'],
 
     'react/no-unused-state': 'warn',
     'react/button-has-type': 'error',

--- a/packages/eslint-config-ndla/package.json
+++ b/packages/eslint-config-ndla/package.json
@@ -25,6 +25,7 @@
     "confusing-browser-globals": "^1.0.11",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsx-a11y": "^6.6.1",
+    "eslint-plugin-lodash": "^7.4.0",
     "eslint-plugin-react": "^7.31.9",
     "eslint-plugin-react-hooks": "^4.6.0"
   }

--- a/packages/ndla-tabs/src/FilterTabs.tsx
+++ b/packages/ndla-tabs/src/FilterTabs.tsx
@@ -10,6 +10,7 @@ import React, { Component, MutableRefObject, ReactNode, KeyboardEvent, createRef
 import BEMHelper from 'react-bem-helper';
 import { ArrowDropDown } from '@ndla/icons/common';
 import debounce from 'lodash/debounce';
+// eslint-disable-next-line lodash/import-scope
 import type { DebouncedFunc } from 'lodash';
 
 const classes = BEMHelper('c-tabs');

--- a/yarn.lock
+++ b/yarn.lock
@@ -8382,6 +8382,13 @@ eslint-plugin-jsx-a11y@^6.6.1:
     minimatch "^3.1.2"
     semver "^6.3.0"
 
+eslint-plugin-lodash@^7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-7.4.0.tgz#14a761547f126c92ff56789662a20a44f8bb6290"
+  integrity sha512-Tl83UwVXqe1OVeBRKUeWcfg6/pCW1GTRObbdnbEJgYwjxp5Q92MEWQaH9+dmzbRt6kvYU1Mp893E79nJiCSM8A==
+  dependencies:
+    lodash "^4.17.21"
+
 eslint-plugin-react-hooks@^4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"


### PR DESCRIPTION
Dersom en dårlig lodash-import påvirker bundle-sizen vår burde vi si fra når folk prøver å gjøre det. Denne regelen gir deg kjeft dersom du importerer direkte fra "lodash", og ikke fra f.eks "lodash/partition".