### PR TITLE
Use a light color on primary theme hover/focus

### DIFF
--- a/packages/button/src/themes.ts
+++ b/packages/button/src/themes.ts
@@ -5,8 +5,8 @@ export const themes: Record<ButtonColor, ButtonTheme> = {
   primary: {
     foreground: colors.white,
     background: colors.brand.primary,
-    hoverForeground: colors.white,
-    hoverBackground: colors.brand.dark,
+    hoverForeground: colors.brand.primary,
+    hoverBackground: colors.brand.light,
   },
   light: {
     foreground: colors.brand.primary,


### PR DESCRIPTION
https://trello.com/c/mHPCrh67/149-uu-wcag-247-fokusmarkering-p%C3%A5-alle-bl%C3%A5-knapper-er-for-liten-og-kun-med-fargeendring

Dette er egentlig den eneste kontrast-greia på knapper som er problematisk, tror jeg. Hedvig var enig i at dette var en grei løsning.