### PR TITLE
Append popover button style to head

### DIFF
--- a/packages/tooltip/src/Popover/initPopover.tsx
+++ b/packages/tooltip/src/Popover/initPopover.tsx
@@ -26,6 +26,12 @@ const initPopovers = () => {
     const inner = el.querySelector('[data-trigger]');
 
     const outerHTML = inner?.outerHTML;
+    // Popovers located inside dialogs fail to resolve their css.
+    // This is a hacky workaround, and should be removed once article-converter usage is
+    // straightened out.
+    if (el.children.length === 2) {
+      document.head.appendChild(el.children[0]);
+    }
 
     ReactDOM.hydrate(<Popover popover={popover!} hydrateHTML={outerHTML} />, el);
   });


### PR DESCRIPTION
Dette fikser problemet som oppstår når man bruker Popover inne i en `Dialog`-komponent, og er egentlig en fæl løsning. Emotion resolver en styled-komponent til to elementer: Et style-tag og den faktiske komponenten. Popover tar ikke hensyn til style-tagen, og det ender opp med at den ikke gjelder. Dette løses ved å flytte den inn i head. Hvorfor det funker fint utenfor Dialog forstår jeg ikke. 