### PR TITLE
Add language tags to banner card content

### DIFF
--- a/packages/ndla-ui/src/BannerCard/BannerCard.tsx
+++ b/packages/ndla-ui/src/BannerCard/BannerCard.tsx
@@ -75,9 +75,9 @@ type ImageProps = {
 type BannerProps = {
   link: string;
   image: ImageProps;
-  title: string;
-  content: string;
-  linkText: string;
+  title: { title: string; lang?: string };
+  content: { content: string; lang?: string };
+  linkText: { text: string; lang?: string };
 };
 export const BannerCard = ({ link, title, content, linkText, image }: BannerProps) => {
   return (
@@ -86,10 +86,10 @@ export const BannerCard = ({ link, title, content, linkText, image }: BannerProp
         <StyledImage alt={image.altText} src={image.imageSrc} />
       </ImageWrapper>
       <TextWrapper>
-        <TitleText>{title}</TitleText>
-        <ContentText>{content}</ContentText>
-        <LinkText target="_self" to={link}>
-          {linkText}
+        <TitleText lang={title.lang}>{title.title}</TitleText>
+        <ContentText lang={content.lang}>{content.content}</ContentText>
+        <LinkText target="_self" to={link} lang={linkText.lang}>
+          {linkText.text}
         </LinkText>
       </TextWrapper>
     </BannerWrapper>

--- a/stories/molecules/UkraineBannerExample.tsx
+++ b/stories/molecules/UkraineBannerExample.tsx
@@ -5,9 +5,9 @@ const UkraineBannerExample = () => {
   return (
     <BannerCard
       link="/"
-      title="Lær om det norske samfunn - på ukrainsk"
-      content="Дізнайтеся про норвезьке суспільство – українською"
-      linkText="Learn about Norwegian society - in Ukrainian"
+      title={{ title: 'Lær om det norske samfunn - på ukrainsk', lang: 'nb' }}
+      content={{ content: 'Дізнайтеся про норвезьке суспільство – українською', lang: 'uk' }}
+      linkText={{ text: 'Learn about Norwegian society - in Ukrainian', lang: 'en' }}
       image={{
         altText: 'Ukrainian flag',
         imageSrc:


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3212

Vi bruker bare BannerCard et sted - på forsiden. Der er det innhold på tre forskjellige språk - norsk, engelsk og ukrainsk.