### PR TITLE
New heading styles. Simplify usage of @chinese

### DIFF
--- a/packages/core/scss/global/elements/_elements.aside.scss
+++ b/packages/core/scss/global/elements/_elements.aside.scss
@@ -1,4 +1,6 @@
-aside, article aside, .c-article aside {
+aside,
+article aside,
+.c-article aside {
   width: 100%;
   display: inline-block;
   margin: $spacing 0 $spacing 0;
@@ -14,22 +16,22 @@ aside, article aside, .c-article aside {
     padding: $spacing / 2;
     overflow: hidden;
     max-height: 150px;
-    transition: max-height .4s cubic-bezier(1, 1.05, 0, 1);
+    transition: max-height 0.4s cubic-bezier(1, 1.05, 0, 1);
     position: relative;
     &:after {
-      content: "";
+      content: '';
       text-align: center;
       position: absolute;
       top: 0;
       bottom: 0;
       right: 0;
       width: 100%;
-      transition: background .5s cubic-bezier(0.74, -0.04, 0.96, 0.97);
-      background: linear-gradient(rgba($brand-color--light,0),$white)
+      transition: background 0.5s cubic-bezier(0.74, -0.04, 0.96, 0.97);
+      background: linear-gradient(rgba($brand-color--light, 0), $white);
     }
     &:hover {
-      &:after{
-        background: linear-gradient(rgba($white,0),rgba($white, 0.4))
+      &:after {
+        background: linear-gradient(rgba($white, 0), rgba($white, 0.4));
       }
     }
   }
@@ -40,7 +42,7 @@ aside, article aside, .c-article aside {
       background: none;
     }
     &:hover {
-      &:after{
+      &:after {
         background: none;
       }
     }
@@ -49,7 +51,10 @@ aside, article aside, .c-article aside {
   *:first-child {
     margin-top: 0;
   }
-  h2,h3,h4,h5 {
+  h2,
+  h3,
+  h4,
+  h5 {
     display: block;
     margin-top: $spacing--small;
     margin-bottom: $spacing--small;
@@ -69,12 +74,12 @@ aside, article aside, .c-article aside {
   }
 
   @include mq(desktop) {
-    @include font-size(16px);
+    @include font-size(16px, 1.5);
     float: right;
     left: 720px;
     clear: both;
     max-width: 300px;
-    padding: 0 0 0 $spacing*1.5;
+    padding: 0 0 0 $spacing * 1.5;
     border: none;
     border-left: 1px solid $brand-color--light;
     background: none;
@@ -87,7 +92,6 @@ aside, article aside, .c-article aside {
       &:after {
         display: none;
       }
-
     }
   }
 }

--- a/packages/core/scss/global/elements/_elements.headings.scss
+++ b/packages/core/scss/global/elements/_elements.headings.scss
@@ -21,82 +21,50 @@ h5 {
   font-weight: $font-weight-bold;
   font-family: $font;
   margin: $spacing 0 $spacing 0;
-  line-height: 1.3;
+  &[data-serif='true'] {
+    font-family: $font-serif;
+  }
 }
 
 h1 {
-  font-weight: $font-weight-semibold;
-  @include font-size(30px, 40px);
+  @include font-size(30px, 36px);
   margin-bottom: $spacing--small;
 
   @include mq(tablet) {
-    @include font-size(38px, 45px);
+    @include font-size(48px, 60px);
     margin-bottom: $spacing;
   }
-
-  @include chinese() {
-    @include font-size(32px, 40px);
-
-    @include mq(tablet) {
-      @include font-size(40px, 45px);
-    }
-  }
 }
 
-@include chinese() {
-  h1 {
-    @include font-size(32px, 40px);
-
-    @include mq(tablet) {
-      @include font-size(40px, 45px);
-    }
-  }
-}
-
-h2,
-h3,
-h4,
-h5 {
+h2 {
   margin-top: $spacing--large;
   margin-bottom: $spacing--small;
-  @include font-size(22px, 30px);
-
-  @include mq(desktop) {
-    line-height: 1.5;
-  }
-
-  @include chinese() {
-    @include font-size(24px, 30px);
+  @include font-size(28px, 36px);
+  @include mq(tablet) {
+    @include font-size(30px, 38px);
   }
 }
 
-@include chinese() {
-  h2,
-  h3,
-  h4,
-  h5 {
-    @include font-size(24px, 30px);
+h3 {
+  @include font-size(26px, 35px);
+  @include mq(tablet) {
+    @include font-size(26px, 36px);
+  }
+}
+
+h4,
+h5 {
+  @include font-size(22px, 30px);
+  @include mq(tablet) {
+    @include font-size(22px, 30px);
   }
 }
 
 h3,
 h4,
 h5 {
-  @include font-size(18px, 26px);
   margin-top: $spacing--medium;
   margin-bottom: $spacing--small / 2;
-
-  @include chinese() {
-    @include font-size(20px, 26px);
-  }
-}
-
-@include chinese() {
-  h3,
-  h4,
-  h5 {
-    @include font-size(20px, 26px);
-  }
 }
 
 h2 + h2 {

--- a/packages/core/scss/global/elements/_elements.input.scss
+++ b/packages/core/scss/global/elements/_elements.input.scss
@@ -1,10 +1,11 @@
 input {
   padding: $spacing/3;
-  @include font-size(18px);
+  @include font-size(18px, 1.33);
   border-style: solid;
   border-color: $brand-grey--light;
 }
-input::-ms-clear { // Remove X-button on input for IE
+input::-ms-clear {
+  // Remove X-button on input for IE
   width: 0;
   height: 0;
 }

--- a/packages/core/scss/global/tools/tools.aliases.scss
+++ b/packages/core/scss/global/tools/tools.aliases.scss
@@ -10,6 +10,9 @@ $spacing--large: $inuit-global-spacing-unit * 2;
   --spacing--large: #{$spacing--large};
 }
 
-@mixin font-size($args...) {
-  @include inuit-font-size($args...);
+@mixin font-size($font-size, $line-height, $modifier: 0, $important: false) {
+  @include inuit-font-size($font-size, $line-height, $modifier, $important);
+  @include chinese() {
+    @include inuit-font-size(calc($font-size * 1.11), calc($line-height * 1.11), $modifier, true);
+  }
 }

--- a/packages/core/scss/global/utilities/utilities.helpers.scss
+++ b/packages/core/scss/global/utilities/utilities.helpers.scss
@@ -6,7 +6,7 @@
   background: transparent;
   border: none;
   color: $brand-color;
-  @include font-size(20px);
+  @include font-size(20px, 1.33);
   font-weight: $font-weight-normal;
   z-index: 9;
   cursor: pointer;

--- a/packages/core/scss/global/utilities/utilities.typographic.scss
+++ b/packages/core/scss/global/utilities/utilities.typographic.scss
@@ -22,31 +22,13 @@
 
   @include mq(tablet) {
     font-weight: $font-weight-light;
-    margin-top: $spacing*1.5;
+    margin-top: $spacing * 1.5;
     @include font-size(26px, 36px);
   }
-}
-
-.c-article .article_introduction {
-  @include chinese() {
-    @include font-size(24px, 32px);
-  }
-
-  @include mq(tablet) {
-    @include chinese() {
-      @include font-size(28px, 36px);
-    }
-  }
-
   span {
-    @include chinese() {
-      @include font-size(24px, 32px);
-    }
-
+    @include font-size(22px, 30px);
     @include mq(tablet) {
-      @include chinese() {
-        @include font-size(28px, 36px);
-      }
+      @include font-size(26px, 36px);
     }
   }
 }

--- a/packages/core/src/fonts.ts
+++ b/packages/core/src/fonts.ts
@@ -7,14 +7,11 @@ const baseLineHeightUnit = 26;
 function sizes(fontSize: string | number, lineHeight?: string | number) {
   const fontSizeUnit = parseInt(fontSize as string, 10);
   const fontSizeRem = parseInt(fontSize as string, 10) / baseFontSizeUnit;
+  const _lineHeight = lineHeight ?? Math.ceil(fontSizeUnit / baseLineHeightUnit) * (baseLineHeightUnit / fontSizeUnit);
 
   const fontSizeStyling = `font-size: ${fontSize};font-size: ${fontSizeRem}rem;`;
-  if (lineHeight) {
-    return `${fontSizeStyling} line-height: ${lineHeight}`;
-  }
-
-  const defaultLineHeight = Math.ceil(fontSizeUnit / baseLineHeightUnit) * (baseLineHeightUnit / fontSizeUnit);
-  return `${fontSizeStyling} line-height: ${defaultLineHeight}`;
+  const chineseStyling = `&[lang='zh'], &[lang='zh-Hans'], &[lang='zh-Hant'] {font-size: calc(${fontSize} * 1.11); font-size: calc(${fontSizeRem}rem * 1.11)}`;
+  return `${fontSizeStyling} line-height: ${_lineHeight}; ${chineseStyling}`;
 }
 
 const fonts = {

--- a/packages/ndla-tabs/scss/tabs.scss
+++ b/packages/ndla-tabs/scss/tabs.scss
@@ -106,7 +106,8 @@ $tabs-spacing: 12px;
           padding-right: $spacing--small;
           white-space: nowrap;
           //transform: translateX(-$spacing--small);
-          &:focus, &:hover {
+          &:focus,
+          &:hover {
             background-color: $brand-grey--light;
             color: $brand-color;
           }
@@ -128,7 +129,7 @@ $tabs-spacing: 12px;
 
   &__list {
     max-width: 100%;
-    @include font-size(18px);
+    @include font-size(18px, 1.33);
     font-weight: $font-weight-bold;
     list-style: none;
     margin: $spacing/1.4 0 $spacing--small;
@@ -168,7 +169,7 @@ $tabs-spacing: 12px;
         margin-left: $spacing;
       }
       &:last-child:after {
-        content: "";
+        content: '';
         display: inline-flex;
         width: $spacing;
       }

--- a/packages/ndla-ui/src/Article/component.article.scss
+++ b/packages/ndla-ui/src/Article/component.article.scss
@@ -4,15 +4,6 @@
 ** Title has icon when article is a resource type
 **/
 
-@mixin contentList() {
-  ul:not([class]),
-  ul.o-list--two-columns,
-  ul.o-list--bullets,
-  ol {
-    @content;
-  }
-}
-
 .c-article {
   font-family: $font-serif;
   background: $white;
@@ -33,55 +24,13 @@
       margin-bottom: 29px;
     }
   }
-  p {
-    @include chinese() {
-      @include font-size(20px, 35px);
-    }
-  }
-
-  @include contentList() {
-    @include chinese() {
-      @include font-size(20px, 35px);
-    }
-  }
-
-  @include chinese() {
-    @include contentList() {
-      @include font-size(22px, 35px);
-    }
-
-    p {
-      @include font-size(22px, 35px);
-    }
-  }
 
   @include mq(tablet) {
     @include font-size(20px, 35px);
 
-    p {
-      @include chinese() {
-        @include font-size(22px, 35px);
-      }
-    }
-
     > section > p {
       &:not([class]) {
         margin-bottom: 35px;
-      }
-    }
-
-    @include contentList() {
-      @include chinese() {
-        @include font-size(22px, 35px);
-      }
-    }
-
-    @include chinese() {
-      @include contentList() {
-        @include font-size(22px, 35px);
-      }
-      p {
-        @include font-size(22px, 35px);
       }
     }
 
@@ -178,7 +127,7 @@
   }
 
   p {
-    @include inuit-font-size(16px, 20px);
+    @include font-size(16px, 20px);
     color: $text-light-color;
     text-transform: uppercase;
     margin-bottom: 0;

--- a/packages/ndla-ui/src/Article/component.footnotes.scss
+++ b/packages/ndla-ui/src/Article/component.footnotes.scss
@@ -17,7 +17,7 @@ $highlight-color: $brand-grey--lighter;
   display: block;
   border-top: 2px solid $brand-grey--lighter;
   color: gray;
-  @include inuit-font-size(15px);
+  @include font-size(15px, 1.6);
 }
 .c-footnotes__item {
   margin-bottom: $spacing--small;
@@ -37,7 +37,7 @@ $highlight-color: $brand-grey--lighter;
       padding: 10px 15px;
       box-shadow: none;
       text-decoration: underline;
-      @include inuit-font-size(15px);
+      @include font-size(15px, 1.6);
 
       &:hover,
       &:active,

--- a/packages/ndla-ui/src/Aside/component.aside.scss
+++ b/packages/ndla-ui/src/Aside/component.aside.scss
@@ -6,7 +6,7 @@
 .c-aside {
   position: relative;
   margin: $spacing--large 0;
-  @include inuit-font-size(16px);
+  @include font-size(16px, 1.5);
   z-index: 1;
 
   @include mq(tablet) {
@@ -59,7 +59,7 @@
 .c-aside h1 {
   margin-top: 0;
   margin-bottom: $spacing;
-  @include inuit-font-size(22px, 34px);
+  @include font-size(22px, 34px);
   font-weight: $font-weight-bold;
   position: relative;
   z-index: 2;
@@ -70,7 +70,7 @@
 .c-aside h4,
 .c-aside h5 {
   display: block;
-  @include inuit-font-size(16px);
+  @include font-size(16px, 1.5);
   letter-spacing: 0.1em;
   margin-top: $spacing;
   margin-bottom: $spacing--small;

--- a/packages/ndla-ui/src/Dialog/component.dialog.scss
+++ b/packages/ndla-ui/src/Dialog/component.dialog.scss
@@ -17,12 +17,12 @@
   }
   &:not(&--large, &--fullscreen) {
     h1 {
-      @include inuit-font-size(22px, 26px);
+      @include font-size(22px, 26px);
     }
   }
   &--small-heading {
     h1 {
-      @include inuit-font-size(22px, 26px);
+      @include font-size(22px, 26px);
     }
   }
 
@@ -45,7 +45,7 @@
     @include mq(tablet) {
       min-width: 20rem;
     }
-    @include font-size(18px);
+    @include font-size(18px, 1.33);
   }
 
   &--active &__content {
@@ -90,7 +90,7 @@
     background: transparent;
     border: none;
     color: $brand-color;
-    @include font-size(20px);
+    @include font-size(18px, 1.33);
     font-weight: $font-weight-normal;
     padding: 0;
     box-shadow: $link;
@@ -123,7 +123,6 @@
       min-height: 100vh;
     }
   }
-
 
   &--fullscreen &__content {
     @include mq(tablet) {

--- a/packages/ndla-ui/src/FactBox/component.factbox.scss
+++ b/packages/ndla-ui/src/FactBox/component.factbox.scss
@@ -7,7 +7,7 @@ $padding-bottom: 17px;
   overflow: hidden;
   padding-bottom: $padding-bottom;
 
-  @include inuit-font-size(16px);
+  @include font-size(16px, 1.5);
 
   &__content {
     position: relative;
@@ -148,7 +148,7 @@ $padding-bottom: 17px;
     border-bottom: 2px solid $brand-color;
     margin-top: 0;
     margin-bottom: $spacing;
-    @include inuit-font-size(22px, 34px);
+    @include font-size(22px, 34px);
     font-weight: $font-weight-bold;
     position: relative;
     z-index: 2;
@@ -159,7 +159,7 @@ $padding-bottom: 17px;
   h4,
   h5 {
     display: block;
-    @include inuit-font-size(16px);
+    @include font-size(16px, 1.5);
     letter-spacing: 0.1em;
     margin-top: $spacing;
     margin-bottom: $spacing--small;

--- a/packages/ndla-ui/src/Figure/component.figure-license.scss
+++ b/packages/ndla-ui/src/Figure/component.figure-license.scss
@@ -7,7 +7,7 @@
 **/
 
 .c-figure-license {
-  @include font-size(16px);
+  @include font-size(16px, 1.5);
   font-family: $font-serif;
 }
 
@@ -57,7 +57,7 @@
   background: transparent;
   border: none;
   color: $brand-color;
-  @include font-size(20px);
+  @include font-size(18px, 1.33);
   font-weight: $font-weight-normal;
   z-index: 9;
   cursor: pointer;
@@ -71,7 +71,7 @@
 
 .c-figure-license__title {
   margin: 0 0 $spacing--small;
-  @include inuit-font-size(18px);
+  @include font-size(18px, 1.33);
   color: $brand-color;
 }
 .c-figure-license--fullscreen {
@@ -84,7 +84,7 @@
 }
 
 .c-figure-license__image-title {
-  @include inuit-font-size(28px);
+  @include font-size(28px, 30px);
   margin: $spacing 0 0;
   text-align: left;
 }

--- a/packages/ndla-ui/src/Figure/component.figure.scss
+++ b/packages/ndla-ui/src/Figure/component.figure.scss
@@ -154,7 +154,7 @@
   margin-bottom: $spacing--small;
   font-family: $font;
   color: $primary-color;
-  @include inuit-font-size(16px, 24px);
+  @include font-size(16px, 24px);
   @include mq($from: tablet) {
     flex: 2;
     margin-bottom: $spacing--small;

--- a/packages/ndla-ui/src/MediaList/component.medialist.scss
+++ b/packages/ndla-ui/src/MediaList/component.medialist.scss
@@ -28,7 +28,7 @@
 }
 
 .c-medialist__body {
-  @include inuit-font-size(14px, 24px);
+  @include font-size(14px, 24px);
   @include mq(tablet) {
     max-width: 70% !important;
   }
@@ -143,7 +143,7 @@
 .c-medialist__title {
   margin-top: 0;
   margin-bottom: $spacing--small/2;
-  @include inuit-font-size(16px);
+  @include font-size(16px, 1.5);
   color: $brand-color;
   + p {
     margin-top: 0;

--- a/packages/ndla-ui/src/Navigation/NavigationBox.tsx
+++ b/packages/ndla-ui/src/Navigation/NavigationBox.tsx
@@ -8,6 +8,7 @@ import { Switch } from '@ndla/switch';
 import { uuid } from '@ndla/util';
 import { useTranslation } from 'react-i18next';
 import { HumanMaleBoard } from '@ndla/icons/common';
+import { Heading } from '../Typography';
 
 const StyledWrapper = styled.nav`
   margin: 20px 0 34px;
@@ -18,19 +19,10 @@ const StyledHeadingWrapper = styled.div`
   align-items: baseline;
 `;
 
-type InvertItProps = {
-  invertedStyle?: boolean;
-};
-
-const StyledHeading = styled.h2<InvertItProps>`
-  ${fonts.sizes('18px', '32px')};
-  text-transform: uppercase;
-  margin: 0 0 10px;
-  ${(props) =>
-    props.invertedStyle &&
-    css`
-      color: #fff;
-    `}
+const StyledHeading = styled(Heading)`
+  &[data-inverted='true'] {
+    color: ${colors.white};
+  }
 `;
 
 type listProps = {
@@ -216,7 +208,11 @@ export const NavigationBox = ({
   return (
     <StyledWrapper>
       <StyledHeadingWrapper>
-        {heading && <StyledHeading invertedStyle={invertedStyle}>{heading}</StyledHeading>}
+        {heading && (
+          <StyledHeading element="h2" margin="small" headingStyle="list-title" data-inverted={invertedStyle}>
+            {heading}
+          </StyledHeading>
+        )}
         {hasAdditionalResources && (
           <Switch
             id={uuid()}

--- a/packages/ndla-ui/src/Navigation/NavigationHeading.tsx
+++ b/packages/ndla-ui/src/Navigation/NavigationHeading.tsx
@@ -1,29 +1,12 @@
 import React, { ReactNode } from 'react';
 import styled from '@emotion/styled';
-import { css } from '@emotion/react';
-import { breakpoints, fonts, mq } from '@ndla/core';
+import { breakpoints, colors, fonts, mq } from '@ndla/core';
+import { Heading } from '../Typography';
 
-type InvertItProps = {
-  invertedStyle?: boolean;
-};
-
-const StyledH1 = styled.h1<InvertItProps>`
-  ${fonts.sizes('24px', '28px')};
-  margin: 30px 0 20px 0;
-  font-weight: ${fonts.weight.bold};
-  ${mq.range({ from: breakpoints.tablet })} {
-    margin: 40px 0 22px;
-    ${fonts.sizes('40px', '48px')};
+const StyledHeading = styled(Heading)`
+  &[data-inverted='true'] {
+    color: ${colors.white};
   }
-  ${mq.range({ from: breakpoints.desktop })} {
-    margin: 50px 0 24px;
-    ${fonts.sizes('52px', '65px')};
-  }
-  ${(props) =>
-    props.invertedStyle &&
-    css`
-      color: #fff;
-    `}
 `;
 const StyledMainText = styled.span`
   display: block;
@@ -49,10 +32,18 @@ type Props = {
 };
 
 export const NavigationHeading = ({ subHeading, children, invertedStyle, headingId }: Props) => (
-  <StyledH1 invertedStyle={invertedStyle} id={headingId} tabIndex={-1}>
+  <StyledHeading
+    element="h1"
+    margin="xlarge"
+    headingStyle="h1"
+    serif
+    data-inverted={invertedStyle}
+    id={headingId}
+    tabIndex={-1}
+  >
     {subHeading && <StyledSubText>{subHeading}</StyledSubText>}
     <StyledMainText>{children}</StyledMainText>
-  </StyledH1>
+  </StyledHeading>
 );
 
 export default NavigationHeading;

--- a/packages/ndla-ui/src/RelatedArticleList/component.related-articles.scss
+++ b/packages/ndla-ui/src/RelatedArticleList/component.related-articles.scss
@@ -77,14 +77,10 @@
   }
 
   &__title {
-    @include font-size(18px);
+    @include font-size(18px, 1.33);
     margin: 0 0 $spacing--small 0;
     font-weight: $font-weight-semibold;
     display: flex;
-
-    @include chinese() {
-      @include font-size(20px);
-    }
 
     .c-content-type-badge {
       flex-shrink: 0;
@@ -93,16 +89,10 @@
   }
 
   &__description {
-    @include font-size(16px);
-
-    @include chinese() {
-      @include font-size(18px);
-    }
+    @include font-size(16px, 1.5);
 
     span {
-      @include chinese() {
-        @include font-size(18px);
-      }
+      @include font-size(16px, 1.5);
     }
 
     margin: 0;

--- a/packages/ndla-ui/src/Table/component.tables.scss
+++ b/packages/ndla-ui/src/Table/component.tables.scss
@@ -83,31 +83,6 @@ article table {
 
   // scrolling shadows on left/right
 
-  @include chinese() {
-    th {
-      @include font-size(18px, 22px);
-
-      @include mq(tablet) {
-        @include font-size(18px, 30px);
-      }
-    }
-
-    thead tr:nth-child(2) th {
-      @include font-size(16px, 18px);
-
-      @include mq(tablet) {
-        @include font-size(18px, 26px);
-      }
-    }
-
-    td {
-      @include font-size(16px, 22px);
-      @include mq(tablet) {
-        @include font-size(18px, 30px);
-      }
-    }
-  }
-
   &:after,
   &:before {
     content: '';
@@ -144,13 +119,6 @@ article table {
     @include mq(tablet) {
       @include font-size(16px, 30px);
     }
-
-    @include chinese() {
-      @include font-size(18px, 22px);
-      @include mq(tablet) {
-        @include font-size(18px, 30px);
-      }
-    }
   }
 
   tbody th {
@@ -174,13 +142,6 @@ article table {
     &:empty {
       background-color: transparent;
     }
-
-    @include chinese() {
-      @include font-size(16px, 18px);
-      @include mq(tablet) {
-        @include font-size(18px, 26px);
-      }
-    }
   }
 
   td {
@@ -191,13 +152,6 @@ article table {
     @include font-size(14px, 22px);
     @include mq(tablet) {
       @include font-size(15px, 30px);
-    }
-
-    @include chinese() {
-      @include font-size(16px, 22px);
-      @include mq(tablet) {
-        @include font-size(18px, 30px);
-      }
     }
 
     p {

--- a/packages/ndla-ui/src/Translation/component.translation.scss
+++ b/packages/ndla-ui/src/Translation/component.translation.scss
@@ -38,12 +38,10 @@
   margin-left: 0;
 }
 .c-translation__line-body {
-  @include chinese() {
-    @include font-size(18px, 28px);
+  @include font-size(16px, 26px);
 
-    @include mq(tablet) {
-      @include font-size(20px, 32px);
-    }
+  @include mq(tablet) {
+    @include font-size(18px, 30px);
   }
 }
 

--- a/packages/ndla-ui/src/Typography/Heading.tsx
+++ b/packages/ndla-ui/src/Typography/Heading.tsx
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { css } from '@emotion/react';
+import { breakpoints, fonts, mq, spacing } from '@ndla/core';
+import { HTMLAttributes, ReactNode } from 'react';
+import { HeadingLevel } from '../types';
+
+const style = css`
+  font-weight: ${fonts.weight.bold};
+  font-family: ${fonts.sans};
+  ${fonts.sizes('22px', '30px')};
+  margin: ${spacing.normal} 0 ${spacing.normal} 0;
+
+  &[data-margin='none'] {
+    margin: 0px;
+  }
+  &[data-margin='xlarge'] {
+    margin: ${spacing.normal} 0 ${spacing.small} 0;
+    ${mq.range({ from: breakpoints.tablet })} {
+      margin-bottom: ${spacing.normal};
+    }
+  }
+  &[data-margin='large'] {
+    margin-top: ${spacing.large};
+    margin-bottom: ${spacing.small};
+  }
+  &[data-margin='small'] {
+    margin-top: ${spacing.normal};
+    margin-bottom: ${spacing.small};
+  }
+  &[data-style='h1'] {
+    ${fonts.sizes('30px', '36px')};
+    ${mq.range({ from: breakpoints.tablet })} {
+      ${fonts.sizes('48px', '60px')};
+      margin-bottom: ${spacing.normal};
+    }
+  }
+
+  &[data-style='h2'] {
+    ${fonts.sizes('28px', '36px')};
+    ${mq.range({ from: breakpoints.tablet })} {
+      ${fonts.sizes('30px', '38px')};
+    }
+  }
+
+  &[data-style='h3'] {
+    ${fonts.sizes('26px', '35px')};
+    ${mq.range({ from: breakpoints.tablet })} {
+      ${fonts.sizes('26px', '36px')};
+    }
+  }
+  &[data-style='list-title'] {
+    ${fonts.sizes('18px', '24px')};
+    text-transform: uppercase;
+  }
+`;
+
+type AllowedElements = HeadingLevel | 'p' | 'span';
+
+interface Props<T extends AllowedElements> extends HTMLAttributes<T> {
+  element: HeadingLevel | 'p' | 'span';
+  headingStyle: 'h1' | 'h2' | 'h3' | 'list-title' | 'default';
+  serif?: boolean;
+  /**
+   * General usage
+   * xlarge -> h1
+   * large -> h2
+   * normal -> anything else
+   */
+  margin?: 'xlarge' | 'large' | 'normal' | 'small' | 'none';
+  children: ReactNode;
+  className?: string;
+}
+
+const Heading = <T extends AllowedElements>({
+  element: Element,
+  children,
+  headingStyle,
+  margin = 'normal',
+  serif,
+  className,
+}: Props<T>) => {
+  return (
+    <Element css={style} data-serif={serif} data-style={headingStyle} data-margin={margin} className={className}>
+      {children}
+    </Element>
+  );
+};
+
+export default Heading;

--- a/packages/ndla-ui/src/Typography/index.ts
+++ b/packages/ndla-ui/src/Typography/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export { default as Heading } from './Heading';


### PR DESCRIPTION
Dette krever egentlig at vi setter oss ned og fjerner en hel del med `/styled.h/d`. Inntil videre har jeg bare valgt å gjøre dette ett sted. Annet enn det har jeg gjort en effort for å sentralisere kinesisk styling til to filer: `tools.aliases.scss`, og `fonts.ts`. Inntil videre sørger denne funksjonen bare for at kall til `font-size(16px, 1.5)` eller `fonts.sizes('16px', 20px)` autogenerer en ekstra stil for elementer som har språket sitt satt til kinesisk. Inntil videre har jeg valgt å  skalere font-størrelse og linjehøyde med 111%, men dette kan (og bør sikkert) justeres på.

Denne PR'en kommer til å brekke styling på ndla-frontend, listing-frontend og ED. Gjerne gi tilbakemelding, da dette er et ganske så vanskelig område å navigere seg i.

Ting som gjenstår:

- [ ] Oppdatere typografi-verdier i designmanual.
- [ ] Fjerne styling fra header-elementer, eller bytte om til `Heading`-komponenten.