### PR TITLE
Add incremental flag to root tsconfig to speed up type checking and generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ dist/
 storybook-static/
 .DS_Store
 *.iml
-packages/*/tsconfig.build.tsbuildinfo
+tsconfig.build.tsbuildinfo
+tsconfig.tsbuildinfo
 /.idea
 *.iml
 .eslintcache

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "frontend-packages",
   "description": "NDLA Frontend Packages",
   "scripts": {
-    "build-clean": "rm -rf ./packages/*/es ./packages/*/lib ./packages/*/dist",
+    "build-clean": "rm -rf ./packages/*/es ./packages/*/lib ./packages/*/dist ./packages/*/tsconfig.build.tsbuildinfo",
     "build": "node ./scripts/build.js packages",
     "lint": "yarn format-check && yarn lint-es",
     "lint-es": "eslint --cache --ext .js,.jsx,.ts,.tsx --max-warnings=0 ./packages --ignore-path .gitignore",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     // "declaration": true,
     "strict": true,
     "moduleResolution": "node",
+    "incremental": true,
     "noLib": false,
     "noEmit": true,
     "sourceMap": true,


### PR DESCRIPTION
Jeg har prøvd på dette en gang før, og feilet miserabelt (https://github.com/NDLANO/frontend-packages/pull/1049). frontend-packages har blitt oppgradert en del siden da, og jeg har troen på at vi kan få det til å fungere denne gangen (famous last words). 

Ved lokal testing går bootstrap fra ~100s -> ~50s når buildinfo allerede eksisterer. Typesjekking går fra 18s -> 3s.