### PR TITLE
Make aria label for the copy paragraph button screen reader friendly

### DIFF
--- a/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
+++ b/packages/ndla-ui/src/CopyParagraphButton/CopyParagraphButton.tsx
@@ -59,7 +59,7 @@ const CopyButton = ({ onClick, title, tooltip, content }: CopyButtonProps) => {
   return (
     <div>
       <Tooltip tooltip={tooltip}>
-        <IconButton onClick={onClick} data-title={title} aria-label={`${tooltip}: ${title}`}>
+        <IconButton onClick={onClick} data-title={title} aria-label={`${tooltip}: ${content}`}>
           <Link title={''} />
         </IconButton>
       </Tooltip>


### PR DESCRIPTION
Går fra å være "Kopier lenke til overskriften: Meninger-og-kunnskap-om-samfunnet" til "Koper lenke til overskriften: Meninger og kunnskap om samfunnet".