### PR TITLE
Tooltip fixes and Resource Item a11y adjustments

### DIFF
--- a/packages/ndla-forms/src/CheckboxItem.tsx
+++ b/packages/ndla-forms/src/CheckboxItem.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import styled from '@emotion/styled';
 import { colors, fonts, spacing, utils } from '@ndla/core';
 import { uuid } from '@ndla/util';
@@ -116,26 +116,29 @@ interface Props {
   label?: string;
 }
 
-const CheckboxItem = ({ label = '', checked, value, id, onChange, disabled }: Props) => {
-  const uniqueID = uuid();
-  return (
-    <>
-      <CheckboxInput
-        disabled={disabled}
-        aria-checked={checked}
-        checked={checked}
-        type="checkbox"
-        value={value}
-        id={uniqueID}
-        name={id?.toString()}
-        onChange={() => onChange?.(id)}
-      />
-      <CheckboxLabel htmlFor={uniqueID} hasLabel={label !== ''}>
-        <span />
-        <span>{label}</span>
-      </CheckboxLabel>
-    </>
-  );
-};
+const CheckboxItem = forwardRef<HTMLInputElement, Props>(
+  ({ label = '', checked, value, id, onChange, disabled }, ref) => {
+    const uniqueID = uuid();
+    return (
+      <>
+        <CheckboxInput
+          ref={ref}
+          disabled={disabled}
+          aria-checked={checked}
+          checked={checked}
+          type="checkbox"
+          value={value}
+          id={uniqueID}
+          name={id?.toString()}
+          onChange={() => onChange?.(id)}
+        />
+        <CheckboxLabel htmlFor={uniqueID} hasLabel={label !== ''}>
+          <span />
+          <span>{label}</span>
+        </CheckboxLabel>
+      </>
+    );
+  },
+);
 
 export default CheckboxItem;

--- a/packages/ndla-ui/src/FileList/File.tsx
+++ b/packages/ndla-ui/src/FileList/File.tsx
@@ -6,7 +6,7 @@ import Tooltip from '@ndla/tooltip';
 import React from 'react';
 import { FileFormat, FileType } from './FileList';
 
-const LinkText = styled.span`
+const LinkTextWrapper = styled.div`
   & > span {
     box-shadow: inset 0 -1px;
   }
