### PR TITLE
Small embed fixes 

### DIFF
--- a/packages/ndla-ui/src/AudioPlayer/initAudioPlayers.tsx
+++ b/packages/ndla-ui/src/AudioPlayer/initAudioPlayers.tsx
@@ -7,11 +7,16 @@
  */
 import React from 'react';
 import ReactDOM from 'react-dom';
-
+import shave from 'shave';
 import Controls from './Controls';
 import SpeechControl from './SpeechControl';
 import { Locale } from '../types';
-import { truncateDescription } from './AudioPlayer';
+
+export const truncateDescription = (el: HTMLElement, readMoreLabel: string | null) => {
+  shave(el, 90, {
+    character: `... <a href="#" onclick="(function(e){e.preventDefault(); const parentNode = e.target.parentNode; parentNode.nextSibling.style.display = 'inline'; parentNode.remove();return false;})(arguments[0]);return false;">${readMoreLabel}</a>`,
+  });
+};
 
 const forEachElement = (selector: string, callback: Function) => {
   const nodeList = document.querySelectorAll(selector);

--- a/packages/ndla-ui/src/Embed/AudioEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/AudioEmbed.tsx
@@ -62,8 +62,7 @@ const AudioEmbed = ({ embed, heartButton: HeartButton }: Props) => {
 
   const subtitle = data.series ? { title: data.series.title.title, url: `/podkast/${data.series.id}` } : undefined;
 
-  const textVersion = data.manuscript && renderMarkdown(data.manuscript.manuscript);
-  const description = renderMarkdown(data.podcastMeta?.introduction ?? '');
+  const textVersion = data.manuscript?.manuscript.length ? renderMarkdown(data.manuscript.manuscript) : undefined;
 
   const coverPhoto = data.podcastMeta?.coverPhoto;
 
@@ -74,7 +73,7 @@ const AudioEmbed = ({ embed, heartButton: HeartButton }: Props) => {
   return (
     <Figure id={figureId} type="full">
       <AudioPlayer
-        description={description}
+        description={data.podcastMeta?.introduction ?? ''}
         img={img}
         src={data.audioFile.url}
         textVersion={textVersion}

--- a/packages/ndla-ui/src/Embed/BrightcoveEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/BrightcoveEmbed.tsx
@@ -108,7 +108,12 @@ const BrightcoveEmbed = ({ embed, isConcept, heartButton: HeartButton }: Props) 
           allowFullScreen
         />
       </div>
-      <EmbedByline type="video" copyright={data.copyright!} description={data.description ?? ''} bottomRounded>
+      <EmbedByline
+        type="video"
+        copyright={data.copyright!}
+        description={embedData.caption ?? data.description ?? ''}
+        bottomRounded
+      >
         {!!linkedVideoId && (
           <LinkedVideoButton
             variant="outline"

--- a/packages/ndla-ui/src/Embed/ImageEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/ImageEmbed.tsx
@@ -144,11 +144,11 @@ const ImageEmbed = ({ embed, previewAlt, heartButton: HeartButton }: Props) => {
           }
         />
       </ImageWrapper>
-      {(!isSmall(embedData.size) || !isBylineHidden) && (
+      {isBylineHidden || (isSmall(embedData.size) && !imageSizes) ? null : (
         <EmbedByline
           type="image"
           copyright={data.copyright}
-          description={data.caption.caption}
+          description={embedData.caption ?? data.caption.caption}
           bottomRounded
           visibleAlt={previewAlt ? embed.embedData.alt : ''}
         >

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -1007,6 +1007,7 @@ const messages = {
       close: 'Close text version',
     },
     readMoreDescriptionLabel: 'show more',
+    readLessDescriptionLabel: 'show less',
   },
   h5p: {
     reuse: 'Use H5P',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -1006,6 +1006,7 @@ const messages = {
       close: 'Lukk tekstversjon',
     },
     readMoreDescriptionLabel: 'vis mer',
+    readLessDescriptionLabel: 'vis mindre',
   },
   h5p: {
     reuse: 'Bruk H5P',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -1006,6 +1006,7 @@ const messages = {
       close: 'Lukk tekstversjon',
     },
     readMoreDescriptionLabel: 'vis meir',
+    readLessDescriptionLabel: 'vis mindre',
   },
   h5p: {
     reuse: 'Bruk H5P',

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -1007,6 +1007,7 @@ const messages = {
       close: 'Govčča teakstavearšuvnna',
     },
     readMoreDescriptionLabel: 'Čájet eanet',
+    readLessDescriptionLabel: 'vis mindre',
   },
   h5p: {
     reuse: 'Geavat H5P',

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -1010,6 +1010,7 @@ const messages = {
       close: 'Dahph teeksteversjovnem',
     },
     readMoreDescriptionLabel: 'vis mer',
+    readLessDescriptionLabel: 'vis mindre',
   },
   h5p: {
     reuse: 'Bruk H5P',


### PR DESCRIPTION

* Bruk en mer React-aktig løsning for å vise/skjule full-teksten på podcast-introduksjon.
* Legge til mulighet for å skjule/vise byline på image-embeds som har satt skjul byline.
* Skjul byline på små bilder som kan ekspanderes. Vises når de er ekspandert.
* Bruker embedData sin caption før vi faller tilbake til metadataen sin caption på Brightcove og Image.