### PR TITLE
Remove dialog from table

### DIFF
--- a/packages/ndla-article-scripts/src/tableScripts.js
+++ b/packages/ndla-article-scripts/src/tableScripts.js
@@ -49,24 +49,6 @@ const eventListener = (event) => {
   toggleShadows(targetEl);
 };
 
-const expandButtonEventListner = (event) => {
-  const el = event.currentTarget;
-
-  const dialogId = el.getAttribute('data-dialog-trigger-id');
-  const tableId = el.getAttribute('data-table-id');
-
-  const dialog = document.querySelector(`[data-dialog-id='${dialogId}']`);
-
-  const expandedTableWrapper = dialog.querySelector('.c-table__content');
-
-  if (!expandedTableWrapper.hasChildNodes()) {
-    const table = document.getElementById(tableId);
-    const clonedTable = table.cloneNode(true);
-    clonedTable.setAttribute('id', `${tableId}_dup`);
-    expandedTableWrapper.appendChild(clonedTable);
-  }
-};
-
 const throttledEventListner = throttle(eventListener, 100);
 
 export const initTableScript = () => {
@@ -90,8 +72,6 @@ export const initTableScript = () => {
         el.classList.remove('c-table__wrapper');
       }
     });
-
-    forEachElement('.c-table__expand-button', (el) => el.addEventListener('click', expandButtonEventListner));
   }, 0);
 };
 

