### PR TITLE
Rewrite animations to framer-motion

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "cross-spawn": "^6.0.4",
     "css-loader": "^2.1.0",
     "eslint": "^8.27.0",
+    "framer-motion": "^6.5.1",
     "i18next": "^21.9.2",
     "jest": "^27.5.1",
     "lerna": "^5.6.2",

--- a/packages/designmanual/.storybook/main.js
+++ b/packages/designmanual/.storybook/main.js
@@ -46,6 +46,11 @@ module.exports = {
         'sass-loader',
       ],
     });
+    config.module.rules.push({
+      test: /\.mjs$/,
+      include: /node_modules/,
+      type: 'javascript/auto',
+    });
     return config;
   },
   babel: async (options) => {

--- a/packages/designmanual/package.json
+++ b/packages/designmanual/package.json
@@ -40,7 +40,6 @@
     "autoprefixer": "^9.4.7",
     "css-loader": "^2.1.0",
     "date-fns": "^1.30.1",
-    "framer-motion": "^6.5.1",
     "lazysizes": "^5.2.2",
     "pdfmake": "^0.1.51",
     "postcss-loader": "^3.0.0",

--- a/packages/designmanual/package.json
+++ b/packages/designmanual/package.json
@@ -40,6 +40,7 @@
     "autoprefixer": "^9.4.7",
     "css-loader": "^2.1.0",
     "date-fns": "^1.30.1",
+    "framer-motion": "^6.5.1",
     "lazysizes": "^5.2.2",
     "pdfmake": "^0.1.51",
     "postcss-loader": "^3.0.0",

--- a/packages/ndla-ui/package.json
+++ b/packages/ndla-ui/package.json
@@ -57,7 +57,6 @@
     "react-device-detect": "^2.2.2",
     "react-select": "^5.4.0",
     "react-swipeable": "^7.0.0",
-    "react-transition-group": "^2.5.3",
     "remarkable": "^2.0.1",
     "shave": "^2.5.10"
   },
@@ -74,7 +73,6 @@
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.11.0",
     "@types/reach__dialog": "^0.1.0",
-    "@types/react-transition-group": "^4.4.2",
     "css-loader": "^2.1.0",
     "mini-css-extract-plugin": "^0.5.0",
     "sass-loader": "^7.1.0",

