### PR TITLE
Fix padding on resource titles by switching away from heading

### DIFF
--- a/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
@@ -182,21 +182,24 @@ const Folder = ({
   return (
     <FolderWrapper type={type} id={id}>
       <TitleWrapper type={type}>
-        <IconWrapper>
-          <Icon aria-label={t('myNdla.folder.folder')} />
+        <IconWrapper
+          aria-label={`${isShared ? `${t('myNdla.folder.sharing.shared')} ` : ''}${t('myNdla.folder.folder')}`}
+        >
+          <Icon />
         </IconWrapper>
         <ResourceTitleLink to={link}>
           <FolderTitle title={title}>{title}</FolderTitle>
         </ResourceTitleLink>
       </TitleWrapper>
       <MenuWrapper>
-        {isShared && (
-          <IconTextWrapper type={type}>
-            <Share />
-            <span>{t('myNdla.folder.sharing.shared')}</span>
-          </IconTextWrapper>
-        )}
         <CountContainer>
+          {isShared && (
+            // Information regarding the shared status of a folder is read previously, ignore this
+            <IconTextWrapper type={type} aria-hidden>
+              <Share />
+              <span>{t('myNdla.folder.sharing.shared')}</span>
+            </IconTextWrapper>
+          )}
           <Count layoutType={type} type={'folder'} count={subFolders} />
           <Count layoutType={type} type={'resource'} count={subResources} />
         </CountContainer>

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -197,7 +197,6 @@ export interface ListResourceProps {
   tagLinkPrefix?: string;
   title: string;
   resourceImage: ResourceImageProps;
-  headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   resourceTypes: { id: string; name: string }[];
   tags?: string[];
   description?: string;
@@ -214,7 +213,6 @@ const ListResource = ({
   tags,
   resourceImage,
   resourceTypes,
-  headingLevel = 'h2',
   description,
   menuItems,
   isLoading = false,
@@ -223,7 +221,6 @@ const ListResource = ({
   const showDescription = description !== undefined;
   const imageType = showDescription ? 'normal' : 'compact';
   const firstContentType = resourceTypes?.[0]?.id ?? '';
-  const Title = ResourceTitle.withComponent(headingLevel);
 
   return (
     <ListResourceWrapper id={id}>
@@ -238,7 +235,7 @@ const ListResource = ({
       <TopicAndTitleWrapper>
         <TypeAndTitleLoader loading={isLoading}>
           <StyledLink to={link} target={targetBlank ? '_blank' : undefined}>
-            <Title title={title}>{title}</Title>
+            <ResourceTitle title={title}>{title}</ResourceTitle>
           </StyledLink>
           <ResourceTypeList resourceTypes={resourceTypes} />
         </TypeAndTitleLoader>

--- a/packages/ndla-ui/src/Resource/resourceComponents.tsx
+++ b/packages/ndla-ui/src/Resource/resourceComponents.tsx
@@ -35,10 +35,11 @@ export const ResourceTitleLink = styled(SafeLink)`
   }
 `;
 
-export const ResourceTitle = styled.h2`
+export const ResourceTitle = styled.span`
   margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-weight: ${fonts.weight.bold};
   // Unfortunate css needed for multi-line text overflow ellipsis.
   line-height: 1;
   display: -webkit-box;


### PR DESCRIPTION
Allerede fikset i https://github.com/NDLANO/frontend-packages/pull/1563
Fixes https://github.com/NDLANO/Issues/issues/3499

Er nok mer riktig at dette er en span uansett.