### PR TITLE
Manually position concept popover depending on mobile or desktop

### DIFF
--- a/packages/ndla-ui/src/Embed/ConceptEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/ConceptEmbed.tsx
@@ -45,7 +45,6 @@ const PopoverWrapper = styled.div`
       z-index: 9999 !important;
       height: 100vh;
       min-width: 100vw !important;
-      overflow-y: scroll;
     }
   }
 `;

--- a/packages/ndla-ui/src/Embed/ConceptEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/ConceptEmbed.tsx
@@ -171,16 +171,16 @@ const InlineConcept = ({ title, content, copyright, source, visualElement, linkT
   const { t } = useTranslation();
   return (
     <Root>
+      <StyledAnchor asChild>
+        <StyledAnchorSpan />
+      </StyledAnchor>
+      <Trigger asChild>
+        <NotionButton>
+          {linkText}
+          {<BaselineIcon />}
+        </NotionButton>
+      </Trigger>
       <PopoverWrapper>
-        <StyledAnchor asChild>
-          <StyledAnchorSpan />
-        </StyledAnchor>
-        <Trigger asChild>
-          <NotionButton>
-            {linkText}
-            {<BaselineIcon />}
-          </NotionButton>
-        </Trigger>
         <Content asChild avoidCollisions={false} side="bottom">
           <ConceptNotion
             title={title}
@@ -232,39 +232,39 @@ export const BlockConcept = ({
 
   return (
     <Root>
-      <PopoverWrapper>
-        <StyledAnchor />
-        <Figure resizeIframe type={fullWidth ? 'full' : 'full-column'}>
-          <UINotion
-            id=""
-            title={title}
-            text={content}
-            visualElement={
-              visualElement?.status === 'success' && (
-                <>
-                  <ImageWrapper>
-                    <Tooltip tooltip={t('searchPage.resultType.showNotion')}>
-                      <Trigger asChild>
-                        <StyledButton type="button" aria-label={t('concept.showDescription', { title: title })}>
-                          {visualElement.resource === 'image' ? (
-                            <NotionImage
-                              type={visualElementType}
-                              id={''}
-                              src={visualElement.data.imageUrl}
-                              alt={visualElement.data.alttext.alttext}
-                            />
-                          ) : metaImage ? (
-                            <NotionImage
-                              type={visualElementType}
-                              id={''}
-                              src={metaImage?.url ?? ''}
-                              alt={metaImage?.alt ?? ''}
-                            />
-                          ) : undefined}
-                        </StyledButton>
-                      </Trigger>
-                    </Tooltip>
-                  </ImageWrapper>
+      <StyledAnchor />
+      <Figure resizeIframe type={fullWidth ? 'full' : 'full-column'}>
+        <UINotion
+          id=""
+          title={title}
+          text={content}
+          visualElement={
+            visualElement?.status === 'success' && (
+              <>
+                <ImageWrapper>
+                  <Tooltip tooltip={t('searchPage.resultType.showNotion')}>
+                    <Trigger asChild>
+                      <StyledButton type="button" aria-label={t('concept.showDescription', { title: title })}>
+                        {visualElement.resource === 'image' ? (
+                          <NotionImage
+                            type={visualElementType}
+                            id={''}
+                            src={visualElement.data.imageUrl}
+                            alt={visualElement.data.alttext.alttext}
+                          />
+                        ) : metaImage ? (
+                          <NotionImage
+                            type={visualElementType}
+                            id={''}
+                            src={metaImage?.url ?? ''}
+                            alt={metaImage?.alt ?? ''}
+                          />
+                        ) : undefined}
+                      </StyledButton>
+                    </Trigger>
+                  </Tooltip>
+                </ImageWrapper>
+                <PopoverWrapper>
                   <Content asChild avoidCollisions={false} side="bottom">
                     <ConceptNotion
                       title={title}
@@ -281,42 +281,42 @@ export const BlockConcept = ({
                       }
                     />
                   </Content>
-                </>
-              )
-            }
-          />
-          {copyright?.license && license ? (
-            <FigureCaption
-              figureId=""
-              id=""
-              authors={authors}
-              licenseRights={license.rights}
-              locale={i18n.language}
-              hideIconsAndAuthors
-              modalButton={
-                <ButtonV2 variant="outline" size="small" shape="pill" onClick={() => setIsOpen(true)}>
-                  {t('concept.reuse')}
-                </ButtonV2>
-              }>
-              <ModalV2 controlled isOpen={isOpen} onClose={() => setIsOpen(false)}>
-                {(close) => (
-                  <FigureLicenseDialogContent
-                    authors={groupedAuthors}
-                    locale={i18n.language}
-                    title={title}
-                    origin={copyright.origin}
-                    license={license}
-                    onClose={close}
-                    type="concept"
-                  />
-                )}
-              </ModalV2>
-            </FigureCaption>
-          ) : (
-            <BottomBorder />
-          )}
-        </Figure>
-      </PopoverWrapper>
+                </PopoverWrapper>
+              </>
+            )
+          }
+        />
+        {copyright?.license && license ? (
+          <FigureCaption
+            figureId=""
+            id=""
+            authors={authors}
+            licenseRights={license.rights}
+            locale={i18n.language}
+            hideIconsAndAuthors
+            modalButton={
+              <ButtonV2 variant="outline" size="small" shape="pill" onClick={() => setIsOpen(true)}>
+                {t('concept.reuse')}
+              </ButtonV2>
+            }>
+            <ModalV2 controlled isOpen={isOpen} onClose={() => setIsOpen(false)}>
+              {(close) => (
+                <FigureLicenseDialogContent
+                  authors={groupedAuthors}
+                  locale={i18n.language}
+                  title={title}
+                  origin={copyright.origin}
+                  license={license}
+                  onClose={close}
+                  type="concept"
+                />
+              )}
+            </ModalV2>
+          </FigureCaption>
+        ) : (
+          <BottomBorder />
+        )}
+      </Figure>
     </Root>
   );
 };

--- a/packages/ndla-ui/src/Embed/ConceptEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/ConceptEmbed.tsx
@@ -6,10 +6,10 @@
  *
  */
 
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from '@emotion/styled';
-import { css } from '@emotion/react';
+import { isMobile } from 'react-device-detect';
 import { Root, Trigger, Content, Anchor, Close, Portal } from '@radix-ui/react-popover';
 import { ButtonV2, IconButtonV2 } from '@ndla/button';
 import { Cross } from '@ndla/icons/action';
@@ -170,7 +170,7 @@ const StyledAnchorSpan = styled.span`
 const InlineConcept = ({ title, content, copyright, source, visualElement, linkText }: InlineConceptProps) => {
   const { t } = useTranslation();
   return (
-    <Root>
+    <Root modal={isMobile}>
       <StyledAnchor asChild>
         <StyledAnchorSpan />
       </StyledAnchor>
@@ -231,7 +231,7 @@ export const BlockConcept = ({
   const license = copyright?.license && getLicenseByAbbreviation(copyright?.license?.license, i18n.language);
 
   return (
-    <Root>
+    <Root modal={isMobile}>
       <StyledAnchor />
       <Figure resizeIframe type={fullWidth ? 'full' : 'full-column'}>
         <UINotion

--- a/packages/ndla-ui/src/Embed/conceptComponents.tsx
+++ b/packages/ndla-ui/src/Embed/conceptComponents.tsx
@@ -92,7 +92,6 @@ const getVisualElement = (
 };
 
 const notionContentCss = css`
-  overflow: auto;
   @keyframes animateIn {
     0% {
       opacity: 0;

--- a/packages/ndla-ui/src/Embed/conceptComponents.tsx
+++ b/packages/ndla-ui/src/Embed/conceptComponents.tsx
@@ -119,8 +119,8 @@ const notionContentCss = css`
 
   ${mq.range({ until: breakpoints.tablet })} {
     z-index: 9999;
-    width: 100vw;
-    height: 100vh;
+    height: 100%;
+    width: 100%;
   }
 `;
 

--- a/packages/ndla-ui/src/Figure/component.figure.scss
+++ b/packages/ndla-ui/src/Figure/component.figure.scss
@@ -167,7 +167,6 @@
 .c-figure__fullscreen-btn {
   cursor: pointer;
   position: absolute;
-  z-index: 1;
   padding: 0;
   bottom: 8px;
   right: 8px;


### PR DESCRIPTION
Hva som er gjort:
Overstyrer Popover sin default posisjonering. Den plasseres nå absolute ved desktop og plasseres som en fullscreen modal på mobil med scroll lock.