### PR TITLE
Add translations for favorite subject login modal

### DIFF
--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -267,6 +267,9 @@ const messages = {
     removeFavorite: 'Remove favorite subject',
     removeConfirmed: '{{subject}} is removed from your favorite subjects',
     addConfirmed: '{{subject}} is added to your favorite subjects',
+    subjectFavoritePitch: 'Do you want to favorite this subject?',
+    subjectFavoriteGuide:
+      'To favorite a subject you must log in to My NDLA. You will find the subject on the top of this page after logging in.',
     shows: 'Shows',
   },
   topicPage: {

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -327,7 +327,7 @@ const messages = {
     menuOptions: {
       programme: 'Utdanningsprogram',
       subjects: 'Fag',
-      kultidisciplinarySubjects: 'Tverrfaglige tema',
+      multidisciplinarySubjects: 'Tverrfaglige tema',
       toolboxStudents: 'Verktøykassa - for elever',
       toolboxTeachers: 'Verktøykassa - for lærere',
       film: 'NDLA Film',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -266,6 +266,9 @@ const messages = {
     removeFavorite: 'Fjern favorittfag',
     removeConfirmed: '{{subject}} er fjernet fra favorittfag',
     addConfirmed: '{{subject}} er lagt til som favorittfag',
+    subjectFavoritePitch: 'Ønsker du å favorittmerke dette faget?',
+    subjectFavoriteGuide:
+      'For å favorittmerke et fag må du logge inn på Min NDLA. Du finner faget øverst på denne siden etter at du har logget inn.',
     shows: 'Viser',
   },
   topicPage: {
@@ -324,7 +327,7 @@ const messages = {
     menuOptions: {
       programme: 'Utdanningsprogram',
       subjects: 'Fag',
-      multidisciplinarySubjects: 'Tverrfaglige tema',
+      kultidisciplinarySubjects: 'Tverrfaglige tema',
       toolboxStudents: 'Verktøykassa - for elever',
       toolboxTeachers: 'Verktøykassa - for lærere',
       film: 'NDLA Film',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -266,6 +266,9 @@ const messages = {
     removeFavorite: 'Fjern favorittfag',
     removeConfirmed: '{{subject}} er fjerna frå favorittfag',
     addConfirmed: '{{subject}} er lagt til som favorittfag',
+    subjectFavoritePitch: 'Ønsker du å favorittmerke dette faget?',
+    subjectFavoriteGuide:
+      'For å favorittmerke eit fag må du logge inn på Min NDLA. Du finner faget øverst på denne sida etter at du har logga inn.',
     shows: 'Viser',
   },
   topicPage: {

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -268,7 +268,7 @@ const messages = {
     addConfirmed: '{{subject}} er lagt til som favorittfag',
     subjectFavoritePitch: 'Ønsker du å favorittmerke dette faget?',
     subjectFavoriteGuide:
-      'For å favorittmerke eit fag må du logge inn på Min NDLA. Du finner faget øverst på denne sida etter at du har logga inn.',
+      'For å favorittmerke eit fag må du logge inn på Min NDLA. Du finn faget øverst på denne sida etter at du har logga inn.',
     shows: 'Viser',
   },
   topicPage: {

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -266,6 +266,9 @@ const messages = {
     removeFavorite: 'Fjern favorittfag',
     removeConfirmed: '{{subject}} er fjernet fra favorittfag',
     addConfirmed: '{{subject}} er lagt til som favorittfag',
+    subjectFavoritePitch: 'Ønsker du å favorittmerke dette faget?',
+    subjectFavoriteGuide:
+      'For å favorittmerke et fag må du logge inn på Min NDLA. Du finner faget øverst på denne siden etter at du har logget inn.',
     shows: 'Viser',
   },
   topicPage: {

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -266,6 +266,9 @@ const messages = {
     removeFavorite: 'Fjern favorittfag',
     removeConfirmed: '{{subject}} er fjernet fra favorittfag',
     addConfirmed: '{{subject}} er lagt til som favorittfag',
+    subjectFavoritePitch: 'Ønsker du å favorittmerke dette faget?',
+    subjectFavoriteGuide:
+      'For å favorittmerke et fag må du logge inn på Min NDLA. Du finner faget øverst på denne siden etter at du har logget inn.',
     shows: 'Viser',
   },
   topicPage: {


### PR DESCRIPTION
Se tilhørende PR i ndla-frontend https://github.com/NDLANO/ndla-frontend/pull/1267

https://trello.com/c/JFOS9m9e/296-modal-for-favorittmerking-av-fag-som-utlogget-bruker

Oversettelser er basert på denne skissen og engelsk/nynorsk er oversatt på egenhånd

![image](https://user-images.githubusercontent.com/17144211/211024092-e8a85fca-b3c6-4fb5-a096-ff99408052cb.png)
