### PR TITLE
Coniditional CSS for footer link depending on screen size

### DIFF
--- a/packages/ndla-ui/src/Footer/FooterPrivacy.tsx
+++ b/packages/ndla-ui/src/Footer/FooterPrivacy.tsx
@@ -34,6 +34,9 @@ const StyledLinkSpacer = styled.span`
   margin-left: ${spacing.xxsmall};
   margin-right: ${spacing.xxsmall};
   margin-bottom: ${spacing.large};
+  ${mq.range({ until: breakpoints.mobileWide })} {
+    visibility: hidden;
+  }
 `;
 
 const StyledFooterText = styled.div`
@@ -56,6 +59,7 @@ const StyledFooterText = styled.div`
     > span {
       padding-bottom: ${spacing.xsmall};
     }
+    flex-direction: column;
   }
   margin-bottom: ${spacing.large};
 `;

--- a/stories/molecules/footers.jsx
+++ b/stories/molecules/footers.jsx
@@ -11,6 +11,10 @@ const FooterExample = ({ inverted, t, hideLanguageSelector, i18n, isAuthenticate
   const privacyLinks = [
     { label: t('footer.privacyLink'), url: 'https://om.ndla.no/gpdr' },
     { label: t('footer.cookiesLink'), url: 'https://om.ndla.no/cookies' },
+    {
+      url: 'https://uustatus.no/nn/erklaringer/publisert/8cefdf3d-3272-402a-907b-689ddfc9bba7',
+      label: t('footer.availabilityLink'),
+    },
   ];
   return (
     <Footer


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/3437

Linkene som er nederst i footer var ikke veldig behaglige å se på når ser på mindre skjermer. Gjør css'en  for linkene mer conditional. 
Går vekk fra `flex-direction: row` til `flex-direction: column` når skjermen er på telefon størrelse og gjemmer separator linjen.
 
**Iphone SE**
<img width="482" alt="image" src="https://user-images.githubusercontent.com/35299038/216079715-dece55d1-16ec-466f-99a6-d8414d27fc75.png">

**Ipad**
<img width="713" alt="image" src="https://user-images.githubusercontent.com/35299038/216079828-76b1f940-cd88-4ed6-b800-ebff99079940.png">
