### PR TITLE
Show Spinner instead of no results when search is loading

### DIFF
--- a/packages/ndla-ui/src/SearchTypeResult/SearchHeader.tsx
+++ b/packages/ndla-ui/src/SearchTypeResult/SearchHeader.tsx
@@ -126,15 +126,11 @@ const SearchHeader = ({
       </SearchInputWrapper>
       <PhraseWrapper>
         <div aria-live="assertive">
-          {loading ? (
-            <Spinner margin="0" size="normal" aria-label={t('loading')} />
-          ) : (
-            searchPhrase && (
-              <>
-                <PhraseText>{phraseText}</PhraseText>
-                {removeFilterSuggestion && <PhraseText>{removeFilterSuggestion}</PhraseText>}
-              </>
-            )
+          {!loading && searchPhrase && (
+            <>
+              <PhraseText>{phraseText}</PhraseText>
+              {removeFilterSuggestion && <PhraseText>{removeFilterSuggestion}</PhraseText>}
+            </>
           )}
         </div>
         {searchPhraseSuggestion && (

--- a/packages/ndla-ui/src/SearchTypeResult/SearchHeader.tsx
+++ b/packages/ndla-ui/src/SearchTypeResult/SearchHeader.tsx
@@ -10,12 +10,12 @@ import { useTranslation } from 'react-i18next';
 import styled from '@emotion/styled';
 import { breakpoints, fonts, mq, spacing } from '@ndla/core';
 import { ButtonV2 } from '@ndla/button';
+import { Spinner } from '@ndla/icons';
 
 import SearchFieldHeader from './SearchFieldHeader';
 import { CompetenceGoalsItemType } from '../types';
 import CompetenceGoalItem from '../CompetenceGoalTab/CompetenceGoalItem';
 import SubjectFilters, { SubjectFilterProps } from './components/SubjectFilters';
-import { Spinner } from '@ndla/icons';
 
 const Wrapper = styled.div`
   margin-top: ${spacing.normal};

--- a/packages/ndla-ui/src/SearchTypeResult/SearchHeader.tsx
+++ b/packages/ndla-ui/src/SearchTypeResult/SearchHeader.tsx
@@ -15,6 +15,7 @@ import SearchFieldHeader from './SearchFieldHeader';
 import { CompetenceGoalsItemType } from '../types';
 import CompetenceGoalItem from '../CompetenceGoalTab/CompetenceGoalItem';
 import SubjectFilters, { SubjectFilterProps } from './components/SubjectFilters';
+import { Spinner } from '@ndla/icons';
 
 const Wrapper = styled.div`
   margin-top: ${spacing.normal};
@@ -71,6 +72,7 @@ type Props = {
   onSearchValueChange: (value: string) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   noResults?: boolean;
+  loading: boolean;
 };
 
 const SearchHeader = ({
@@ -84,6 +86,7 @@ const SearchHeader = ({
   filters,
   competenceGoals,
   noResults,
+  loading,
 }: Props) => {
   const { t } = useTranslation();
   const [isNarrowScreen, setIsNarrowScreen] = useState<boolean | undefined>();
@@ -122,12 +125,18 @@ const SearchHeader = ({
         />
       </SearchInputWrapper>
       <PhraseWrapper>
-        {searchPhrase && (
-          <>
-            <PhraseText>{phraseText}</PhraseText>
-            {removeFilterSuggestion && <PhraseText>{removeFilterSuggestion}</PhraseText>}
-          </>
-        )}
+        <div aria-live="assertive">
+          {loading ? (
+            <Spinner margin="0" size="normal" aria-label={t('loading')} />
+          ) : (
+            searchPhrase && (
+              <>
+                <PhraseText>{phraseText}</PhraseText>
+                {removeFilterSuggestion && <PhraseText>{removeFilterSuggestion}</PhraseText>}
+              </>
+            )
+          )}
+        </div>
         {searchPhraseSuggestion && (
           <PhraseSuggestionText>
             {t('searchPage.resultType.searchPhraseSuggestion')}{' '}

--- a/packages/ndla-ui/src/SearchTypeResult/SearchHeader.tsx
+++ b/packages/ndla-ui/src/SearchTypeResult/SearchHeader.tsx
@@ -129,9 +129,10 @@ const SearchHeader = ({
           {!loading && searchPhrase && (
             <>
               <PhraseText>{phraseText}</PhraseText>
-              {removeFilterSuggestion && <PhraseText>{removeFilterSuggestion}</PhraseText>}
+              <PhraseText>{removeFilterSuggestion}</PhraseText>
             </>
           )}
+          {loading && <div aria-label={t('loading')} />}
         </div>
         {searchPhraseSuggestion && (
           <PhraseSuggestionText>


### PR DESCRIPTION
Ved søk på søkesiden på ndla.no vises "ingen treff på søk ..." fram til søket er ferdig. Tar nå inn parameter for loading slik at Spinner heller kan vises.

Hvordan teste:
- Link ndla-ui inn i ndla-frontend (https://github.com/NDLANO/ndla-frontend/pull/1310)
- Søk på noe tilfeldig
- Sjekk at Spinner vises fram til søket er ferdig
- Kan teste med skjermleser også. Har lagt på aria-live slik at "loading" og antall søketreff leses opp automatisk.