### PR TITLE
Change modal to pixel sized definitions

### DIFF
--- a/packages/designmanual/stories/atoms/DrawerExample.tsx
+++ b/packages/designmanual/stories/atoms/DrawerExample.tsx
@@ -26,7 +26,6 @@ const positionOptions: Record<DrawerPosition, Option<DrawerPosition>> = {
 };
 
 const sizeOptions: Record<ModalSize, Option<ModalSize>> = {
-  xxsmall: { title: 'Skikkelig Liten', value: 'xxsmall' },
   xsmall: { title: 'Ekstra Liten', value: 'xsmall' },
   small: { title: 'Liten', value: 'small' },
   normal: { title: 'Vanlig', value: 'normal' },

--- a/packages/designmanual/stories/atoms/ModalV2Example.tsx
+++ b/packages/designmanual/stories/atoms/ModalV2Example.tsx
@@ -27,7 +27,6 @@ interface Option<T> {
 }
 
 const sizeOptions: Record<ModalSize, Option<ModalSize>> = {
-  xxsmall: { title: 'Skikkelig Liten', value: 'xxsmall' },
   xsmall: { title: 'Ekstra Liten', value: 'xsmall' },
   small: { title: 'Liten', value: 'small' },
   normal: { title: 'Vanlig', value: 'normal' },

--- a/packages/ndla-modal/src/ModalV2.tsx
+++ b/packages/ndla-modal/src/ModalV2.tsx
@@ -84,7 +84,8 @@ const StyledDialogContent = styled(DialogContent, { shouldForwardProp: forwardCo
   position: fixed;
   overflow-y: auto;
   background: white;
-  max-height: 100%;
+  max-height: 85%;
+  max-width: 100%;
   ${(p) => p.position !== 'center' && `${p.position}: ${p.margin}`};
   ${(p) => p.position !== 'center' && `${opposite[p.position]}: unset`};
   animation-name: ${(p) => p.animationName};

--- a/packages/ndla-modal/src/ModalV2.tsx
+++ b/packages/ndla-modal/src/ModalV2.tsx
@@ -10,7 +10,7 @@ import React, { cloneElement, MouseEvent, useMemo, useState } from 'react';
 import styled from '@emotion/styled';
 import { css, SerializedStyles } from '@emotion/react';
 import { DialogContent, DialogOverlay } from '@reach/dialog';
-import { breakpoints, mq } from '@ndla/core';
+import { breakpoints, mq, spacing } from '@ndla/core';
 import { BaseProps, ModalAnimation, ModalMargin, ModalPosition, ModalSizeType } from './types';
 import { animations } from './animations';
 import { margins, sizeCombos, sizes } from './modalStyles';
@@ -85,7 +85,7 @@ const StyledDialogContent = styled(DialogContent, { shouldForwardProp: forwardCo
   overflow-y: auto;
   background: white;
   max-height: 85%;
-  max-width: 100%;
+  max-width: 95%;
   ${(p) => p.position !== 'center' && `${p.position}: ${p.margin}`};
   ${(p) => p.position !== 'center' && `${opposite[p.position]}: unset`};
   animation-name: ${(p) => p.animationName};

--- a/packages/ndla-modal/src/ModalV2.tsx
+++ b/packages/ndla-modal/src/ModalV2.tsx
@@ -13,7 +13,7 @@ import { DialogContent, DialogOverlay } from '@reach/dialog';
 import { breakpoints, mq, spacing } from '@ndla/core';
 import { BaseProps, ModalAnimation, ModalMargin, ModalPosition, ModalSizeType } from './types';
 import { animations } from './animations';
-import { margins, sizeCombos, sizes } from './modalStyles';
+import { heights, margins, sizeCombos, sizes, widths } from './modalStyles';
 
 interface DialogProps {
   size?: ModalSizeType;
@@ -50,6 +50,7 @@ const StyledDialogOverlay = styled(DialogOverlay, { shouldForwardProp: forwardOv
 interface StyledDialogContentProps {
   position: ModalPosition;
   margin: string;
+  size: ModalSizeType;
   dialogSize: SerializedStyles;
   animationDuration: number;
   animationName: string;
@@ -78,6 +79,10 @@ const opposite = {
   bottom: 'top',
 };
 
+const getSize = (sizeType: ModalSizeType, type: 'width' | 'height') => {
+  return typeof sizeType === 'string' ? sizeType : sizeType[type];
+};
+
 const StyledDialogContent = styled(DialogContent, { shouldForwardProp: forwardContent })<StyledDialogContentProps>`
   display: flex;
   flex-direction: column;
@@ -102,6 +107,10 @@ const StyledDialogContent = styled(DialogContent, { shouldForwardProp: forwardCo
   ${(p) =>
     p.expands &&
     css`
+      width: unset;
+      height: unset;
+      min-width: ${widths[getSize(p.size, 'width')]};
+      min-height: ${heights[getSize(p.size, 'height')]};
       max-width: 100%;
       max-height: 100%;
     `};
@@ -191,6 +200,7 @@ const ModalV2 = ({
           margin={margins[modalMargin]}
           expands={expands}
           dialogSize={dialogSize}
+          size={size}
           {...rest}>
           {children(closeModal)}
         </StyledDialogContent>

--- a/packages/ndla-modal/src/modalStyles.ts
+++ b/packages/ndla-modal/src/modalStyles.ts
@@ -10,58 +10,74 @@ import { css, SerializedStyles } from '@emotion/react';
 import { spacing } from '@ndla/core';
 import { ModalMargin, ModalSize } from './types';
 
+export const widths = {
+  xsmall: '300px',
+  small: '500px',
+  normal: '700px',
+  large: '1100px',
+  full: '100%',
+};
+
+export const heights = {
+  xsmall: 'auto',
+  small: '500px',
+  normal: '700px',
+  large: '1100px',
+  full: '100%',
+};
+
 export const sizeCombos: Record<ModalSize, SerializedStyles> = {
   xsmall: css`
-    width: 300px;
+    width: ${widths.xsmall};
   `,
   small: css`
-    width: 500px;
+    width: ${widths.small};
   `,
   normal: css`
-    width: 700px;
+    width: ${widths.normal};
   `,
   large: css`
-    width: 1100px;
+    width: ${widths.large};
   `,
   full: css`
-    min-width: 100%;
-    min-height: 100%;
+    min-width: ${widths.full};
+    min-height: ${heights.full};
   `,
 };
 
 export const sizes: Record<'width' | 'height', Record<ModalSize, SerializedStyles>> = {
   width: {
     xsmall: css`
-      width: 300px;
+      width: ${widths.xsmall};
     `,
     small: css`
-      width: 500px;
+      width: ${widths.small};
     `,
     normal: css`
-      width: 700px;
+      width: ${widths.normal};
     `,
     large: css`
-      width: 1100px;
+      width: ${widths.large};
     `,
     full: css`
-      min-width: 100%;
+      width: ${widths.full};
     `,
   },
   height: {
     xsmall: css`
-      height: auto;
+      width: ${heights.xsmall};
     `,
     small: css`
-      height: 500px;
+      width: ${heights.small};
     `,
     normal: css`
-      height: 700px;
+      width: ${heights.normal};
     `,
     large: css`
-      height: 1100px;
+      width: ${heights.large};
     `,
     full: css`
-      min-height: 100%;
+      min-height: ${heights.full};
     `,
   },
 };

--- a/packages/ndla-modal/src/modalStyles.ts
+++ b/packages/ndla-modal/src/modalStyles.ts
@@ -11,90 +11,57 @@ import { spacing } from '@ndla/core';
 import { ModalMargin, ModalSize } from './types';
 
 export const sizeCombos: Record<ModalSize, SerializedStyles> = {
-  xxsmall: css`
-    min-width: 15%;
-    max-width: 15%;
-    max-height: 85%;
-  `,
   xsmall: css`
-    max-height: 85%;
-    max-width: 30%;
-    min-width: 30%;
+    width: 300px;
   `,
   small: css`
-    max-height: 85%;
-    max-width: 40%;
-    min-width: 40%;
+    width: 500px;
   `,
   normal: css`
-    max-height: 85%;
-    max-width: 60%;
-    min-width: 60%;
+    width: 700px;
   `,
   large: css`
-    max-height: 85%;
-    max-width: 80%;
-    min-width: 80%;
+    width: 1100px;
   `,
   full: css`
     min-width: 100%;
-    max-width: 100%;
     min-height: 100%;
-    max-height: 100%;
   `,
 };
 
 export const sizes: Record<'width' | 'height', Record<ModalSize, SerializedStyles>> = {
   width: {
-    xxsmall: css`
-      min-width: 15%;
-      max-width: 15%;
-    `,
     xsmall: css`
-      min-width: 30%;
-      max-width: 30%;
+      width: 300px;
     `,
     small: css`
-      min-width: 40%;
-      max-width: 40%;
+      width: 500px;
     `,
     normal: css`
-      min-width: 60%;
-      max-width: 60%;
+      width: 700px;
     `,
     large: css`
-      min-width: 80%;
-      max-width: 80%;
+      width: 1100px;
     `,
     full: css`
       min-width: 100%;
-      max-width: 100%;
     `,
   },
   height: {
-    xxsmall: css`
-      min-width: 15%;
-      max-width: 15%;
-    `,
     xsmall: css`
-      min-height: 30%;
-      max-height: 30%;
+      height: auto;
     `,
     small: css`
-      min-height: 40%;
-      max-height: 40%;
+      height: 500px;
     `,
     normal: css`
-      min-height: 60%;
-      max-height: 60%;
+      height: 700px;
     `,
     large: css`
-      min-height: 80%;
-      max-height: 80%;
+      height: 1100px;
     `,
     full: css`
       min-height: 100%;
-      max-height: 100%;
     `,
   },
 };

--- a/packages/ndla-modal/src/types.ts
+++ b/packages/ndla-modal/src/types.ts
@@ -11,7 +11,7 @@ import { DialogContentProps } from '@reach/dialog';
 import { HTMLAttributes, ReactElement, ReactNode } from 'react';
 import { animations } from './animations';
 
-export type ModalSize = 'xxsmall' | 'xsmall' | 'small' | 'normal' | 'large' | 'full';
+export type ModalSize = 'xsmall' | 'small' | 'normal' | 'large' | 'full';
 export type ModalSizeType = ModalSize | { width: ModalSize; height: ModalSize };
 export type ModalPosition = 'top' | 'center' | 'bottom' | 'left' | 'right';
 export type ModalMargin = 'none' | 'small';


### PR DESCRIPTION
Endrer litt på måten størrelsen i modaler fungerer.

Gammelt:
Størrelsene er en prosentvis del av bredde. E.g. modalens bredde varierer fra maskin til maskin.

Ny:
Har definert et par konkrete pikselstørrelser. I Modal V1 var dette i `em`, men ser det som like kurant å bruke `px` heller. Kan godt være design vil komme med innspill på dette etterhvert, men det kan justeres når den tid kommer. `px`-størrelsene er basert på det som var i Modal V1.


Hvordan teste:
Sjekk eksempler på Skuff og Modal