### PR TITLE
Add subjects translation

### DIFF
--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -672,6 +672,7 @@ const messages = {
   contentTypes: {
     all: 'All',
     subject: 'Subject',
+    subjects: 'Subjects',
     'topic-article': 'Topic article',
     'learning-path': 'Learning path',
     'subject-material': 'Subject material',

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -14,6 +14,10 @@ export const { contentTypes, subjectCategories, subjectTypes } = constants;
 const titleTemplate = ' - NDLA';
 
 const messages = {
+  common: {
+    subject: 'Subject',
+    subject_plural: 'Subjects',
+  },
   treeStructure: {
     folderChildOptions: {
       edit: 'Edit foldername',
@@ -672,7 +676,6 @@ const messages = {
   contentTypes: {
     all: 'All',
     subject: 'Subject',
-    subjects: 'Subjects',
     'topic-article': 'Topic article',
     'learning-path': 'Learning path',
     'subject-material': 'Subject material',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -671,6 +671,7 @@ const messages = {
   contentTypes: {
     all: 'Alle',
     subject: 'Fag',
+    subjects: 'Fag',
     'topic-article': 'Emne',
     'learning-path': 'Læringssti',
     'subject-material': 'Fagstoff',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -14,6 +14,10 @@ export const { contentTypes, subjectCategories, subjectTypes } = constants;
 const titleTemplate = ' - NDLA';
 
 const messages = {
+  common: {
+    subject: 'Fag',
+    subject_plural: 'Fag',
+  },
   treeStructure: {
     folderChildOptions: {
       edit: 'Endre mappenavn',
@@ -671,7 +675,6 @@ const messages = {
   contentTypes: {
     all: 'Alle',
     subject: 'Fag',
-    subjects: 'Fag',
     'topic-article': 'Emne',
     'learning-path': 'Læringssti',
     'subject-material': 'Fagstoff',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -14,6 +14,10 @@ export const { contentTypes, subjectCategories, subjectTypes } = constants;
 const titleTemplate = ' - NDLA';
 
 const messages = {
+  common: {
+    subject: 'Fag',
+    subject_plural: 'Fag',
+  },
   treeStructure: {
     folderChildOptions: {
       edit: 'Endre mappenamn',
@@ -671,7 +675,6 @@ const messages = {
   contentTypes: {
     all: 'Alle',
     subject: 'Fag',
-    subjects: 'Fag',
     'topic-article': 'Emne',
     'learning-path': 'Læringssti',
     'subject-material': 'Fagstoff',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -671,6 +671,7 @@ const messages = {
   contentTypes: {
     all: 'Alle',
     subject: 'Fag',
+    subjects: 'Fag',
     'topic-article': 'Emne',
     'learning-path': 'Læringssti',
     'subject-material': 'Fagstoff',

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -16,7 +16,7 @@ const titleTemplate = ' - NDLA';
 const messages = {
   common: {
     subject: 'Fága',
-    subject_plural: 'Fágat,
+    subject_plural: 'Fágat',
   },
   treeStructure: {
     folderChildOptions: {

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -672,6 +672,7 @@ const messages = {
   contentTypes: {
     all: 'Buot',
     subject: 'Fága',
+    subjects: 'Fag',
     'topic-article': 'Fáddá',
     'learning-path': 'Oahppanbálggis',
     'subject-material': 'Fágaávdnasat',

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -14,6 +14,10 @@ export const { contentTypes, subjectCategories, subjectTypes } = constants;
 const titleTemplate = ' - NDLA';
 
 const messages = {
+  common: {
+    subject: 'Fag',
+    subject_plural: 'Fag',
+  },
   treeStructure: {
     folderChildOptions: {
       edit: 'Rievdat máhpa nama',
@@ -672,7 +676,6 @@ const messages = {
   contentTypes: {
     all: 'Buot',
     subject: 'Fága',
-    subjects: 'Fag',
     'topic-article': 'Fáddá',
     'learning-path': 'Oahppanbálggis',
     'subject-material': 'Fágaávdnasat',

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -15,8 +15,8 @@ const titleTemplate = ' - NDLA';
 
 const messages = {
   common: {
-    subject: 'Fag',
-    subject_plural: 'Fag',
+    subject: 'Fága',
+    subject_plural: 'Fágat,
   },
   treeStructure: {
     folderChildOptions: {

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -675,6 +675,7 @@ const messages = {
   contentTypes: {
     all: 'Alle',
     subject: 'Faagem',
+    subjectTypes: 'Fag',
     'topic-article': 'Teema',
     'learning-path': 'Lïeremebaalka',
     'subject-material': 'Faage-aamhtese',

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -14,6 +14,10 @@ export const { contentTypes, subjectCategories, subjectTypes } = constants;
 const titleTemplate = ' - NDLA';
 
 const messages = {
+  common: {
+    subject: 'Fag',
+    subject_plural: 'Fag',
+  },
   treeStructure: {
     folderChildOptions: {
       edit: 'Endre mappenavn',
@@ -675,7 +679,6 @@ const messages = {
   contentTypes: {
     all: 'Alle',
     subject: 'Faagem',
-    subjects: 'Fag',
     'topic-article': 'Teema',
     'learning-path': 'Lïeremebaalka',
     'subject-material': 'Faage-aamhtese',

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -675,7 +675,7 @@ const messages = {
   contentTypes: {
     all: 'Alle',
     subject: 'Faagem',
-    subjectTypes: 'Fag',
+    subjects: 'Fag',
     'topic-article': 'Teema',
     'learning-path': 'Lïeremebaalka',
     'subject-material': 'Faage-aamhtese',


### PR DESCRIPTION
Legger til oversettelser på filter i fagsiden. Det ble litt rart når det sto "Active subject" og ikke "Active subjects". Se også tilhørende PR https://github.com/NDLANO/ndla-frontend/pull/1278

<img width="664" alt="image" src="https://user-images.githubusercontent.com/17144211/213679313-32d331fa-f5ac-4e9e-8775-2ef344cd5963.png">