--- a/packages/ndla-ui/src/Animation/DisplayOnPageYOffset.tsx
+++ b/packages/ndla-ui/src/Animation/DisplayOnPageYOffset.tsx
@@ -57,7 +57,8 @@ export default class DisplayOnPageYOffset extends Component<Props, State> {
   }
 
   render() {
-    return <Fade in={this.state.show}>{this.props.children}</Fade>;
+    const { children } = this.props;
+    return <Fade show={this.state.show}>{children}</Fade>;
   }
   static propTypes = {
     children: PropTypes.node.isRequired,

--- a/packages/ndla-ui/src/Animation/Fade.tsx
+++ b/packages/ndla-ui/src/Animation/Fade.tsx
@@ -8,7 +8,7 @@
 
 import { ReactNode, useMemo } from 'react';
 import { AnimatePresence, LazyMotion, m, domAnimation } from 'framer-motion';
-import { uniqueId } from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 
 interface Props {
   children: ReactNode;

--- a/packages/ndla-ui/src/Animation/Fade.tsx
+++ b/packages/ndla-ui/src/Animation/Fade.tsx
@@ -1,60 +1,46 @@
-import React, { ReactNode } from 'react';
-import PropTypes from 'prop-types';
-import { CSSTransition } from 'react-transition-group';
-import { CSSTransitionProps } from 'react-transition-group/CSSTransition';
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { ReactNode, useMemo } from 'react';
+import { AnimatePresence, LazyMotion, m, domAnimation } from 'framer-motion';
+import { uniqueId } from 'lodash';
 
 interface Props {
   children: ReactNode;
-  delay?: number | undefined | null;
+  delay?: number;
   timeout?: number;
-  exitDelay?: number | undefined | null;
+  exitDelay?: number;
+  show: boolean;
 }
+
+const animations = (duration: number, delayIn: number, delayOut: number) => ({
+  open: { opacity: 1, transition: { delay: delayIn / 1000, ease: 'easeInOut', duration: duration / 1000 } },
+  closed: { opacity: 0, transition: { delay: delayOut / 1000, ease: 'easeInOut', duration: duration / 1000 } },
+});
 
 const defaultTimeout = 300;
 
-const Fade = ({
-  children,
-  delay = null,
-  timeout = defaultTimeout,
-  exitDelay = null,
-  ...rest
-}: Props & Omit<CSSTransitionProps, 'timeout' | 'unmountOnExit' | 'onEnter' | 'onExit'>) => (
-  <CSSTransition
-    classNames="u-fade"
-    {...rest}
-    timeout={timeout}
-    unmountOnExit
-    onEnter={(node: HTMLElement) => {
-      const n = node;
-      n.style.transitionDuration = `${timeout}ms`;
+const Fade = ({ show, delay = 0, timeout = defaultTimeout, exitDelay = 0, children }: Props) => {
+  const id = useMemo(() => uniqueId(), []);
 
-      if (delay) {
-        n.style.transitionDelay = `${delay}ms`;
-      }
-    }}
-    onExit={
-      exitDelay
-        ? (node: HTMLElement) => {
-            const n = node;
-            n.style.transitionDelay = `${exitDelay}ms`;
-          }
-        : undefined
-    }>
-    {children}
-  </CSSTransition>
-);
+  const variants = useMemo(() => animations(timeout, delay, exitDelay), [timeout, delay, exitDelay]);
 
-Fade.propTypes = {
-  children: PropTypes.node.isRequired,
-  timeout: PropTypes.number,
-  delay: PropTypes.number,
-  exitDelay: PropTypes.number,
-};
-
-Fade.defaultProps = {
-  timeout: defaultTimeout,
-  delay: null,
-  exitDelay: null,
+  return (
+    <LazyMotion features={domAnimation}>
+      <AnimatePresence>
+        {show && (
+          <m.div key={id} initial="closed" animate="open" exit="closed" variants={variants}>
+            {children}
+          </m.div>
+        )}
+      </AnimatePresence>
+    </LazyMotion>
+  );
 };
 
 export default Fade;

--- a/packages/ndla-ui/src/Subject/SubjectShortcuts.tsx
+++ b/packages/ndla-ui/src/Subject/SubjectShortcuts.tsx
@@ -1,5 +1,12 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import React, { Component } from 'react';
-import { TransitionGroup } from 'react-transition-group';
 import styled from '@emotion/styled';
 import { colors, fonts, spacing } from '@ndla/core';
 import { Forward } from '@ndla/icons/common';
@@ -11,7 +18,7 @@ const SubjectShortcutsSection = styled.section`
   margin-bottom: ${spacing.large};
 `;
 
-const StyledTransitionGroup = styled(TransitionGroup)`
+const StyledList = styled.ul`
   display: flex;
   flex-wrap: wrap;
   list-style: none;
@@ -23,7 +30,6 @@ const StyledListItem = styled.li`
   display: block;
   margin-right: 9px;
   margin-bottom: 9px;
-
   a {
     display: block;
     background: ${colors.brand.light};
@@ -33,7 +39,6 @@ const StyledListItem = styled.li`
     font-weight: ${fonts.weight.semibold};
     color: ${colors.brand.dark};
     padding: 9px 20px;
-
     &:hover,
     &:active,
     &:focus {
@@ -52,13 +57,11 @@ const StyledButton = styled.button`
   color: ${colors.brand};
   margin-top: ${spacing.normal};
   cursor: pointer;
-
   .c-icon {
     width: 18px;
     height: 18px;
     margin-right: ${spacing.xsmall};
   }
-
   span {
     ${fonts.sizes('14px', '18px')};
   }
@@ -130,15 +133,15 @@ class SubjectShortcuts extends Component<Props, State> {
       <SubjectShortcutsSection>
         <SubjectSectionTitle>{messages.heading}</SubjectSectionTitle>
         <nav id={id}>
-          <StyledTransitionGroup component="ul">
+          <StyledList>
             {filteredLinks.map((link) => (
-              <Fade key={link.url}>
+              <Fade show={true}>
                 <StyledListItem>
                   <SafeLink to={link.url}>{link.text}</SafeLink>
                 </StyledListItem>
               </Fade>
             ))}
-          </StyledTransitionGroup>
+          </StyledList>
         </nav>
         {button}
       </SubjectShortcutsSection>

--- a/packages/ndla-ui/src/Subject/SubjectShortcuts.tsx
+++ b/packages/ndla-ui/src/Subject/SubjectShortcuts.tsx
@@ -135,7 +135,7 @@ class SubjectShortcuts extends Component<Props, State> {
         <nav id={id}>
           <StyledList>
             {filteredLinks.map((link) => (
-              <Fade show={true}>
+              <Fade key={link.url} show={true}>
                 <StyledListItem>
                   <SafeLink to={link.url}>{link.text}</SafeLink>
                 </StyledListItem>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1115,7 +1115,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.17.2", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.17.2", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
   integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
@@ -1255,6 +1255,13 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.0.tgz#c5153d50401ee3c027a57a177bc269b16d889cb7"
   integrity sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==
 
+"@emotion/is-prop-valid@^0.8.2":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
 "@emotion/is-prop-valid@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz#7f2d35c97891669f7e276eb71c83376a5dc44c83"
@@ -1272,6 +1279,11 @@
     chalk "^4.1.0"
     specificity "^0.4.1"
     stylis "4.0.13"
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
 "@emotion/memoize@^0.8.0":
   version "0.8.0"
@@ -2433,6 +2445,59 @@
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
   integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
+
+"@motionone/animation@^10.12.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@motionone/animation/-/animation-10.14.0.tgz#2f2a3517183bb58d82e389aac777fe0850079de6"
+  integrity sha512-h+1sdyBP8vbxEBW5gPFDnj+m2DCqdlAuf2g6Iafb1lcMnqjsRXWlPw1AXgvUMXmreyhqmPbJqoNfIKdytampRQ==
+  dependencies:
+    "@motionone/easing" "^10.14.0"
+    "@motionone/types" "^10.14.0"
+    "@motionone/utils" "^10.14.0"
+    tslib "^2.3.1"
+
+"@motionone/dom@10.12.0":
+  version "10.12.0"
+  resolved "https://registry.yarnpkg.com/@motionone/dom/-/dom-10.12.0.tgz#ae30827fd53219efca4e1150a5ff2165c28351ed"
+  integrity sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==
+  dependencies:
+    "@motionone/animation" "^10.12.0"
+    "@motionone/generators" "^10.12.0"
+    "@motionone/types" "^10.12.0"
+    "@motionone/utils" "^10.12.0"
+    hey-listen "^1.0.8"
+    tslib "^2.3.1"
+
+"@motionone/easing@^10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@motionone/easing/-/easing-10.14.0.tgz#d8154b7f71491414f3cdee23bd3838d763fffd00"
+  integrity sha512-2vUBdH9uWTlRbuErhcsMmt1jvMTTqvGmn9fHq8FleFDXBlHFs5jZzHJT9iw+4kR1h6a4SZQuCf72b9ji92qNYA==
+  dependencies:
+    "@motionone/utils" "^10.14.0"
+    tslib "^2.3.1"
+
+"@motionone/generators@^10.12.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@motionone/generators/-/generators-10.14.0.tgz#e05d9dd56da78a4b92db99185848a0f3db62242d"
+  integrity sha512-6kRHezoFfIjFN7pPpaxmkdZXD36tQNcyJe3nwVqwJ+ZfC0e3rFmszR8kp9DEVFs9QL/akWjuGPSLBI1tvz+Vjg==
+  dependencies:
+    "@motionone/types" "^10.14.0"
+    "@motionone/utils" "^10.14.0"
+    tslib "^2.3.1"
+
+"@motionone/types@^10.12.0", "@motionone/types@^10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@motionone/types/-/types-10.14.0.tgz#148c34f3270b175397e49c3058b33fab405c21e3"
+  integrity sha512-3bNWyYBHtVd27KncnJLhksMFQ5o2MSdk1cA/IZqsHtA9DnRM1SYgN01CTcJ8Iw8pCXF5Ocp34tyAjY7WRpOJJQ==
+
+"@motionone/utils@^10.12.0", "@motionone/utils@^10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@motionone/utils/-/utils-10.14.0.tgz#a19a3464ed35b08506747b062d035c7bc9bbe708"
+  integrity sha512-sLWBLPzRqkxmOTRzSaD3LFQXCPHvDzyHJ1a3VP9PRzBxyVd2pv51/gMOsdAcxQ9n+MIeGJnxzXBYplUHKj4jkw==
+  dependencies:
+    "@motionone/types" "^10.14.0"
+    hey-listen "^1.0.8"
+    tslib "^2.3.1"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -4308,7 +4373,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-transition-group@^4.4.0", "@types/react-transition-group@^4.4.2":
+"@types/react-transition-group@^4.4.0":
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"
   integrity sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==
@@ -7665,13 +7730,6 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
-  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-
 dom-helpers@^5.0.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
@@ -9138,6 +9196,27 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+framer-motion@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-6.5.1.tgz#802448a16a6eb764124bf36d8cbdfa6dd6b931a7"
+  integrity sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==
+  dependencies:
+    "@motionone/dom" "10.12.0"
+    framesync "6.0.1"
+    hey-listen "^1.0.8"
+    popmotion "11.0.3"
+    style-value-types "5.0.0"
+    tslib "^2.1.0"
+  optionalDependencies:
+    "@emotion/is-prop-valid" "^0.8.2"
+
+framesync@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/framesync/-/framesync-6.0.1.tgz#5e32fc01f1c42b39c654c35b16440e07a25d6f20"
+  integrity sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==
+  dependencies:
+    tslib "^2.1.0"
+
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
@@ -9786,6 +9865,11 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+hey-listen@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
+  integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
 highlight.js@^10.4.1, highlight.js@~10.7.0:
   version "10.7.3"
@@ -13731,6 +13815,16 @@ polished@^4.2.2:
   dependencies:
     "@babel/runtime" "^7.17.8"
 
+popmotion@11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-11.0.3.tgz#565c5f6590bbcddab7a33a074bb2ba97e24b0cc9"
+  integrity sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==
+  dependencies:
+    framesync "6.0.1"
+    hey-listen "^1.0.8"
+    style-value-types "5.0.0"
+    tslib "^2.1.0"
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -14370,11 +14464,6 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-react-lifecycles-compat@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
-  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-
 react-property@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-property/-/react-property-1.0.1.tgz#4ae4211557d0a0ae050a71aa8ad288c074bea4e6"
@@ -14479,16 +14568,6 @@ react-tabs@^3.2.3:
   dependencies:
     clsx "^1.1.0"
     prop-types "^15.5.0"
-
-react-transition-group@^2.5.3:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
-  integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
-  dependencies:
-    dom-helpers "^3.4.0"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
-    react-lifecycles-compat "^3.0.4"
 
 react-transition-group@^4.3.0:
   version "4.4.5"
@@ -16008,6 +16087,14 @@ style-to-object@0.3.0, style-to-object@^0.3.0:
   dependencies:
     inline-style-parser "0.1.1"
 
+style-value-types@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-5.0.0.tgz#76c35f0e579843d523187989da866729411fc8ad"
+  integrity sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==
+  dependencies:
+    hey-listen "^1.0.8"
+    tslib "^2.1.0"
+
 stylis@4.0.13:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
@@ -16475,6 +16562,11 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
+tslib@^2.3.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
Skriver om react-transition-group til framer-motion.

Fade brukes blant annet på språkvelger i masthead på fagsidene ved scroll og i eksempel for strukturredigering.

Er egentlig bare å sammenlikne at animasjonene er like.