### PR TITLE
Fix hydration order for copyparagraph onclicks to work

### DIFF
--- a/packages/ndla-ui/src/Article/ArticleContent.tsx
+++ b/packages/ndla-ui/src/Article/ArticleContent.tsx
@@ -26,9 +26,9 @@ const ArticleContent = ({ content, locale, ...rest }: Props) => {
     removeEventListenerForResize();
     initArticleScripts();
     initAudioPlayers(locale);
-    initCopyParagraphButtons();
     initTooltips();
     initPopovers();
+    initCopyParagraphButtons();
     return () => {
       removeEventListenerForResize();
     };

--- a/packages/ndla-ui/src/CopyParagraphButton/initCopyParagraphButtons.tsx
+++ b/packages/ndla-ui/src/CopyParagraphButton/initCopyParagraphButtons.tsx
@@ -20,7 +20,7 @@ const initCopyParagraphButtons = () => {
   forEachElement('[data-header-copy-container]', (el: HTMLElement) => {
     const title = el.getAttribute('data-title');
 
-    ReactDOM.hydrate(<CopyParagraphButton title={title} content={title} hydrate={true} />, el);
+    ReactDOM.hydrate(<CopyParagraphButton title={title} content={title} hydrate />, el);
   });
 };
 


### PR DESCRIPTION
En liten triviell blemme som ga stort utfall. Er viktig at CopyParagraphButtons hydreres etter tooltips, hvis ikke fjerner tooltip dynamikken til CopyParagraphButton