### PR TITLE
Fix tag padding for resources and folders without menuItem

### DIFF
--- a/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
@@ -106,7 +106,6 @@ const MenuWrapper = styled.div<MenuWrapperProps>`
   align-items: center;
   gap: ${spacing.xsmall};
   justify-content: space-between;
-  margin: -${spacing.nsmall} -${(props) => (props.hasMenuButton ? spacing.nsmall : 0)} -${spacing.nsmall} 0;
 `;
 
 const CountContainer = styled.div`

--- a/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
@@ -113,6 +113,7 @@ const CountContainer = styled.div`
   overflow: hidden;
   display: flex;
   flex-direction: row;
+  min-height: 44px;
   gap: ${spacing.small};
 `;
 

--- a/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
@@ -26,8 +26,6 @@ const FolderWrapper = styled.div<LayoutProps>`
   position: relative;
   align-items: center;
   justify-content: space-between;
-  padding: ${spacing.nsmall};
-  gap: ${spacing.small};
 
   ${mq.range({ until: breakpoints.mobileWide })} {
     ${({ type }) =>
@@ -56,8 +54,10 @@ const FolderWrapper = styled.div<LayoutProps>`
   }
 `;
 
-const TitleWrapper = styled.div`
+const TitleWrapper = styled.div<LayoutProps>`
   display: flex;
+  margin: ${spacing.nsmall};
+  margin-bottom: ${({ type }) => type === 'block' && 0};
   flex-direction: row;
   align-items: center;
   gap: ${spacing.xsmall};
@@ -94,17 +94,12 @@ const FolderTitle = styled.h2`
   }
 `;
 
-interface MenuWrapperProps {
-  hasMenuButton: boolean;
-}
-
-const MenuWrapper = styled.div<MenuWrapperProps>`
+const MenuWrapper = styled.div`
   overflow: hidden;
   display: flex;
   z-index: 1;
   flex-direction: row;
   align-items: center;
-  gap: ${spacing.xsmall};
   justify-content: space-between;
 `;
 
@@ -114,6 +109,7 @@ const CountContainer = styled.div`
   flex-direction: row;
   min-height: 44px;
   gap: ${spacing.small};
+  margin: 0 ${spacing.small} 0 ${spacing.nsmall};
 `;
 
 const IconCountWrapper = styled.div<LayoutProps>`
@@ -171,7 +167,7 @@ const Folder = ({ id, link, title, subFolders, subResources, type = 'list', menu
 
   return (
     <FolderWrapper type={type} id={id}>
-      <TitleWrapper>
+      <TitleWrapper type={type}>
         <IconWrapper>
           <FolderOutlined aria-label={t('myNdla.folder.folder')} />
         </IconWrapper>
@@ -179,7 +175,7 @@ const Folder = ({ id, link, title, subFolders, subResources, type = 'list', menu
           <FolderTitle title={title}>{title}</FolderTitle>
         </ResourceTitleLink>
       </TitleWrapper>
-      <MenuWrapper hasMenuButton={!!menuItems?.length}>
+      <MenuWrapper>
         <CountContainer>
           <Count layoutType={type} type={'folder'} count={subFolders} />
           <Count layoutType={type} type={'resource'} count={subResources} />

--- a/packages/ndla-ui/src/Resource/BlockResource.tsx
+++ b/packages/ndla-ui/src/Resource/BlockResource.tsx
@@ -16,7 +16,6 @@ import {
   CompressedTagList,
   ResourceImageProps,
   ResourceTitle,
-  Row,
   ResourceTypeList,
   ResourceTitleLink,
   LoaderProps,
@@ -67,24 +66,21 @@ const BlockDescription = styled.p`
   }
 `;
 
-interface TagsAndActionProps {
-  hasMenuButton: boolean;
-}
-
-const TagsAndActionMenu = styled(Row)<TagsAndActionProps>`
-  z-index: 1;
+const TagsAndActionMenu = styled.div`
+  display: flex;
+  align-items: center;
   justify-content: flex-end;
-  margin: 0 -${(props) => (props.hasMenuButton ? spacing.small : 0)} -${spacing.small} 0;
+  z-index: 1;
 `;
 
 const BlockInfoWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  padding: ${spacing.small};
 `;
 
 const ContentWrapper = styled.div`
   display: flex;
+  margin: ${spacing.small} ${spacing.small} 0 ${spacing.small};
   flex-direction: column;
 `;
 
@@ -190,7 +186,7 @@ const BlockResource = ({
           <ResourceTypeList resourceTypes={resourceTypes} />
           <BlockDescription>{description}</BlockDescription>
         </ContentWrapper>
-        <TagsAndActionMenu hasMenuButton={!!(tags && tags.length > 3) || !!(menuItems && menuItems.length)}>
+        <TagsAndActionMenu>
           {tags && tags.length > 0 && <CompressedTagList tagLinkPrefix={tagLinkPrefix} tags={tags} />}
           {menuItems && menuItems.length > 0 && <MenuButton align="end" size="small" menuItems={menuItems} />}
         </TagsAndActionMenu>

--- a/packages/ndla-ui/src/Resource/BlockResource.tsx
+++ b/packages/ndla-ui/src/Resource/BlockResource.tsx
@@ -8,7 +8,7 @@
 
 import styled from '@emotion/styled';
 import React from 'react';
-import { colors, fonts, mq, spacing } from '@ndla/core';
+import { colors, fonts, spacing } from '@ndla/core';
 import { MenuButton, MenuItemProps } from '@ndla/button';
 import ContentTypeBadge from '../ContentTypeBadge';
 import Image from '../Image';

--- a/packages/ndla-ui/src/Resource/BlockResource.tsx
+++ b/packages/ndla-ui/src/Resource/BlockResource.tsx
@@ -7,8 +7,8 @@
  */
 
 import styled from '@emotion/styled';
-import React, { useRef } from 'react';
-import { colors, fonts, spacing } from '@ndla/core';
+import React from 'react';
+import { colors, fonts, mq, spacing } from '@ndla/core';
 import { MenuButton, MenuItemProps } from '@ndla/button';
 import ContentTypeBadge from '../ContentTypeBadge';
 import Image from '../Image';
@@ -67,10 +67,14 @@ const BlockDescription = styled.p`
   }
 `;
 
-const RightRow = styled(Row)`
+interface TagsAndActionProps {
+  hasMenuButton: boolean;
+}
+
+const TagsAndActionMenu = styled(Row)<TagsAndActionProps>`
   z-index: 1;
   justify-content: flex-end;
-  margin: 0 -${spacing.small} -${spacing.small} 0;
+  margin: 0 -${(props) => (props.hasMenuButton ? spacing.small : 0)} -${spacing.small} 0;
 `;
 
 const BlockInfoWrapper = styled.div`
@@ -186,10 +190,10 @@ const BlockResource = ({
           <ResourceTypeList resourceTypes={resourceTypes} />
           <BlockDescription>{description}</BlockDescription>
         </ContentWrapper>
-        <RightRow>
+        <TagsAndActionMenu hasMenuButton={!!(tags && tags.length > 3) || !!(menuItems && menuItems.length)}>
           {tags && tags.length > 0 && <CompressedTagList tagLinkPrefix={tagLinkPrefix} tags={tags} />}
           {menuItems && menuItems.length > 0 && <MenuButton align="end" size="small" menuItems={menuItems} />}
-        </RightRow>
+        </TagsAndActionMenu>
       </BlockInfoWrapper>
     </BlockElementWrapper>
   );

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -40,8 +40,6 @@ const ListResourceWrapper = styled.div`
       'tags                 tags';
   }
 
-  padding: ${spacing.small};
-  column-gap: ${spacing.small};
   cursor: pointer;
   border: 1px solid ${colors.brand.neutral7};
   border-radius: 2px;
@@ -69,6 +67,7 @@ const ImageWrapper = styled.div<StyledImageProps>`
   overflow: hidden;
   border-radius: 2px;
   display: flex;
+  margin: ${spacing.small};
   align-items: center;
   justify-content: center;
   aspect-ratio: 4/3;
@@ -84,8 +83,10 @@ const StyledResourceDescription = styled.p`
   line-clamp: 2;
   line-height: 1em;
   height: 3.1em;
-  margin: 0;
-  margin-top: ${spacing.xxsmall};
+  margin: 0 ${spacing.small} ${spacing.small} 0;
+  ${mq.range({ until: breakpoints.mobileWide })} {
+    margin: 0 ${spacing.small};
+  }
   overflow: hidden;
   ${fonts.sizes(16)};
   text-overflow: ellipsis;
@@ -96,11 +97,7 @@ const StyledResourceDescription = styled.p`
   -webkit-box-orient: vertical;
 `;
 
-interface TagsAndActionProps {
-  hasMenuButton: boolean;
-}
-
-const TagsandActionMenu = styled.div<TagsAndActionProps>`
+const TagsandActionMenu = styled.div`
   grid-area: tags;
   z-index: 1;
   box-sizing: content-box;
@@ -109,18 +106,16 @@ const TagsandActionMenu = styled.div<TagsAndActionProps>`
   align-items: center;
   align-self: flex-start;
   justify-items: flex-end;
-  margin: -${spacing.small} -${(props) => (props.hasMenuButton ? spacing.small : 0)} 0 0;
-  ${mq.range({ until: breakpoints.mobileWide })} {
-    margin: 0 -${(props) => (props.hasMenuButton ? spacing.small : 0)} -${spacing.small} 0;
-  }
   overflow: hidden;
 `;
 
 const TopicAndTitleWrapper = styled.div`
   grid-area: topicAndTitle;
   display: flex;
+  margin: ${spacing.small} 0;
   flex-direction: column;
   overflow: hidden;
+  margin-right: ${spacing.small};
 `;
 
 interface ListResourceImageProps {
@@ -241,7 +236,7 @@ const ListResource = ({
         </TypeAndTitleLoader>
       </TopicAndTitleWrapper>
       {showDescription && <Description description={description} loading={isLoading} />}
-      <TagsandActionMenu hasMenuButton={!!(tags && tags.length > 3) || !!(menuItems && menuItems.length)}>
+      <TagsandActionMenu>
         {tags && tags.length > 0 && <CompressedTagList tagLinkPrefix={tagLinkPrefix} tags={tags} />}
         {menuItems && menuItems.length > 0 && <MenuButton align="end" size="small" menuItems={menuItems} />}
       </TagsandActionMenu>

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -63,6 +63,7 @@ const ImageWrapper = styled.div<StyledImageProps>`
   width: ${(p) => (p.imageSize === 'normal' ? '136px' : '56px')};
   ${mq.range({ until: breakpoints.mobileWide })} {
     width: 56px;
+    margin-bottom: 0;
   }
   overflow: hidden;
   border-radius: 2px;
@@ -107,6 +108,9 @@ const TagsandActionMenu = styled.div`
   align-self: flex-start;
   justify-items: flex-end;
   overflow: hidden;
+  ${mq.range({ until: breakpoints.mobileWide })} {
+    min-height: ${spacing.small};
+  }
 `;
 
 const TopicAndTitleWrapper = styled.div`
@@ -116,6 +120,9 @@ const TopicAndTitleWrapper = styled.div`
   flex-direction: column;
   overflow: hidden;
   margin-right: ${spacing.small};
+  ${mq.range({ until: breakpoints.mobileWide })} {
+    margin-bottom: 0;
+  }
 `;
 
 interface ListResourceImageProps {

--- a/packages/ndla-ui/src/Resource/resourceComponents.tsx
+++ b/packages/ndla-ui/src/Resource/resourceComponents.tsx
@@ -53,9 +53,13 @@ const StyledTagList = styled.ul`
   list-style: none;
   display: flex;
   margin: 0;
+  margin-left: ${spacing.small};
   padding: 2px;
   gap: ${spacing.xsmall};
   overflow: hidden;
+  :last-child {
+    margin-right: ${spacing.small};
+  }
 `;
 
 const StyledTagListElement = styled.li`
@@ -71,6 +75,7 @@ const StyledSafeLink = styled(SafeLink)`
   color: ${colors.brand.grey};
   min-height: 44px;
   min-width: 44px;
+  white-space: nowrap;
   &:hover {
     color: ${colors.brand.primary};
   }
@@ -97,12 +102,6 @@ const StyledResourceListElement = styled.li`
   padding: 0;
   display: flex;
   align-items: center;
-`;
-
-export const Row = styled.div`
-  display: flex;
-  align-items: center;
-  gap: ${spacing.xsmall};
 `;
 
 const TagCounterWrapper = styled.span`


### PR DESCRIPTION
Blokkressurs og mapper har identisk feil der tags ikke har padding til høyre dersom menyknapp ikke finnes. Løser dette på samme måte som det allerede er gjort i ListResource med conditional styling basert på om menyen finnes eller ikke

<img width="431" alt="image" src="https://user-images.githubusercontent.com/17144211/216277565-8a34f9fd-edc2-405e-94fc-cb361cb5a0af.png">

Fikser også en mer spesifikk feil i blokkvisning av mappe der tags manglet padding over og under dersom menyknapp ikke finnes.

<img width="319" alt="image" src="https://user-images.githubusercontent.com/17144211/216277953-c30a806c-45b4-4d1a-8bf1-61cb4c91b8a3.png">

