### PR TITLE
add faculty to phrases and give teacher/staff/faculty one translation

### DIFF
--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -1053,8 +1053,9 @@ const messages = {
     loggedInAs: 'You are logged in as {{role}}.',
     loggedInAsButton: 'You are logged in as {{role}}',
     role: {
-      employee: 'Teacher',
-      staff: 'Staff',
+      employee: 'Employee',
+      faculty: 'Employee',
+      staff: 'Employee',
       student: 'Student',
     },
     buttonLogIn: 'Log in with Feide',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -1052,7 +1052,8 @@ const messages = {
     loggedInAs: 'Du er pålogget som {{role}}.',
     loggedInAsButton: 'Du er pålogget som {{role}}',
     role: {
-      employee: 'lærer',
+      employee: 'ansatt',
+      faculty: 'ansatt',
       staff: 'ansatt',
       student: 'elev',
     },

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -1052,7 +1052,8 @@ const messages = {
     loggedInAs: 'Du er pålogga som {{role}}.',
     loggedInAsButton: 'Du er pålogga som {{role}}',
     role: {
-      employee: 'lærar',
+      employee: 'tilsett',
+      faculty: 'tilsett',
       staff: 'tilsett',
       student: 'elev',
     },

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -1053,7 +1053,8 @@ const messages = {
     loggedInAs: 'Don leat sisaloggejuvvon {{role}}.',
     loggedInAsButton: 'Don leat sisaloggejuvvon {{role}}',
     role: {
-      employee: 'oahpaheaddji',
+      employee: 'bargi',
+      faculty: 'bargi',
       staff: 'bargi',
       student: 'oahppi',
     },

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -1056,8 +1056,9 @@ const messages = {
     loggedInAs: 'Datne tjaangeme goh {{role}}.',
     loggedInAsButton: 'Datne tjaangeme goh {{role}}',
     role: {
-      employee: 'lohkehtæjja',
-      staff: 'ansatt',
+      employee: 'barkije',
+      faculty: 'barkije',
+      staff: 'barkije',
       student: 'learohke',
     },
     buttonLogIn: 'Tjaangh Feidine',


### PR DESCRIPTION
`Jeg tenker kanskje "Ansatt" (BM) eller "Tilsett" (NN) passer for "employee", "staff" og "faculty". Vi ser at fylkene bruker dette så ulikt så det er ikke mulig for oss å vite at "Faculty" alltid betyr lærer.`

Endrer teacher/staff/faculty oversettelser til en felles verdi -> "ansatt", basert på tilbakemeldingen fra NDLA.
Legger til en ny nøkkel "faculty" i user-roles.