### PR TITLE
Change ItemBoxInput width to auto to limit growth

### DIFF
--- a/packages/ndla-forms/src/CheckboxItem.tsx
+++ b/packages/ndla-forms/src/CheckboxItem.tsx
@@ -14,6 +14,7 @@ import { uuid } from '@ndla/util';
 const CheckboxInput = styled.input`
   position: absolute;
   opacity: 0;
+  width: auto;
   cursor: pointer;
   &:checked {
     & + label > span:first-of-type {


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/3429

![image](https://user-images.githubusercontent.com/35299038/215055614-6eb2a568-f195-490b-8c2a-819277473160.png)
Trykkefeltet til checkboxen strekker seg over hele den svarte linjen i bildet over. Fikset width på input objektet til å være auto som da limiter den til å kun være innenfor checkbox elementet.
CheckboxItem brukes kun i en setting og det er i denne hvor den viser filer og er en gammel komponent så trenger ikke mer omfattende forandring. 