### PR TITLE
Decrease Masthead content padding

### DIFF
--- a/packages/ndla-ui/src/Masthead/Masthead.tsx
+++ b/packages/ndla-ui/src/Masthead/Masthead.tsx
@@ -59,13 +59,6 @@ const MastheadContent = styled.div`
   display: flex;
   height: 84px;
   justify-content: space-between;
-  ${mq.range({ from: breakpoints.tablet })} {
-    flex-direction: row;
-    padding: ${spacing.small} ${spacing.normal};
-  }
-  ${mq.range({ from: breakpoints.desktop })} {
-    padding: ${spacing.small} ${spacing.large};
-  }
 `;
 
 interface StyledMastheadProps {


### PR DESCRIPTION
Relatert til https://github.com/NDLANO/ndla-frontend/pull/1320/files
Padding er nå lik på tvers av alle størrelser.

<img width="1440" alt="bilde" src="https://user-images.githubusercontent.com/9728475/224302504-bc656a3d-0a81-4c58-affe-c41c2793512f.png">