@@ -26,7 +26,7 @@ const FileLink = styled(SafeLink)`
   &:hover,
   &:focus,
   &:active {
-    ${LinkText} {
+    ${LinkTextWrapper} {
       box-shadow: none;
     }
   }
@@ -50,9 +50,9 @@ const renderFormat = (format: FileFormat, title: string, isPrimary: boolean, id:
     <FileLink key={format.url} to={format.url} target="_blank" aria-label={titleWithFormat} aria-describedby={formatId}>
       <Download />
       <Tooltip tooltip={format.tooltip}>
-        <LinkText>
+        <LinkTextWrapper>
           <span>{isPrimary ? titleWithFormat : `(${format.fileType.toUpperCase()})`}</span>
-        </LinkText>
+        </LinkTextWrapper>
       </Tooltip>
     </FileLink>
   );

--- a/packages/ndla-ui/src/ResourceGroup/ResourceItem.tsx
+++ b/packages/ndla-ui/src/ResourceGroup/ResourceItem.tsx
@@ -74,7 +74,7 @@ const ListElement = styled.li<ListElementProps>`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-right: 1rem;
+  padding: ${spacing.small};
 
   ${(props) =>
     props.additional &&
@@ -108,48 +108,12 @@ const ListElement = styled.li<ListElementProps>`
   ${({ hidden }) => hidden && `display:none; opacity:0;`}
 `;
 
-const LinkStyle = css`
-  display: flex;
-  color: ${colors.brand.dark};
-  align-items: center;
-  width: auto;
-  padding: ${spacing.small};
-  box-shadow: none;
-  min-height: 70px;
-`;
-
-const ActiveWrapper = styled.div`
-  ${LinkStyle}
-`;
 const ResourceLink = styled(SafeLink)`
-  ${LinkStyle}
-  &:hover .c-content-type-badge {
-    width: 38px;
-    height: 38px;
-
-    svg {
-      width: 20px;
-      height: 20px;
-    }
-    &.c-content-type-badge--subject-material,
-    &.c-content-type-badge--learning-path,
-    &.c-content-type-badge--source-material,
-    &.c-content-type-badge--external-learning-resources {
-      svg {
-        width: 26px;
-        height: 26px;
-      }
-    }
-  }
-`;
-
-const headingStyle = css`
   font-weight: ${fonts.weight.semibold};
-  transform: translateY(-1px);
-  text-transform: none;
-  letter-spacing: 0;
-  margin: 0;
-  display: inline;
+  box-shadow: none;
+  text-decoration: underline;
+  text-underline-offset: 5px;
+  color: ${colors.brand.dark};
   ${fonts.sizes('16px', '26px')};
   ${mq.range({ from: breakpoints.tablet })} {
     ${fonts.sizes('18px', '26px')};
@@ -157,21 +121,8 @@ const headingStyle = css`
   ${mq.range({ from: breakpoints.desktop })} {
     ${fonts.sizes('20px', '26px')};
   }
-
-  box-shadow: ${colors.link};
-
-  ${ResourceLink}:hover &,
-  ${ResourceLink}:focus & {
-    box-shadow: ${colors.linkHover};
-  }
-`;
-
-const activeHeadingStyle = css`
-  color: ${colors.brand.greyDark};
-  box-shadow: none;
-  small {
-    padding-left: ${spacing.small};
-    font-weight: ${fonts.weight.normal};
+  &:hover {
+    text-decoration: none;
   }
 `;
 
@@ -208,6 +159,40 @@ const ContentTypeName = styled.span`
   text-align: right;
 `;
 
+const InlineContainer = styled.div`
+  display: inline;
+`;
+
+const ResourceWrapper = styled.div`
+  display: flex;
+  gap: ${spacing.xsmall};
+  align-items: center;
+  :hover {
+    .c-content-type-badge {
+      width: 38px;
+      height: 38px;
+
+      svg {
+        width: 20px;
+        height: 20px;
+      }
+      &.c-content-type-badge--subject-material,
+      &.c-content-type-badge--learning-path,
+      &.c-content-type-badge--source-material,
+      &.c-content-type-badge--external-learning-resources {
+        svg {
+          width: 26px;
+          height: 26px;
+        }
+      }
+    }
+  }
+`;
+
+const CurrentSmall = styled.small`
+  margin-left: ${spacing.xsmall};
+`;
+
 type Props = {
   id: string;
   showContentTypeDescription?: boolean;
@@ -234,6 +219,10 @@ const ResourceItem = ({
   heartButton,
 }: Props & Resource) => {
   const { t } = useTranslation();
+  const accessId = `${id}-teacher`;
+  const coreId = `${id}-core`;
+  const additionalId = `${id}-additional`;
+  const describedBy = `${coreId} ${additionalId} ${accessId}`;
   const hidden = additional ? !showAdditionalResources : false;
   return (
     <ListElement
@@ -243,32 +232,28 @@ const ResourceItem = ({
       active={active}
       additional={additional}
       extraBottomMargin={extraBottomMargin}>
-      {active ? (
-        <ActiveWrapper>
-          <IconWrapper>
-            <ContentTypeBadge type={contentType ?? ''} background border={false} />
-          </IconWrapper>
-          <span css={[headingStyle, activeHeadingStyle]}>
+      <ResourceWrapper>
+        <IconWrapper>
+          <ContentTypeBadge type={contentType ?? ''} background border={false} />
+        </IconWrapper>
+        <InlineContainer>
+          <ResourceLink to={path} aria-current={active ? 'page' : undefined} aria-describedby={describedBy}>
             {name}
-            <small>{t('resource.youAreHere')}</small>
-          </span>
-        </ActiveWrapper>
-      ) : (
-        <ResourceLink to={path}>
-          <IconWrapper>
-            <ContentTypeBadge type={contentType ?? ''} background border={false} />
-          </IconWrapper>
-          <span css={headingStyle}>{name}</span>
-        </ResourceLink>
-      )}
+          </ResourceLink>
+          {active ? <CurrentSmall>{t('resource.youAreHere')}</CurrentSmall> : undefined}
+        </InlineContainer>
+      </ResourceWrapper>
       <TypeWrapper>
         {contentTypeName && <ContentTypeName>{contentTypeName}</ContentTypeName>}
         {access && access === 'teacher' && (
           <Tooltip tooltip={t('article.access.onlyTeacher')}>
-            <HumanMaleBoard
-              className="c-icon--20 u-margin-left-tiny c-topic-resource__list__additional-icons"
-              aria-label={t('article.access.onlyTeacher')}
-            />
+            <div>
+              <HumanMaleBoard
+                id={accessId}
+                aria-label={t('article.access.onlyTeacher')}
+                className="c-icon--20 u-margin-left-tiny c-topic-resource__list__additional-icons"
+              />
+            </div>
           </Tooltip>
         )}
         {showAdditionalResources && contentTypeDescription && (
@@ -277,6 +262,7 @@ const ResourceItem = ({
               <Tooltip tooltip={contentTypeDescription}>
                 <div>
                   <Additional
+                    id={additionalId}
                     className="c-icon--20 u-margin-left-tiny c-topic-resource__list__additional-icons"
                     aria-label={contentTypeDescription}
                   />
@@ -287,8 +273,9 @@ const ResourceItem = ({
               <Tooltip tooltip={contentTypeDescription}>
                 <div>
                   <Core
-                    className="c-icon--20 u-margin-left-tiny c-topic-resource__list__additional-icons"
+                    id={coreId}
                     aria-label={contentTypeDescription}
+                    className="c-icon--20 u-margin-left-tiny c-topic-resource__list__additional-icons"
                   />
                 </div>
               </Tooltip>

--- a/packages/ndla-ui/src/Search/ActiveFilterContent.tsx
+++ b/packages/ndla-ui/src/Search/ActiveFilterContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import styled from '@emotion/styled';
 import { Cross } from '@ndla/icons/action';
 import { spacing, mq, breakpoints, colors, misc, fonts } from '@ndla/core';
@@ -41,14 +41,15 @@ interface Props {
   ariaLabel: string;
 }
 
-const ActiveFilterContent = ({ filter, onFilterRemove, ariaLabel }: Props) => (
+const ActiveFilterContent = forwardRef<HTMLButtonElement, Props>(({ filter, onFilterRemove, ariaLabel }, ref) => (
   <StyledActiveFilter
     aria-label={ariaLabel}
     type="button"
+    ref={ref}
     onClick={() => onFilterRemove(filter.value, filter.filterName)}>
     <StyledActiveFilterTitle>{filter.title}</StyledActiveFilterTitle>
     <Cross />
   </StyledActiveFilter>
-);
+));
 
 export default ActiveFilterContent;

--- a/packages/ndla-ui/src/Search/ContentTypeResult.tsx
+++ b/packages/ndla-ui/src/Search/ContentTypeResult.tsx
@@ -23,7 +23,9 @@ const renderAdditionalIcon = (label: string, isAdditional?: boolean): ReactEleme
   if (isAdditional && label) {
     return (
       <Tooltip tooltip={label}>
-        <Additional className="c-icon--20" />
+        <div>
+          <Additional className="c-icon--20" aria-hidden={false} />
+        </div>
       </Tooltip>
     );
   }

--- a/packages/ndla-ui/src/SearchTypeResult/ActiveFilterContent.tsx
+++ b/packages/ndla-ui/src/SearchTypeResult/ActiveFilterContent.tsx
@@ -6,11 +6,11 @@
  *
  */
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import styled from '@emotion/styled';
 import { Cross } from '@ndla/icons/action';
 import { spacing, fonts } from '@ndla/core';
-import Button from '@ndla/button';
+import { ButtonV2 } from '@ndla/button';
 import { useTranslation } from 'react-i18next';
 
 export const StyledActiveFilterTitle = styled.span`
@@ -19,7 +19,7 @@ export const StyledActiveFilterTitle = styled.span`
   font-weight: ${fonts.weight.semibold};
 `;
 
-const StyledButton = styled(Button)`
+const StyledButton = styled(ButtonV2)`
   display: grid;
   grid-template-columns: 1fr auto;
 `;
@@ -35,21 +35,20 @@ type Props = {
   onFilterRemove: (value: string, name: string) => void;
 };
 
-const ActiveFilterContent = ({ filter, onFilterRemove }: Props) => {
+const ActiveFilterContent = forwardRef<HTMLButtonElement, Props>(({ filter, onFilterRemove }, ref) => {
   const { t } = useTranslation();
   return (
     <StyledButton
       aria-label={t('searchPage.searchFilterMessages.removeFilter', {
         filterName: filter.title,
       })}
-      type="button"
-      size="normal"
-      borderShape="rounded"
+      ref={ref}
+      shape="pill"
       onClick={() => onFilterRemove(filter.value, filter.name)}>
       <StyledActiveFilterTitle>{filter.title}</StyledActiveFilterTitle>
       <Cross />
     </StyledButton>
   );
-};
+});
 
 export default ActiveFilterContent;

--- a/packages/safelink/src/SafeLink.tsx
+++ b/packages/safelink/src/SafeLink.tsx
@@ -30,6 +30,7 @@ type Props = {
   ref?: MutableRefObject<HTMLAnchorElement | null>;
   asAnchor?: boolean;
   children?: ReactNode;
+  disabled?: boolean;
 };
 
 export type SafeLinkProps = Props & LinkProps & HTMLAttributes<HTMLElement>;
@@ -37,13 +38,20 @@ export type SafeLinkProps = Props & LinkProps & HTMLAttributes<HTMLElement>;
 // Fallback to normal link if app is missing RouterContext, link is external or is old ndla link
 
 const SafeLink = forwardRef<HTMLAnchorElement, SafeLinkProps>(
-  ({ to, replace, children, showNewWindowIcon, tabIndex, asAnchor, ...rest }, ref) => {
+  ({ to, replace, disabled, children, showNewWindowIcon, tabIndex, asAnchor, ...rest }, ref) => {
     const isMissingRouterContext = useContext(MissingRouterContext);
 
-    if (isMissingRouterContext || isExternalLink(to) || isOldNdlaLink(to) || asAnchor) {
+    if (isMissingRouterContext || isExternalLink(to) || isOldNdlaLink(to) || asAnchor || disabled) {
       const href = typeof to === 'string' ? to : '#';
       return (
-        <a href={href} ref={ref} tabIndex={tabIndex} {...rest}>
+        // eslint-disable-next-line jsx-a11y/no-redundant-roles
+        <a
+          href={disabled ? undefined : href}
+          role="link"
+          aria-disabled={disabled}
+          ref={ref}
+          tabIndex={tabIndex}
+          {...rest}>
           {children}
           {showNewWindowIcon && <LaunchIcon style={{ verticalAlign: 'text-top' }} />}
         </a>

--- a/packages/safelink/src/SafeLink.tsx
+++ b/packages/safelink/src/SafeLink.tsx
@@ -44,10 +44,9 @@ const SafeLink = forwardRef<HTMLAnchorElement, SafeLinkProps>(
     if (isMissingRouterContext || isExternalLink(to) || isOldNdlaLink(to) || asAnchor || disabled) {
       const href = typeof to === 'string' ? to : '#';
       return (
-        // eslint-disable-next-line jsx-a11y/no-redundant-roles
         <a
           href={disabled ? undefined : href}
-          role="link"
+          role={disabled ? 'link' : undefined}
           aria-disabled={disabled}
           ref={ref}
           tabIndex={tabIndex}

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -43,9 +43,11 @@ const CoreTooltip = ({ children, tooltip, className, hydrateHTML }: Props) => {
         <RadixTooltip.Trigger data-trigger asChild>
           {hydrateHTML ? parse(hydrateHTML) : children}
         </RadixTooltip.Trigger>
-        <StyledContent className={className} side={'bottom'} align={'start'} sideOffset={10}>
-          {tooltip}
-        </StyledContent>
+        <RadixTooltip.Portal>
+          <StyledContent className={className} side={'bottom'} align={'start'} sideOffset={10}>
+            {tooltip}
+          </StyledContent>
+        </RadixTooltip.Portal>
       </RadixTooltip.Root>
     </RadixTooltip.Provider>
   );


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3227
Tooltips ser ut til å bli lest opp rart av skjermleser dersom man ikke har en `Radix.Portal` rundt innholdet. Har også skrevet om `ResourceItem` ganske kraftig.

* Det aktive elementet er nå en lenke
* Fikset tooltip på `access`, `core` og `additional`. De kan ikke nås av skjermleser, men blir lest opp når man fokuserer lenken.
* `Du er her`-teksten blir nå lagt bedre inline. Konsekvensen er at `ContentTypeBadge` blir større når man hovrer `small`-teksten.