### PR TITLE
Change markdown wrapping from paragraph to div

### DIFF
--- a/packages/ndla-listview/src/ListItem.tsx
+++ b/packages/ndla-listview/src/ListItem.tsx
@@ -130,7 +130,7 @@ const ListItem = ({ item, clickCallback, nextItem, previousItem, viewStyle, rend
   const renderItem = () => (
     <>
       <h3 className={'item-name'}>{item.name}</h3>
-      <p className={'item-description'}>{renderMarkdown(item.description)}</p>
+      <div className={'item-description'}>{renderMarkdown(item.description)}</div>
     </>
   );
 

--- a/packages/ndla-notion/src/NotionDialog.tsx
+++ b/packages/ndla-notion/src/NotionDialog.tsx
@@ -92,7 +92,7 @@ export const NotionDialogRelatedLinks = ({ links, label }: NotionDialogRelatedLi
     </NotionDialogRelatedLinksWrapper>
   ) : null;
 
-const Paragraph = styled.p`
+const StyledDiv = styled.div`
   font-weight: ${fonts.weight.normal};
   ${fonts.sizes('18px', 1.3)};
   color: ${colors.text.primary};
@@ -102,7 +102,7 @@ const Paragraph = styled.p`
 interface NotionDialogTextProps {
   children?: ReactNode;
 }
-export const NotionDialogText = ({ children }: NotionDialogTextProps) => <Paragraph>{children}</Paragraph>;
+export const NotionDialogText = ({ children }: NotionDialogTextProps) => <StyledDiv>{children}</StyledDiv>;
 
 const NotionDialogImageWrapper = styled.div`
   display: flex;

--- a/packages/ndla-ui/src/Article/Article.tsx
+++ b/packages/ndla-ui/src/Article/Article.tsx
@@ -82,10 +82,10 @@ export const ArticleIntroduction = ({
   },
 }: ArticleIntroductionProps) => {
   if (isString(children)) {
-    return <p className="article_introduction">{parse(renderMarkdown(children))}</p>;
+    return <div className="article_introduction">{parse(renderMarkdown(children))}</div>;
   }
   if (children) {
-    return <p className="article_introduction">{children}</p>;
+    return <div className="article_introduction">{children}</div>;
   }
   return null;
 };


### PR DESCRIPTION
Vi har flere steder i applikasjonen der vi har paragrafer i paragrafer. Dette kommer av at (1) vi wrapper markdown i `<p>` og (2) markdown generer opptil flere `<p>`-tags.

Hvordan teste:
1. Link inn ndla-ui og ndla-notion i article-converter og ndla-frontend.
2. Start med lokal graphql og article-converter.
3. Sjekk ingress i artikkel og markdown-innhold i blokkforklaring i artikkel (sett inn i artikkel med blokkvisning av forklaring i ed).
4. I test skal dette resultere i paragraf i paragraf. Lokalt skal det være div utenfor paragraf.

**Nærmere eksempler:**
Inspiser ingress:
https://test.ndla.no/subject:1:4ad7fe49-b14a-4caf-8e19-ad402d1e2ce6/topic:1:30b499d3-65af-4341-872c-2b13893ff7ab/topic:1:60d636f6-fe2d-4aeb-a175-54f9b3c5f6d4/resource:1:16396

