### PR TITLE
Hjertemerking av embeds

### DIFF
--- a/packages/article-converter/src/index.ts
+++ b/packages/article-converter/src/index.ts
@@ -8,4 +8,4 @@
 
 export { default as transform } from './transform';
 export { default as extractEmbedMeta } from './extractEmbedMeta';
-export type { TransformOptions } from './plugins/types';
+export type { TransformOptions, DynamicComponents } from './plugins/types';

--- a/packages/article-converter/src/plugins/embed/audioEmbedPlugin.tsx
+++ b/packages/article-converter/src/plugins/embed/audioEmbedPlugin.tsx
@@ -11,8 +11,8 @@ import { AudioMetaData } from '@ndla/types-embed';
 import { AudioEmbed } from '@ndla/ui';
 import { PluginType } from '../types';
 
-export const audioEmbedPlugin: PluginType = (element) => {
+export const audioEmbedPlugin: PluginType = (element, _, opts) => {
   const props = attributesToProps(element.attribs);
   const data = JSON.parse(props['data-json']) as AudioMetaData;
-  return <AudioEmbed embed={data} />;
+  return <AudioEmbed embed={data} heartButton={opts.components?.heartButton} />;
 };

--- a/packages/article-converter/src/plugins/embed/brightcoveEmbedPlugin.tsx
+++ b/packages/article-converter/src/plugins/embed/brightcoveEmbedPlugin.tsx
@@ -11,8 +11,8 @@ import { BrightcoveMetaData } from '@ndla/types-embed';
 import { BrightcoveEmbed } from '@ndla/ui';
 import { PluginType } from '../types';
 
-export const brightcoveEmbedPlugin: PluginType = (element) => {
+export const brightcoveEmbedPlugin: PluginType = (element, _, opts) => {
   const props = attributesToProps(element.attribs);
   const data = JSON.parse(props['data-json']) as BrightcoveMetaData;
-  return <BrightcoveEmbed embed={data} />;
+  return <BrightcoveEmbed embed={data} heartButton={opts.components?.heartButton} />;
 };

--- a/packages/article-converter/src/plugins/embed/conceptEmbedPlugin.tsx
+++ b/packages/article-converter/src/plugins/embed/conceptEmbedPlugin.tsx
@@ -11,8 +11,8 @@ import { ConceptMetaData } from '@ndla/types-embed';
 import { ConceptEmbed } from '@ndla/ui';
 import { PluginType } from '../types';
 
-export const conceptEmbedPlugin: PluginType = (element) => {
+export const conceptEmbedPlugin: PluginType = (element, _, opts) => {
   const props = attributesToProps(element.attribs);
   const data = JSON.parse(props['data-json']) as ConceptMetaData;
-  return <ConceptEmbed embed={data} fullWidth />;
+  return <ConceptEmbed embed={data} fullWidth heartButton={opts.components?.heartButton} />;
 };

--- a/packages/article-converter/src/plugins/embed/imageEmbedPlugin.tsx
+++ b/packages/article-converter/src/plugins/embed/imageEmbedPlugin.tsx
@@ -14,5 +14,5 @@ import { PluginType } from '../types';
 export const imageEmbedPlugin: PluginType = (element, _, opts) => {
   const props = attributesToProps(element.attribs);
   const data = JSON.parse(props['data-json']) as ImageMetaData;
-  return <ImageEmbed embed={data} previewAlt={opts.previewAlt} />;
+  return <ImageEmbed embed={data} previewAlt={opts.previewAlt} heartButton={opts.components?.heartButton} />;
 };

--- a/packages/article-converter/src/plugins/types.ts
+++ b/packages/article-converter/src/plugins/types.ts
@@ -6,7 +6,12 @@
  *
  */
 
+import { HeartButtonType } from '@ndla/ui';
 import { Element, HTMLReactParserOptions } from 'html-react-parser';
+
+export interface DynamicComponents {
+  heartButton?: HeartButtonType;
+}
 
 export interface TransformOptions {
   isOembed?: boolean;
@@ -14,6 +19,7 @@ export interface TransformOptions {
   path?: string;
   previewAlt?: boolean;
   frontendDomain?: string;
+  components?: DynamicComponents;
 }
 
 export type PluginType = (

--- a/packages/ndla-ui/src/Embed/AudioEmbed.stories.tsx
+++ b/packages/ndla-ui/src/Embed/AudioEmbed.stories.tsx
@@ -11,6 +11,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { AudioEmbedData, AudioMeta } from '@ndla/types-embed';
 import AudioEmbed from './AudioEmbed';
 import { defaultParameters } from '../../../../stories/defaults';
+import StoryFavoriteButton from '../../../../stories/StoryFavoriteButton';
 
 const embedData: AudioEmbedData = {
   resource: 'audio',
@@ -176,6 +177,7 @@ export default meta;
 
 export const AudioEmbedStory: StoryObj<typeof AudioEmbed> = {
   args: {
+    heartButton: StoryFavoriteButton,
     embed: {
       resource: 'audio',
       status: 'success',
@@ -188,6 +190,7 @@ export const AudioEmbedStory: StoryObj<typeof AudioEmbed> = {
 
 export const AudioEmbedFailed: StoryObj<typeof AudioEmbed> = {
   args: {
+    heartButton: StoryFavoriteButton,
     embed: {
       resource: 'audio',
       status: 'error',
@@ -199,6 +202,7 @@ export const AudioEmbedFailed: StoryObj<typeof AudioEmbed> = {
 
 export const Podcast: StoryObj<typeof AudioEmbed> = {
   args: {
+    heartButton: StoryFavoriteButton,
     embed: {
       resource: 'audio',
       status: 'success',
@@ -211,6 +215,7 @@ export const Podcast: StoryObj<typeof AudioEmbed> = {
 
 export const PodcastFailed: StoryObj<typeof AudioEmbed> = {
   args: {
+    heartButton: StoryFavoriteButton,
     embed: {
       resource: 'audio',
       status: 'error',

--- a/packages/ndla-ui/src/Embed/BrightcoveEmbed.stories.tsx
+++ b/packages/ndla-ui/src/Embed/BrightcoveEmbed.stories.tsx
@@ -8,9 +8,10 @@
 
 import React from 'react';
 import { Meta, StoryObj } from '@storybook/react';
-import { BrightcoveData, BrightcoveEmbedData, BrightcoveMetaData } from '@ndla/types-embed';
+import { BrightcoveData, BrightcoveEmbedData, BrightcoveMetaData, EmbedMetaData } from '@ndla/types-embed';
 import BrightcoveEmbed from './BrightcoveEmbed';
 import { defaultParameters } from '../../../../stories/defaults';
+import StoryFavoriteButton from '../../../../stories/StoryFavoriteButton';
 
 const embedData: BrightcoveEmbedData = {
   resource: 'brightcove',
@@ -179,6 +180,7 @@ export default meta;
 
 export const BrightcoveEmbedStory: StoryObj<typeof BrightcoveEmbed> = {
   args: {
+    heartButton: StoryFavoriteButton,
     embed: {
       resource: 'brightcove',
       status: 'success',
@@ -191,12 +193,14 @@ export const BrightcoveEmbedStory: StoryObj<typeof BrightcoveEmbed> = {
 
 export const VisuallyInterpreted: StoryObj<typeof BrightcoveEmbed> = {
   args: {
+    heartButton: StoryFavoriteButton,
     embed: visuallyInterpretedEmbedMetaData,
   },
 };
 
 export const BrightcoveFailed: StoryObj<typeof BrightcoveEmbed> = {
   args: {
+    heartButton: StoryFavoriteButton,
     embed: {
       resource: 'brightcove',
       status: 'error',

--- a/packages/ndla-ui/src/Embed/BrightcoveEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/BrightcoveEmbed.tsx
@@ -17,10 +17,12 @@ import { ButtonV2 } from '@ndla/button';
 import { Figure } from '../Figure';
 import { EmbedByline } from '../LicenseByline';
 import EmbedErrorPlaceholder from './EmbedErrorPlaceholder';
+import { HeartButtonType } from './types';
 
 interface Props {
   embed: BrightcoveMetaData;
   isConcept?: boolean;
+  heartButton?: HeartButtonType;
 }
 
 const LinkedVideoButton = styled(ButtonV2)`
@@ -54,7 +56,7 @@ const getIframeProps = (data: BrightcoveEmbedData, sources: BrightcoveVideoSourc
     width: source?.width ?? '640',
   };
 };
-const BrightcoveEmbed = ({ embed, isConcept }: Props) => {
+const BrightcoveEmbed = ({ embed, isConcept, heartButton: HeartButton }: Props) => {
   const [showOriginalVideo, setShowOriginalVideo] = useState(true);
   const { t } = useTranslation();
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -117,6 +119,7 @@ const BrightcoveEmbed = ({ embed, isConcept }: Props) => {
             {t(`figure.button.${!showOriginalVideo ? 'original' : 'alternative'}`)}
           </LinkedVideoButton>
         )}
+        {HeartButton && <HeartButton embed={embed} />}
       </EmbedByline>
     </Figure>
   );

--- a/packages/ndla-ui/src/Embed/ConceptEmbed.stories.tsx
+++ b/packages/ndla-ui/src/Embed/ConceptEmbed.stories.tsx
@@ -11,6 +11,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { ConceptData, ConceptEmbedData } from '@ndla/types-embed';
 import ConceptEmbed from './ConceptEmbed';
 import { defaultParameters } from '../../../../stories/defaults';
+import StoryFavoriteButton from '../../../../stories/StoryFavoriteButton';
 
 const blockEmbedData: ConceptEmbedData = {
   contentId: '35',
@@ -145,6 +146,7 @@ export default meta;
 
 export const Block: StoryObj<typeof ConceptEmbed> = {
   args: {
+    heartButton: StoryFavoriteButton,
     embed: {
       resource: 'concept',
       status: 'success',
@@ -157,6 +159,7 @@ export const Block: StoryObj<typeof ConceptEmbed> = {
 
 export const BlockFailed: StoryObj<typeof ConceptEmbed> = {
   args: {
+    heartButton: StoryFavoriteButton,
     embed: {
       resource: 'concept',
       status: 'error',
@@ -168,6 +171,7 @@ export const BlockFailed: StoryObj<typeof ConceptEmbed> = {
 
 export const Inline: StoryObj<typeof ConceptEmbed> = {
   args: {
+    heartButton: StoryFavoriteButton,
     embed: {
       resource: 'concept',
       status: 'success',
@@ -180,6 +184,7 @@ export const Inline: StoryObj<typeof ConceptEmbed> = {
 
 export const InlineFailed: StoryObj<typeof ConceptEmbed> = {
   args: {
+    heartButton: StoryFavoriteButton,
     embed: {
       resource: 'concept',
       status: 'error',

--- a/packages/ndla-ui/src/Embed/ConceptEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/ConceptEmbed.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { useCallback, useRef, useState } from 'react';
+import { ReactElement, ReactNode, useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from '@emotion/styled';
 import { isMobile } from 'react-device-detect';
@@ -22,6 +22,7 @@ import { NotionImage } from '../Notion/NotionImage';
 import { ConceptNotionV2, ConceptNotionData } from './conceptComponents';
 import { EmbedByline } from '../LicenseByline';
 import EmbedErrorPlaceholder from './EmbedErrorPlaceholder';
+import { HeartButtonType } from './types';
 
 const BottomBorder = styled.div`
   margin-top: ${spacing.normal};
@@ -71,6 +72,7 @@ const ImageWrapper = styled.div`
 interface Props {
   embed: ConceptMetaData;
   fullWidth?: boolean;
+  heartButton?: HeartButtonType;
 }
 
 const StyledButton = styled.button`
@@ -92,7 +94,7 @@ const StyledButton = styled.button`
   }
 `;
 
-export const ConceptEmbed = ({ embed, fullWidth }: Props) => {
+export const ConceptEmbed = ({ embed, fullWidth, heartButton: HeartButton }: Props) => {
   if (embed.status === 'error' && embed.embedData.type === 'inline') {
     return <span>{embed.embedData.linkText}</span>;
   } else if (embed.status === 'error') {
@@ -113,6 +115,8 @@ export const ConceptEmbed = ({ embed, fullWidth }: Props) => {
         copyright={concept.copyright}
         source={concept.source}
         visualElement={visualElement}
+        heartButton={HeartButton}
+        conceptHeartButton={HeartButton && <HeartButton embed={embed} />}
       />
     );
   } else if (embed.embedData.type === 'inline') {
@@ -125,6 +129,8 @@ export const ConceptEmbed = ({ embed, fullWidth }: Props) => {
         source={concept.source}
         visualElement={visualElement}
         linkText={embed.embedData.linkText}
+        heartButton={HeartButton}
+        conceptHeartButton={HeartButton && <HeartButton embed={embed} />}
       />
     );
   } else {
@@ -136,6 +142,8 @@ export const ConceptEmbed = ({ embed, fullWidth }: Props) => {
         copyright={concept.copyright}
         source={concept.source}
         visualElement={visualElement}
+        heartButton={HeartButton}
+        conceptHeartButton={HeartButton && <HeartButton embed={embed} />}
       />
     );
   }
@@ -143,6 +151,8 @@ export const ConceptEmbed = ({ embed, fullWidth }: Props) => {
 
 interface InlineConceptProps extends ConceptNotionData {
   linkText: string;
+  heartButton?: HeartButtonType;
+  conceptHeartButton?: ReactNode;
 }
 
 const BaselineIcon = styled.span`
@@ -203,7 +213,16 @@ const getModalPosition = (anchor: HTMLElement) => {
   return anchorPos.top - (articlePos?.top || -window.scrollY);
 };
 
-const InlineConcept = ({ title, content, copyright, source, visualElement, linkText }: InlineConceptProps) => {
+const InlineConcept = ({
+  title,
+  content,
+  copyright,
+  source,
+  visualElement,
+  linkText,
+  heartButton,
+  conceptHeartButton,
+}: InlineConceptProps) => {
   const { t } = useTranslation();
   const anchorRef = useRef<HTMLDivElement>(null);
   const [modalPos, setModalPos] = useState(-9999);
@@ -241,6 +260,8 @@ const InlineConcept = ({ title, content, copyright, source, visualElement, linkT
               source={source}
               visualElement={visualElement}
               inPopover
+              heartButton={heartButton}
+              conceptHeartButton={conceptHeartButton}
               closeButton={
                 <Close asChild>
                   <IconButtonV2 aria-label={t('close')} variant="ghost">
@@ -258,6 +279,8 @@ const InlineConcept = ({ title, content, copyright, source, visualElement, linkT
 
 interface ConceptProps extends ConceptNotionData {
   fullWidth?: boolean;
+  heartButton?: HeartButtonType;
+  conceptHeartButton?: ReactElement;
 }
 
 export const BlockConcept = ({
@@ -268,6 +291,8 @@ export const BlockConcept = ({
   source,
   visualElement,
   fullWidth,
+  heartButton,
+  conceptHeartButton,
 }: ConceptProps) => {
   const { t } = useTranslation();
   const anchorRef = useRef<HTMLDivElement>(null);
@@ -337,6 +362,8 @@ export const BlockConcept = ({
                         copyright={copyright}
                         source={source}
                         visualElement={visualElement}
+                        heartButton={heartButton}
+                        conceptHeartButton={conceptHeartButton}
                         inPopover
                         closeButton={
                           <Close asChild>
@@ -353,7 +380,13 @@ export const BlockConcept = ({
             )
           }
         />
-        {copyright ? <EmbedByline copyright={copyright} bottomRounded topRounded type="concept" /> : <BottomBorder />}
+        {copyright ? (
+          <EmbedByline copyright={copyright} bottomRounded topRounded type="concept">
+            {conceptHeartButton}
+          </EmbedByline>
+        ) : (
+          <BottomBorder />
+        )}
       </Figure>
     </Root>
   );

--- a/packages/ndla-ui/src/Embed/ImageEmbed.stories.tsx
+++ b/packages/ndla-ui/src/Embed/ImageEmbed.stories.tsx
@@ -12,6 +12,7 @@ import { ImageEmbedData } from '@ndla/types-embed';
 import { IImageMetaInformationV2 } from '@ndla/types-backend/build/image-api';
 import ImageEmbed from './ImageEmbed';
 import { defaultParameters } from '../../../../stories/defaults';
+import StoryFavoriteButton from '../../../../stories/StoryFavoriteButton';
 
 const embedData: ImageEmbedData = {
   resource: 'image',
@@ -81,6 +82,7 @@ export default meta;
 
 export const ImageEmbedStory: StoryObj<typeof ImageEmbed> = {
   args: {
+    heartButton: StoryFavoriteButton,
     embed: {
       resource: 'image',
       status: 'success',
@@ -93,6 +95,7 @@ export const ImageEmbedStory: StoryObj<typeof ImageEmbed> = {
 
 export const Failed: StoryObj<typeof ImageEmbed> = {
   args: {
+    heartButton: StoryFavoriteButton,
     embed: {
       resource: 'image',
       status: 'error',

--- a/packages/ndla-ui/src/Embed/ImageEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/ImageEmbed.tsx
@@ -16,10 +16,12 @@ import { Figure, FigureType } from '../Figure';
 import Image, { ImageLink } from '../Image';
 import { EmbedByline } from '../LicenseByline';
 import EmbedErrorPlaceholder from './EmbedErrorPlaceholder';
+import { HeartButtonType } from './types';
 
 interface Props {
   embed: ImageMetaData;
   previewAlt?: boolean;
+  heartButton?: HeartButtonType;
 }
 
 export interface Author {
@@ -96,7 +98,7 @@ const getCrop = (data: ImageEmbedData) => {
 
 const expandedSizes = '(min-width: 1024px) 1024px, 100vw';
 
-const ImageEmbed = ({ embed, previewAlt }: Props) => {
+const ImageEmbed = ({ embed, previewAlt, heartButton: HeartButton }: Props) => {
   const [isBylineHidden, setIsBylineHidden] = useState(hideByline(embed.embedData.size));
   const [imageSizes, setImageSizes] = useState<string | undefined>(undefined);
   if (embed.status === 'error') {
@@ -149,7 +151,9 @@ const ImageEmbed = ({ embed, previewAlt }: Props) => {
           description={data.caption.caption}
           bottomRounded
           visibleAlt={previewAlt ? embed.embedData.alt : ''}
-        />
+        >
+          {HeartButton && <HeartButton embed={embed} />}
+        </EmbedByline>
       )}
     </Figure>
   );

--- a/packages/ndla-ui/src/Embed/conceptComponents.tsx
+++ b/packages/ndla-ui/src/Embed/conceptComponents.tsx
@@ -18,7 +18,7 @@ import { Copyright } from '../types';
 import ImageEmbed from './ImageEmbed';
 import BrightcoveEmbed from './BrightcoveEmbed';
 import H5pEmbed from './H5pEmbed';
-import { ExternalEmbed, IframeEmbed } from '.';
+import { ExternalEmbed, HeartButtonType, IframeEmbed } from '.';
 import { EmbedByline } from '../LicenseByline';
 
 export interface ConceptNotionData {
@@ -40,6 +40,8 @@ interface ConceptNotionProps extends RefAttributes<HTMLDivElement>, ConceptNotio
   inPopover?: boolean;
   tags?: string[];
   subjects?: string[];
+  heartButton?: HeartButtonType;
+  conceptHeartButton?: ReactNode;
 }
 
 const ContentPadding = styled.div`
@@ -135,7 +137,21 @@ const StyledList = styled.ul`
 
 export const ConceptNotionV2 = forwardRef<HTMLDivElement, ConceptNotionProps>(
   (
-    { visualElement, title, content, source, copyright, closeButton, inPopover, previewAlt, tags, subjects, ...rest },
+    {
+      visualElement,
+      title,
+      content,
+      source,
+      copyright,
+      closeButton,
+      inPopover,
+      previewAlt,
+      tags,
+      subjects,
+      heartButton,
+      conceptHeartButton,
+      ...rest
+    },
     ref,
   ) => {
     const { t } = useTranslation();
@@ -151,9 +167,9 @@ export const ConceptNotionV2 = forwardRef<HTMLDivElement, ConceptNotionProps>(
           </NotionHeader>
           <StyledNotionDialogContent>
             {visualElement?.resource === 'image' ? (
-              <ImageEmbed embed={visualElement} />
+              <ImageEmbed embed={visualElement} heartButton={heartButton} />
             ) : visualElement?.resource === 'brightcove' ? (
-              <BrightcoveEmbed embed={visualElement} />
+              <BrightcoveEmbed embed={visualElement} heartButton={heartButton} />
             ) : visualElement?.resource === 'h5p' ? (
               <H5pEmbed embed={visualElement} />
             ) : visualElement?.resource === 'iframe' ? (
@@ -184,7 +200,11 @@ export const ConceptNotionV2 = forwardRef<HTMLDivElement, ConceptNotionProps>(
             </ListWrapper>
           )}
         </ContentPadding>
-        {copyright && <EmbedByline copyright={copyright} type="concept" />}
+        {copyright && (
+          <EmbedByline copyright={copyright} type="concept">
+            {conceptHeartButton}
+          </EmbedByline>
+        )}
       </div>
     );
   },

--- a/packages/ndla-ui/src/Embed/index.ts
+++ b/packages/ndla-ui/src/Embed/index.ts
@@ -19,3 +19,4 @@ export { default as ConceptEmbed } from './ConceptEmbed';
 export { ConceptNotionV2 } from './conceptComponents';
 export { default as ConceptListEmbed } from './ConceptListEmbed';
 export { default as UnknownEmbed } from './UnknownEmbed';
+export type { HeartButtonType } from './types';

--- a/packages/ndla-ui/src/Embed/types.ts
+++ b/packages/ndla-ui/src/Embed/types.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { ElementType } from 'react';
+import { EmbedMetaData } from '@ndla/types-embed';
+
+export type HeartButtonType = ElementType<{ embed: Extract<EmbedMetaData, { status: 'success' }> }>;

--- a/packages/ndla-ui/src/Resource/resourceComponents.tsx
+++ b/packages/ndla-ui/src/Resource/resourceComponents.tsx
@@ -8,13 +8,15 @@
 
 import styled from '@emotion/styled';
 import { colors, fonts, spacing } from '@ndla/core';
-import React, { MouseEvent, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MenuButton } from '@ndla/button';
 import SafeLink from '@ndla/safelink';
 import { useNavigate } from 'react-router-dom';
 import { HashTag } from '@ndla/icons/common';
 import resourceTypeColor from '../utils/resourceTypeColor';
+import { resourceTypeMapping } from '../model/ContentType';
+
 export interface ResourceImageProps {
   alt: string;
   src: string;
@@ -196,7 +198,7 @@ export const ResourceTypeList = ({ resourceTypes }: ResourceTypeListProps) => {
     <StyledResourceTypeList aria-label={t('navigation.topics')}>
       {resourceTypes.map((resource, i) => (
         <StyledResourceListElement key={resource.id}>
-          {resource.name}
+          {resourceTypeMapping[resource.id] ? t(`embed.type.${resourceTypeMapping[resource.id]}`) : resource.name}
           {i !== resourceTypes.length - 1 && <StyledTopicDivider aria-hidden="true">•</StyledTopicDivider>}
         </StyledResourceListElement>
       ))}

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -275,3 +275,4 @@ export { OrderedList, UnOrderedList } from './List';
 export { BlogPostV2 } from './BlogPost';
 export { KeyFigure } from './KeyFigure';
 export { default as ContactBlock } from './ContactBlock';
+export type { HeartButtonType } from './Embed';

--- a/packages/ndla-ui/src/model/ContentType.ts
+++ b/packages/ndla-ui/src/model/ContentType.ts
@@ -35,18 +35,6 @@ export const RESOURCE_TYPE_ASSESSMENT_RESOURCES = 'urn:resourcetype:reviewResour
 export const RESOURCE_TYPE_EXTERNAL_LEARNING_RESOURCES = 'urn:resourcetype:externalResource';
 export const RESOURCE_TYPE_SOURCE_MATERIAL = 'urn:resourcetype:SourceMaterial';
 
-export const RESOURCE_TYPE_RESOURCE_IMAGE = 'urn:resourcetype:image';
-export const RESOURCE_TYPE_RESOURCE_VIDEO = 'urn:resourcetype:video';
-export const RESOURCE_TYPE_RESOURCE_CONCEPT = 'urn:resourcetype:concept';
-export const RESOURCE_TYPE_RESOURCE_AUDIO = 'urn:resourcetype:audio';
-
-export const RESOURCE_TYPE_RESOURCES = [
-  RESOURCE_TYPE_RESOURCE_IMAGE,
-  RESOURCE_TYPE_RESOURCE_VIDEO,
-  RESOURCE_TYPE_RESOURCE_CONCEPT,
-  RESOURCE_TYPE_RESOURCE_AUDIO,
-];
-
 export const ListOfContentTypes = [
   'SUBJECT_MATERIAL',
   'TASKS_AND_ACTIVITIES',
@@ -70,8 +58,8 @@ export const contentTypeMapping: Record<string, string> = {
 };
 
 export const resourceTypeMapping: Record<string, string> = {
-  [RESOURCE_TYPE_RESOURCE_IMAGE]: 'image',
-  [RESOURCE_TYPE_RESOURCE_VIDEO]: 'video',
-  [RESOURCE_TYPE_RESOURCE_CONCEPT]: 'concept',
-  [RESOURCE_TYPE_RESOURCE_AUDIO]: 'audio',
+  image: 'image',
+  video: 'video',
+  concept: 'concept',
+  audio: 'audio',
 };

--- a/packages/ndla-ui/src/model/ContentType.ts
+++ b/packages/ndla-ui/src/model/ContentType.ts
@@ -35,6 +35,18 @@ export const RESOURCE_TYPE_ASSESSMENT_RESOURCES = 'urn:resourcetype:reviewResour
 export const RESOURCE_TYPE_EXTERNAL_LEARNING_RESOURCES = 'urn:resourcetype:externalResource';
 export const RESOURCE_TYPE_SOURCE_MATERIAL = 'urn:resourcetype:SourceMaterial';
 
+export const RESOURCE_TYPE_RESOURCE_IMAGE = 'urn:resourcetype:image';
+export const RESOURCE_TYPE_RESOURCE_VIDEO = 'urn:resourcetype:video';
+export const RESOURCE_TYPE_RESOURCE_CONCEPT = 'urn:resourcetype:concept';
+export const RESOURCE_TYPE_RESOURCE_AUDIO = 'urn:resourcetype:audio';
+
+export const RESOURCE_TYPE_RESOURCES = [
+  RESOURCE_TYPE_RESOURCE_IMAGE,
+  RESOURCE_TYPE_RESOURCE_VIDEO,
+  RESOURCE_TYPE_RESOURCE_CONCEPT,
+  RESOURCE_TYPE_RESOURCE_AUDIO,
+];
+
 export const ListOfContentTypes = [
   'SUBJECT_MATERIAL',
   'TASKS_AND_ACTIVITIES',
@@ -55,4 +67,11 @@ export const contentTypeMapping: Record<string, string> = {
   [RESOURCE_TYPE_EXTERNAL_LEARNING_RESOURCES]: EXTERNAL_LEARNING_RESOURCES,
   [RESOURCE_TYPE_SOURCE_MATERIAL]: SOURCE_MATERIAL,
   default: SUBJECT_MATERIAL,
+};
+
+export const resourceTypeMapping: Record<string, string> = {
+  [RESOURCE_TYPE_RESOURCE_IMAGE]: 'image',
+  [RESOURCE_TYPE_RESOURCE_VIDEO]: 'video',
+  [RESOURCE_TYPE_RESOURCE_CONCEPT]: 'concept',
+  [RESOURCE_TYPE_RESOURCE_AUDIO]: 'audio',
 };

--- a/stories/StoryFavoriteButton.tsx
+++ b/stories/StoryFavoriteButton.tsx
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { FavoriteButton } from '@ndla/button';
+import { EmbedMetaData } from '@ndla/types-embed';
+
+interface Props {
+  embed: Extract<EmbedMetaData, { status: 'success' }>;
+}
+
+const StoryFavoriteButton = ({ embed }: Props) => {
+  return <FavoriteButton />;
+};
+
+export default StoryFavoriteButton;


### PR DESCRIPTION
Legger til støtte for å sende inn en hjerteknapp til article-converter.
Tar over for https://github.com/NDLANO/frontend-packages/pull/1563