### PR TITLE
Replace button focus styling with focus-visible

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "watch": "concurrently 'yarn watch:src' 'yarn watch:tsc'",
     "start": "yarn build && concurrently -k -p \"[{name}]\" -n \"Babel,Storybook,Typescript\" -c \"yellow.bold,magenta.bold,blue.bold\" \"yarn watch\" \"yarn start-storybook\" \"yarn type-check-watch\"",
     "start-storybook": "node ./scripts/startStorybook.js",
-    "prebuild-storybook": "yarn bootstrap",
+    "prebuild-storybook": "yarn bootstrap:ci",
     "build-storybook": "cross-env NODE_ENV=production node ./scripts/buildStorybook.js",
     "serve-storybook": "cross-env NODE_ENV=production serve -l 5000 ./storybook-static",
     "check-translations": "cross-env BABEL_ENV=test NODE_ENV=unittest jest 'packages/ndla-ui/src/locale/__tests__/'"

--- a/packages/button/src/ButtonV2.tsx
+++ b/packages/button/src/ButtonV2.tsx
@@ -90,7 +90,7 @@ export const buttonStyle = ({
     text-align: center;
 
     &:hover,
-    &:focus {
+    &:focus-visible {
       color: ${theme.hoverForeground};
       background-color: ${theme.hoverBackground};
       border-color: ${theme.hoverBackground};
@@ -135,7 +135,7 @@ export const buttonStyle = ({
       border-color: transparent;
       :hover,
       :active,
-      :focus {
+      :focus-visible {
         color: ${theme.foreground};
         background: ${theme.background};
         border-color: ${theme.background};
@@ -162,7 +162,7 @@ export const buttonStyle = ({
       &:hover,
       &:active,
       &:disabled,
-      &:focus {
+      &:focus-visible {
         outline-width: 2px;
         box-shadow: ${colors.linkHover};
         color: ${colors.brand.primary};
@@ -183,13 +183,13 @@ export const buttonStyle = ({
       &:hover,
       &:active,
       &:disabled,
-      &:focus {
+      &:focus-visible {
         box-shadow: none;
         color: ${colors.brand.primary};
         background-color: transparent;
         border: none;
       }
-      &:focus {
+      &:focus-visible {
         outline-width: medium;
       }
     `}


### PR DESCRIPTION
Denne PR'en fikser en ting som har irritert meg lenge: Knapper beholder fokus-styling inntil knappen mister fokus. I de fleste tilfeller er dette egentlig ikke ønskelig. Dersom man trykker på en knapp burde man få en indikasjon på at knappen er ferdigtrykket, noe man nå ikke gjør. `focus-visible` gjør det samme som focus, men aktiveres ikke av museklikk. Denne løsningen er med andre ord like UU-vennlig som den forrige, om ikke mer.