--- a/packages/ndla-howto/src/StaticInfoComponents/components/Markdown.tsx
+++ b/packages/ndla-howto/src/StaticInfoComponents/components/Markdown.tsx
@@ -14,11 +14,7 @@ const Markdown = () => (
       Markdown er et språk som brukes til å formatere tekst. Nedenfor er en tabell som viser den mest nyttige syntaksen.
       Fullstendig syntaks finnes <a href="https://commonmark.org/help/">her</a>.
     </p>
-    <Table
-      messages={{
-        dialogCloseButton: 'Lukk',
-        expandButtonLabel: 'Vis stor versjon',
-      }}>
+    <Table>
       <thead>
         <tr>
           <th>Syntaks</th>

--- a/packages/ndla-ui/src/Table/Table.tsx
+++ b/packages/ndla-ui/src/Table/Table.tsx
@@ -9,31 +9,22 @@
 import React, { ReactNode } from 'react';
 import BEMHelper from 'react-bem-helper';
 
-import { uuid } from '@ndla/util';
-
 const classes = BEMHelper('c-table');
 
 interface Props {
   id?: string;
-  messages: {
-    dialogCloseButton: string;
-    expandButtonLabel: string;
-  };
   children?: ReactNode;
   dangerouslySetInnerHTML?: {
     __html: string;
   };
 }
 
-const Table = ({ children, messages, id, ...rest }: Props) => {
-  const tableId = id || uuid();
-  const dialogId = `dialog-${tableId}`;
-
+const Table = ({ children, id, ...rest }: Props) => {
   return (
     <div {...classes('wrapper')}>
       <div {...classes('content')}>
         <div {...classes('left-shadow')} />
-        <table id={tableId} {...classes({ extra: ['o-table'] })} {...rest}>
+        <table id={id} {...classes({ extra: ['o-table'] })} {...rest}>
           {children}
         </table>
         <div {...classes('right-shadow')} />

--- a/packages/ndla-ui/src/Table/Table.tsx
+++ b/packages/ndla-ui/src/Table/Table.tsx
@@ -8,10 +8,8 @@
 
 import React, { ReactNode } from 'react';
 import BEMHelper from 'react-bem-helper';
-import { ZoomOutMap } from '@ndla/icons/common';
 
 import { uuid } from '@ndla/util';
-import Dialog from '../Dialog';
 
 const classes = BEMHelper('c-table');
 
@@ -38,30 +36,8 @@ const Table = ({ children, messages, id, ...rest }: Props) => {
         <table id={tableId} {...classes({ extra: ['o-table'] })} {...rest}>
           {children}
         </table>
-        <button
-          type="button"
-          data-dialog-trigger-id={dialogId}
-          data-dialog-source-id={tableId}
-          data-table-id={tableId}
-          {...classes('expand-button')}
-          aria-label={messages.expandButtonLabel}>
-          <ZoomOutMap />
-        </button>
         <div {...classes('right-shadow')} />
       </div>
-      <Dialog
-        id={dialogId}
-        label={messages.expandButtonLabel}
-        messages={{
-          close: messages.dialogCloseButton,
-        }}
-        modifier="fullscreen">
-        <div {...classes('dialog')}>
-          <div {...classes('expanded-table-wrapper')}>
-            <div {...classes('content')} />
-          </div>
-        </div>
-      </Dialog>
     </div>
   );
 };

--- a/packages/ndla-ui/src/Table/component.tables.scss
+++ b/packages/ndla-ui/src/Table/component.tables.scss
@@ -26,39 +26,6 @@
     @include mq($from: desktop) {
       @include grids-expand(4, 6, 2);
     }
-
-    &--has-scroll {
-      .c-table {
-        padding-bottom: $spacing;
-
-        &__expand-button {
-          @include mq($from: wide) {
-            display: block;
-          }
-        }
-      }
-    }
-  }
-
-  &__expand-button {
-    display: none;
-    background: $brand-color--lighter;
-    border: 0;
-    height: 38px;
-    width: 38px;
-    border-radius: 0;
-    margin: $spacing 0 0 auto;
-  }
-
-  &__expanded-table-wrapper {
-    display: inline-block;
-    background: $white;
-    padding: $spacing--medium $spacing--medium $spacing--large $spacing--medium;
-    margin: $spacing--large;
-  }
-
-  &__dialog {
-    text-align: center;
   }
 
   &__content {

--- a/stories/molecules/SolutionExample.jsx
+++ b/stories/molecules/SolutionExample.jsx
@@ -9,12 +9,7 @@ class SolutionTableExample extends Component {
   };
 
   render = () => (
-    <Table
-      id="solutionTable"
-      messages={{
-        dialogCloseButton: 'Lukk',
-        expandButtonLabel: 'Vis stor versjon',
-      }}>
+    <Table id="solutionTable">
       <caption>Tabelltittel</caption>
       <thead>
         <tr>

--- a/stories/molecules/TableExample.jsx
+++ b/stories/molecules/TableExample.jsx
@@ -25,11 +25,7 @@ class TableExample extends Component {
   }
 
   render() {
-    return (
-      <Table id={this.tableId}>
-        {this.props.children}
-      </Table>
-    );
+    return <Table id={this.tableId}>{this.props.children}</Table>;
   }
 }
 

--- a/stories/molecules/TableExample.jsx
+++ b/stories/molecules/TableExample.jsx
@@ -3,14 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Table } from '@ndla/ui';
 import { uuid } from '@ndla/util';
-
-import {
-  addCloseDialogClickListeners,
-  addShowDialogClickListeners,
-  removeShowDialogClickListeners,
-  initTableScript,
-  removeTableEventListeners,
-} from '@ndla/article-scripts';
+import { initTableScript, removeTableEventListeners } from '@ndla/article-scripts';
 
 class TableExample extends Component {
   constructor(props) {
@@ -22,15 +15,12 @@ class TableExample extends Component {
   componentDidMount() {
     if (this.props.runScripts) {
       initTableScript();
-      addCloseDialogClickListeners();
-      addShowDialogClickListeners();
     }
   }
 
   componentWillUnmount() {
     if (this.props.runScripts) {
       removeTableEventListeners();
-      removeShowDialogClickListeners();
     }
   }
 

--- a/stories/molecules/TableExample.jsx
+++ b/stories/molecules/TableExample.jsx
@@ -26,12 +26,7 @@ class TableExample extends Component {
 
   render() {
     return (
-      <Table
-        id={this.tableId}
-        messages={{
-          dialogCloseButton: 'Lukk',
-          expandButtonLabel: 'Vis stor versjon',
-        }}>
+      <Table id={this.tableId}>
         {this.props.children}
       </Table>
     );


### PR DESCRIPTION
Fjerner dialog-visning av tabeller. Scrolling burde være nok, og det gjør det enklere å fjerne `Dialog` fullstendig. Dette kommer til å brekke snapshots i article-converter, samt at vi må fjerne noen props der.