### PR TITLE
Bedre håndtering av boks som lenke

### DIFF
--- a/packages/button/src/MenuButton.tsx
+++ b/packages/button/src/MenuButton.tsx
@@ -126,24 +126,13 @@ export const MenuButton = ({
         tabIndex={tabIndex}
         className={className}
         svgSize={svgSizes[size || 'normal']}
-        onClick={(e) => {
-          e.stopPropagation();
-          e.preventDefault();
-        }} // Prevent redirect from triggering when placed inside <a>
         {...rest}>
         <MenuIconWrapper svgSize={svgSizes[size || 'normal']}>{menuIcon || <StyledHorizontalMenu />}</MenuIconWrapper>
       </StyledMenuButton>
       <DropdownMenu.Portal>
         <StyledMenuItems align={align}>
           {menuItems?.map(({ type, text, icon, onClick }) => (
-            <StyledMenuItem
-              key={text}
-              onClick={(e) => {
-                onClick(e);
-                e.stopPropagation();
-              }}
-              type={type}
-              aria-label={text}>
+            <StyledMenuItem key={text} onClick={onClick} type={type} aria-label={text}>
               {icon}
               {text}
             </StyledMenuItem>

--- a/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
@@ -13,8 +13,8 @@ import { FileDocumentOutline } from '@ndla/icons/common';
 import { fonts, spacing, colors, mq, breakpoints } from '@ndla/core';
 import { css } from '@emotion/react';
 import { useTranslation } from 'react-i18next';
-import SafeLink from '@ndla/safelink';
 import { MenuButton, MenuItemProps } from '@ndla/button';
+import { ResourceTitleLink } from '../../Resource/resourceComponents';
 
 type LayoutType = 'list' | 'listLarger' | 'block';
 interface LayoutProps {
@@ -73,12 +73,6 @@ const IconWrapper = styled.div`
   }
 `;
 
-const StyledLink = styled(SafeLink)`
-  box-shadow: none;
-  color: ${colors.brand.primary};
-  flex: 1;
-`;
-
 const FolderTitle = styled.h2`
   ${fonts.sizes('16px', '20px')};
   font-weight: ${fonts.weight.semibold};
@@ -106,6 +100,7 @@ interface MenuWrapperProps {
 const MenuWrapper = styled.div<MenuWrapperProps>`
   overflow: hidden;
   display: flex;
+  z-index: 1;
   flex-direction: row;
   align-items: center;
   gap: ${spacing.xsmall};
@@ -174,19 +169,15 @@ const Folder = ({ id, link, title, subFolders, subResources, type = 'list', menu
   const { t } = useTranslation();
   const linkRef = useRef<HTMLAnchorElement | null>(null);
 
-  const onClick = () => {
-    linkRef?.current?.click();
-  };
-
   return (
-    <FolderWrapper type={type} onClick={onClick} id={id}>
+    <FolderWrapper type={type} id={id}>
       <TitleWrapper>
         <IconWrapper>
           <FolderOutlined aria-label={t('myNdla.folder.folder')} />
         </IconWrapper>
-        <StyledLink to={link} ref={linkRef}>
+        <ResourceTitleLink to={link} ref={linkRef}>
           <FolderTitle title={title}>{title}</FolderTitle>
-        </StyledLink>
+        </ResourceTitleLink>
       </TitleWrapper>
       <MenuWrapper hasMenuButton={!!menuItems?.length}>
         <CountContainer>

--- a/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
@@ -168,7 +168,6 @@ interface Props {
 
 const Folder = ({ id, link, title, subFolders, subResources, type = 'list', menuItems }: Props) => {
   const { t } = useTranslation();
-  const linkRef = useRef<HTMLAnchorElement | null>(null);
 
   return (
     <FolderWrapper type={type} id={id}>
@@ -176,7 +175,7 @@ const Folder = ({ id, link, title, subFolders, subResources, type = 'list', menu
         <IconWrapper>
           <FolderOutlined aria-label={t('myNdla.folder.folder')} />
         </IconWrapper>
-        <ResourceTitleLink to={link} ref={linkRef}>
+        <ResourceTitleLink to={link}>
           <FolderTitle title={title}>{title}</FolderTitle>
         </ResourceTitleLink>
       </TitleWrapper>

--- a/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
@@ -23,6 +23,7 @@ interface LayoutProps {
 
 const FolderWrapper = styled.div<LayoutProps>`
   display: flex;
+  position: relative;
   align-items: center;
   justify-content: space-between;
   padding: ${spacing.nsmall};

--- a/packages/ndla-ui/src/Resource/BlockResource.tsx
+++ b/packages/ndla-ui/src/Resource/BlockResource.tsx
@@ -27,6 +27,7 @@ import { contentTypeMapping } from '../model/ContentType';
 
 const BlockElementWrapper = styled.div`
   display: flex;
+  position: relative;
   text-decoration: none;
   box-shadow: none;
   flex-direction: column;
@@ -67,6 +68,7 @@ const BlockDescription = styled.p`
 `;
 
 const RightRow = styled(Row)`
+  z-index: 1;
   justify-content: flex-end;
   margin: 0 -${spacing.small} -${spacing.small} 0;
 `;

--- a/packages/ndla-ui/src/Resource/BlockResource.tsx
+++ b/packages/ndla-ui/src/Resource/BlockResource.tsx
@@ -164,18 +164,11 @@ const BlockResource = ({
   targetBlank,
   resourceTypes,
 }: Props) => {
-  const linkRef = useRef<HTMLAnchorElement>(null);
   const firstResourceType = resourceTypes?.[0]?.id ?? '';
   const Title = ResourceTitle.withComponent(headingLevel);
 
-  const handleClick = () => {
-    if (linkRef.current) {
-      linkRef.current.click();
-    }
-  };
-
   return (
-    <BlockElementWrapper onClick={handleClick} id={id}>
+    <BlockElementWrapper id={id}>
       <ImageWrapper>
         <BlockImage
           image={resourceImage}
@@ -186,7 +179,7 @@ const BlockResource = ({
       <BlockInfoWrapper>
         <ContentWrapper>
           <ResourceTypeAndTitleLoader loading={isLoading}>
-            <ResourceTitleLink title={title} target={targetBlank ? '_blank' : undefined} to={link} ref={linkRef}>
+            <ResourceTitleLink title={title} target={targetBlank ? '_blank' : undefined} to={link}>
               <Title>{title}</Title>
             </ResourceTitleLink>
           </ResourceTypeAndTitleLoader>

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -219,7 +219,6 @@ const ListResource = ({
 }: ListResourceProps) => {
   const showDescription = description !== undefined;
   const imageType = showDescription ? 'normal' : 'compact';
-  const linkRef = useRef<HTMLAnchorElement>(null);
   const firstContentType = resourceTypes?.[0]?.id ?? '';
   const Title = ResourceTitle.withComponent(headingLevel);
 
@@ -235,7 +234,7 @@ const ListResource = ({
       </ImageWrapper>
       <TopicAndTitleWrapper>
         <TypeAndTitleLoader loading={isLoading}>
-          <StyledLink to={link} target={targetBlank ? '_blank' : undefined} ref={linkRef}>
+          <StyledLink to={link} target={targetBlank ? '_blank' : undefined}>
             <Title title={title}>{title}</Title>
           </StyledLink>
           <ResourceTypeList resourceTypes={resourceTypes} />

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -27,6 +27,7 @@ import { contentTypeMapping } from '../model/ContentType';
 const ListResourceWrapper = styled.div`
   flex: 1;
   display: grid;
+  position: relative;
   grid-template-columns: auto minmax(50px, 1fr) auto;
   grid-template-areas:
     'image  topicAndTitle   tags'
@@ -101,6 +102,7 @@ interface TagsAndActionProps {
 
 const TagsandActionMenu = styled.div<TagsAndActionProps>`
   grid-area: tags;
+  z-index: 1;
   box-sizing: content-box;
   display: grid;
   grid-template-columns: 1fr auto auto;
@@ -220,14 +222,9 @@ const ListResource = ({
   const linkRef = useRef<HTMLAnchorElement>(null);
   const firstContentType = resourceTypes?.[0]?.id ?? '';
   const Title = ResourceTitle.withComponent(headingLevel);
-  const handleClick = () => {
-    if (linkRef.current) {
-      linkRef.current.click();
-    }
-  };
 
   return (
-    <ListResourceWrapper onClick={handleClick} id={id}>
+    <ListResourceWrapper id={id}>
       <ImageWrapper imageSize={imageType}>
         <ListResourceImage
           resourceImage={resourceImage}

--- a/packages/ndla-ui/src/Resource/resourceComponents.tsx
+++ b/packages/ndla-ui/src/Resource/resourceComponents.tsx
@@ -23,6 +23,16 @@ export interface ResourceImageProps {
 export const ResourceTitleLink = styled(SafeLink)`
   box-shadow: none;
   color: ${colors.brand.primary};
+  flex: 1;
+  :after {
+    content: '';
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
 `;
 
 export const ResourceTitle = styled.h2`
@@ -131,9 +141,7 @@ export const TagList = ({ tags, tagLinkPrefix }: TagListProps) => {
     <StyledTagList aria-label={t('myNdla.tagList')}>
       {tags.map((tag, i) => (
         <StyledTagListElement key={`tag-${i}`}>
-          <StyledSafeLink
-            onClick={(e: MouseEvent<HTMLAnchorElement | HTMLElement>) => e.stopPropagation()}
-            to={`${tagLinkPrefix ? tagLinkPrefix : ''}/${encodeURIComponent(tag)}`}>
+          <StyledSafeLink to={`${tagLinkPrefix ? tagLinkPrefix : ''}/${encodeURIComponent(tag)}`}>
             <HashTag />
             {tag}
           </StyledSafeLink>


### PR DESCRIPTION
Hele containeren til ressurser og mapper fungerer som lenker, men fant ut at ctrl-klikk (åpne i ny fane ikke fungerer) og løsningen per nå krevde mye stopPropagation og preventDefault.

Har funnet en alternativ og bedre løsning der lenken får en usynlig `:after` som dekker hele containeren OG ekstra knapper fungerer fint uten stopPropagation og preventDefault.

Test:
1. Åpne PR-instans.
2. Åpne ?path=/docs/enkle-komponenter-ressurser-blockresource--block-resource
3. Endre lenken til feks https://google.com
4. Trykk på menyknapp eller tag. Det skal ikke trigge redirect til google
5. ctrl-klikk på ressurs. Det skal åpne google i ny fane
6. Trykk på ressurs. Det skal gå til google i samme fane.

Kan også testes ved å linke inn ndla-ui og button i article-converter