### PR TITLE
Undo 100% image width to prevent oversized image wrappers in components

### DIFF
--- a/packages/ndla-ui/src/Image/Image.tsx
+++ b/packages/ndla-ui/src/Image/Image.tsx
@@ -39,8 +39,6 @@ const getSrcSet = (src: string, crop: ImageCrop | undefined, focalPoint: ImageFo
 
 const StyledImageWrapper = styled.div`
   position: relative;
-  width: 100%;
-  height: 100%;
 `;
 interface Props {
   alt: string;

--- a/packages/ndla-ui/src/Image/ImageLink.tsx
+++ b/packages/ndla-ui/src/Image/ImageLink.tsx
@@ -13,8 +13,6 @@ import { ImageCrop, ImageFocalPoint } from '.';
 
 const StyledLink = styled.a`
   box-shadow: inset 0 0;
-  width: 100%;
-  height: 100%;
 `;
 
 interface Props {

--- a/packages/ndla-ui/src/Image/__tests__/__snapshots__/Image-test.jsx.snap
+++ b/packages/ndla-ui/src/Image/__tests__/__snapshots__/Image-test.jsx.snap
@@ -3,8 +3,6 @@
 exports[`Image renderers correctly 1`] = `
 .emotion-0 {
   position: relative;
-  width: 100%;
-  height: 100%;
 }
 
 <div
@@ -26,8 +24,6 @@ exports[`Image renderers correctly 1`] = `
 exports[`Image with crop and focalpoint props renderers correctly 1`] = `
 .emotion-0 {
   position: relative;
-  width: 100%;
-  height: 100%;
 }
 
 <div
@@ -49,8 +45,6 @@ exports[`Image with crop and focalpoint props renderers correctly 1`] = `
 exports[`Lazyloaded image renderers correctly 1`] = `
 .emotion-0 {
   position: relative;
-  width: 100%;
-  height: 100%;
 }
 
 <div


### PR DESCRIPTION
Omgjør en endring som ble gjort for å sørge for at svg-er i concept notion ikke ble 0x0 px. Dette løses nå av containeren til det  visuelle elementet i listing frontend (egen PR)

Åpne /?path=/story/sammensatte-moduler--ressurs-fra-lenke i PR-instans og sammenlikn med prod.

Bilde skal nå se slik ut:
<img width="644" alt="image" src="https://user-images.githubusercontent.com/17144211/207316936-3b89c2dd-c5ab-4da4-8264-741b98bf76d9.png">

I designmanual har bildet masse margin som er feil: https://designmanual.ndla.sh/?path=/story/sammensatte-moduler--ressurs-fra-lenke