### PR TITLE
Multiselect input fixes

### DIFF
--- a/packages/select/src/Select/BaseMultiValue.tsx
+++ b/packages/select/src/Select/BaseMultiValue.tsx
@@ -6,30 +6,12 @@
  *
  */
 import React from 'react';
-import isArray from 'lodash/isArray';
-import { useTranslation } from 'react-i18next';
 import { MultiValueProps } from 'react-select';
 import { Option } from './types';
-import { TextEllipsis } from './BasePlaceholder';
+import { TextEllipsis } from './BaseSingleValue';
 
-const BaseMultiValue = <T extends boolean>({
-  selectProps: { value, postfix },
-  data,
-  children,
-}: MultiValueProps<Option, T>) => {
-  const { t } = useTranslation();
-
-  const count = isArray(value) ? value.length : 0;
-  const isLastItem = isArray(value) && data === value[count - 1];
-
-  if (count === 1) return <TextEllipsis>{children}</TextEllipsis>;
-  if (isLastItem)
-    return (
-      <TextEllipsis>
-        {t('dropdown.selected', { count })} <span>{postfix}</span>
-      </TextEllipsis>
-    );
-  return null;
+const BaseMultiValue = <T extends boolean>({ children }: MultiValueProps<Option, T>) => {
+  return <TextEllipsis>{children}</TextEllipsis>;
 };
 
 export default BaseMultiValue;

--- a/packages/select/src/Select/BasePlaceholder.tsx
+++ b/packages/select/src/Select/BasePlaceholder.tsx
@@ -8,14 +8,8 @@
 
 import React from 'react';
 import { PlaceholderProps } from 'react-select';
-import styled from '@emotion/styled';
 import { Option } from './types';
-
-export const TextEllipsis = styled.span`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`;
+import { TextEllipsis } from './BaseSingleValue';
 
 const BasePlaceholder = <T extends boolean>({ children, innerProps }: PlaceholderProps<Option, T>) => (
   <TextEllipsis {...innerProps}>{children}</TextEllipsis>

--- a/packages/select/src/Select/BaseSingleValue.tsx
+++ b/packages/select/src/Select/BaseSingleValue.tsx
@@ -12,9 +12,10 @@ import { fonts } from '@ndla/core';
 import { GroupBase, SingleValueProps } from 'react-select';
 import { Option } from './types';
 
-const StyledSingleValue = styled.div`
+export const TextEllipsis = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
+  grid-area: 1 / 1 / 2 / 3;
   white-space: nowrap;
 `;
 
@@ -34,13 +35,13 @@ const BaseSingleValue = <T extends boolean>({
   children,
 }: StyledProps & SingleValueProps<Option, T, GroupBase<Option>>) => {
   return (
-    <StyledSingleValue {...innerProps}>
+    <TextEllipsis {...innerProps}>
       <StyledPostfix small={small} bold={bold}>
         {prefix}
       </StyledPostfix>
       {children}
       <span>{postfix}</span>
-    </StyledSingleValue>
+    </TextEllipsis>
   );
 };
 

--- a/packages/select/src/Select/Select.stories.tsx
+++ b/packages/select/src/Select/Select.stories.tsx
@@ -30,7 +30,7 @@ export default {
 export const SelectStory: ComponentStory<typeof Select> = (args) => {
   return (
     <div style={{ display: 'flex' }}>
-      <Select {...args} placeholder="Velg en farge" />
+      <Select {...args} />
     </div>
   );
 };

--- a/packages/select/src/Select/Select.tsx
+++ b/packages/select/src/Select/Select.tsx
@@ -72,7 +72,6 @@ const Select = <T extends boolean>({
       menuPlacement={menuPlacement}
       hideSelectedOptions={false}
       unstyled
-      backspaceRemovesValue={!isMulti}
       menuPortalTarget={portalTarget}
       filterOption={matchFrom === 'start' ? createFilter({ matchFrom: 'start' }) : undefined}
       styles={{ menuPortal: (base) => ({ ...base, zIndex: 99999 }) }}

--- a/packages/select/src/Select/Select.tsx
+++ b/packages/select/src/Select/Select.tsx
@@ -55,6 +55,7 @@ const Select = <T extends boolean>({
   isSearchable = false,
   groupTitle,
   matchFrom = 'start',
+  isMulti,
   ...rest
 }: Props<T>) => {
   const portalTarget = useMemo(() => (typeof document !== 'undefined' ? document?.querySelector('body') : null), []);
@@ -63,6 +64,7 @@ const Select = <T extends boolean>({
   return (
     <ReactSelect<Option, T>
       {...rest}
+      isMulti={isMulti}
       options={customOption}
       colorTheme={colorTheme}
       aria-label={label}
@@ -70,6 +72,7 @@ const Select = <T extends boolean>({
       menuPlacement={menuPlacement}
       hideSelectedOptions={false}
       unstyled
+      backspaceRemovesValue={!isMulti}
       menuPortalTarget={portalTarget}
       filterOption={matchFrom === 'start' ? createFilter({ matchFrom: 'start' }) : undefined}
       styles={{ menuPortal: (base) => ({ ...base, zIndex: 99999 }) }}

--- a/packages/select/src/Select/ValueContainer.tsx
+++ b/packages/select/src/Select/ValueContainer.tsx
@@ -9,15 +9,41 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { ValueContainerProps } from 'react-select';
+import isArray from 'lodash/isArray';
+import { useTranslation } from 'react-i18next';
 import { Option } from './types';
+import { TextEllipsis } from './BaseSingleValue';
 
-const StyledMultiValue = styled.div`
-  display: flex;
+const StyledValueContainer = styled.div`
+  display: grid;
   min-width: 0;
   align-items: center;
 `;
 
-const ValueContainer = <T extends boolean>({ innerProps, children }: ValueContainerProps<Option, T>) => (
-  <StyledMultiValue {...innerProps}>{children}</StyledMultiValue>
-);
+const ValueContainer = <T extends boolean>({
+  selectProps: { postfix },
+  innerProps,
+  children,
+}: ValueContainerProps<Option, T>) => {
+  const { t } = useTranslation();
+
+  if (isArray(children)) {
+    const [values, input] = children;
+    const isTyping = input?.props.value;
+
+    if (values && values.length > 1) {
+      return (
+        <StyledValueContainer>
+          {!isTyping && (
+            <TextEllipsis>
+              {t('dropdown.selected', { count: values.length })} <span>{postfix}</span>
+            </TextEllipsis>
+          )}
+          {input}
+        </StyledValueContainer>
+      );
+    }
+  }
+  return <StyledValueContainer {...innerProps}>{children}</StyledValueContainer>;
+};
 export default ValueContainer;


### PR DESCRIPTION
Oppdaget at søk på multiselect førte til at input dukket opp direkte etter select sin verdi. Følger heller samme mønster som for singleselect der verdien skjules når brukeren skriver et søk.

Hvordan teste:
1. Åpne Select story og test alle kombinasjoner av isSearchable og isMulti
2. Sjekk at markør alltid plasseres til venstre i boksen og at value skjules mens brukeren skriver noe (Når isSearchable)


Gammel:
![image](https://user-images.githubusercontent.com/17144211/214550368-04e66f07-1813-43e2-a7a8-2e848228a0a4.png)

Ny ("2 valgte" skjules når brukeren skriver noe):
![image](https://user-images.githubusercontent.com/17144211/214550847-f4c50d91-9991-4eaf-b78b-4572e79b234e.png)



