### PR TITLE
Design changes to Notion with updates to colors

### DIFF
--- a/packages/core/scss/global/settings/settings.colors.scss
+++ b/packages/core/scss/global/settings/settings.colors.scss
@@ -76,6 +76,9 @@ $subjecttype-background: $brand-color--dark;
 $subjecttype-light: #fff;
 $subjecttype-dark: $brand-color--dark;
 
+$notion-dark: #3E5860;
+$notion-light: #DEF1ED;
+
 /**
  * Supplementary colors,
  */

--- a/packages/core/src/colors.ts
+++ b/packages/core/src/colors.ts
@@ -69,6 +69,11 @@ const colors = {
     additional: 'rgba(220,229,224,0.4)',
   },
 
+  notion: {
+    light: '#DEF1ED',
+    dark: '#3E5860'
+  },
+
   tasksAndActivities: {
     background: '#f8e0c4',
     light: '#fbeddc',

--- a/packages/core/src/colors.ts
+++ b/packages/core/src/colors.ts
@@ -71,7 +71,7 @@ const colors = {
 
   notion: {
     light: '#DEF1ED',
-    dark: '#3E5860'
+    dark: '#3E5860',
   },
 
   tasksAndActivities: {

--- a/packages/ndla-notion/src/Notion.tsx
+++ b/packages/ndla-notion/src/Notion.tsx
@@ -6,9 +6,8 @@
  *
  */
 
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import styled from '@emotion/styled';
-import { ShortText } from '@ndla/icons/common';
 import { Interpolation } from '@emotion/react';
 import { createUniversalPortal } from '@ndla/util';
 import { colors } from '@ndla/core';
@@ -16,14 +15,8 @@ import { useTranslation } from 'react-i18next';
 import Tooltip from '@ndla/tooltip';
 import NotionDialog from './NotionDialog';
 
-const BaselineIcon = styled(ShortText)`
-  position: absolute;
-  margin: calc(0.5em + 1px) auto 0;
-  left: -2px;
-  color: ${colors.brand.secondary};
-  height: 1.1em;
-  width: 1.1em;
-  transition-duration: 0.5s;
+const BaselineIcon = styled.div`
+  border-bottom: 5px double currentColor;
 `;
 
 const StyledButton = styled.button`
@@ -35,17 +28,26 @@ const StyledButton = styled.button`
   padding: 0 0 4px 0;
   margin-bottom: -4px;
   text-decoration: none;
-  color: #000;
   position: relative;
+  text-align: left;
+  display: inline;
+  color: ${colors.notion.dark};
   cursor: pointer;
   &:focus,
   &:hover {
-    color: ${colors.brand.primary};
+    background-color: ${colors.notion.dark};
+    color: ${colors.white};
     outline: none;
     ${BaselineIcon} {
-      color: ${colors.brand.primary};
-      transform: scale(1.2, 1);
-      transform-origin: top left;
+      border-color: transparent;
+    }
+  }
+
+  &:active {
+    color: ${colors.notion.dark};
+    background-color: ${colors.notion.light};
+    ${BaselineIcon} {
+      border-color: currentColor;
     }
   }
 `;


### PR DESCRIPTION
Endring i design på Begrepslenker iht.: 
![image](https://user-images.githubusercontent.com/95403765/215487326-11c45630-f4c7-4b2e-b068-5df95162de93.png)

La til to nye farger i colors.ts i Core for å få det nye designet på plass. 

