### PR TITLE
Select - Update search filtering

### DIFF
--- a/packages/select/src/Select/BaseControl.tsx
+++ b/packages/select/src/Select/BaseControl.tsx
@@ -18,7 +18,7 @@ const StyledBaseControl = styled.div<StyledProps>`
   display: flex;
   width: 100%;
   align-items: center;
-  cursor: pointer;
+  cursor: ${({ disabled }) => (disabled ? 'auto' : 'pointer')};
   justify-content: space-between;
   border-radius: 8px;
   padding: ${spacing.small} ${spacing.normal};
@@ -41,11 +41,12 @@ const StyledBaseControl = styled.div<StyledProps>`
     outline: 2px solid ${colors.brand.dark};
   }
 
-  color: ${colors.brand.dark};
+  color: ${({ disabled }) => (disabled ? colors.brand.greyLight : colors.brand.dark)};
   border-style: solid;
   border-width: ${({ outline }) => (outline ? '1px' : '0px')};
   border-color: ${({ colorTheme }) => (colorTheme === 'blue' ? colors.brand.dark : colors.brand.light)};
-  background: ${({ colorTheme }) => (colorTheme === 'blue' ? colors.brand.lighter : colors.white)};
+  background: ${({ colorTheme, disabled }) =>
+    disabled ? colors.brand.greyMedium : colorTheme === 'blue' ? colors.brand.lighter : colors.white};
 
   & ${StyledDropdown} svg {
     ${({ menuIsOpen }) =>
@@ -64,6 +65,7 @@ interface StyledProps {
   bold?: boolean;
   required?: boolean;
   hasValue?: boolean;
+  disabled?: boolean;
 }
 
 const BaseControl = <T extends boolean>({
@@ -79,6 +81,7 @@ const BaseControl = <T extends boolean>({
     colorTheme={colorTheme}
     outline={outline}
     required={required}
+    disabled={rest.isDisabled}
     ref={innerRef}
     {...innerProps}
     {...rest}>

--- a/packages/select/src/Select/Select.tsx
+++ b/packages/select/src/Select/Select.tsx
@@ -43,6 +43,7 @@ interface Props<T extends boolean> {
   closeMenuOnSelect?: boolean;
   matchFrom?: 'any' | 'start';
   required?: boolean;
+  isDisabled?: boolean;
 }
 
 const Select = <T extends boolean>({


### PR DESCRIPTION
Enda en liten Select update...

- Det kom opp et ønske om at søk skal matche ord fra starten av ordet og ikke vise treff midt i, denne PRen fikser opp i det.
- Legger til required prop og med styling hvis ikke value er satt når Select er required
- Legger til isDisabled prop og med styling når den er satt
- fjerner closeMenuOnSelect={false} fordi den nå kan settes fra props