### PR TITLE
Fix failing error reporter test on newer node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16.17'
       - name: 'Login to ECR repo'
         run: RES=$(aws sts assume-role --role-arn $CI_RELEASE_ROLE --role-session-name github-actions-ecr-login)
           AWS_ACCESS_KEY_ID=$(echo $RES | jq -r .Credentials.AccessKeyId)

--- a/packages/ndla-error-reporter/src/__tests__/ErrorReporter-test.js
+++ b/packages/ndla-error-reporter/src/__tests__/ErrorReporter-test.js
@@ -133,7 +133,7 @@ test('ndla-error-reporter/ErrorReporter should not send duplicate errors ', () =
   const apiMock = nock('http://loggly-mock-api')
     .post('/inputs/1223/', (body) => {
       expect(body).toMatchObject({
-        text: "TypeError: Cannot set property 'foo' of null",
+        text: "TypeError: Cannot set properties of null (setting 'foo')",
       });
       return true;
     })


### PR DESCRIPTION
Ser ut til å fungere på CI og på 16.17 lokalt hos meg.