### PR TITLE
Force sans font on resource list

### DIFF
--- a/packages/ndla-ui/src/ResourceGroup/ResourceList.tsx
+++ b/packages/ndla-ui/src/ResourceGroup/ResourceList.tsx
@@ -10,6 +10,7 @@ import React, { ReactNode } from 'react';
 import styled from '@emotion/styled';
 import { css, keyframes } from '@emotion/react';
 import { useTranslation } from 'react-i18next';
+import { fonts } from '@ndla/core';
 import NoContentBox from '../NoContentBox';
 import ResourceItem from './ResourceItem';
 import { Resource } from '../types';
@@ -33,6 +34,7 @@ const StyledResourceList = styled.ul<StyledListProps>`
   list-style: none;
   margin: 0;
   padding: 0;
+  font-family: ${fonts.sans};
   ${({ showAdditionalResources }) =>
     showAdditionalResources &&
     css`


### PR DESCRIPTION
Før var all tekst stylet med heading-style. Når det forsvinner tar den stylen fra c-article, som har serif som default.