### PR TITLE
Add workaround to ensure crop remains on round search images when scaling

### DIFF
--- a/packages/ndla-ui/src/SearchTypeResult/components/ItemTopicHeader.tsx
+++ b/packages/ndla-ui/src/SearchTypeResult/components/ItemTopicHeader.tsx
@@ -54,6 +54,7 @@ const TopicHeaderVisualElementWrapper = styled.div`
   align-items: center;
   overflow: hidden;
   border-radius: 50%;
+  -webkit-mask-image: -webkit-radial-gradient(white, black);
 `;
 
 const TopicHeaderImage = styled.img`


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3364
Er en bug i Safari (om du kan tro det).