### PR TITLE
Do not set height to auto when receiving a h5p from oembed

### DIFF
--- a/packages/ndla-ui/src/Embed/H5pEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/H5pEmbed.tsx
@@ -30,7 +30,7 @@ const H5pEmbed = ({ embed, isConcept }: Props) => {
   const classes = `c-figure ${fullColumnClass} c-figure--resize`;
 
   if (embed.data.oembed) {
-    return <StyledFigure className={classes} dangerouslySetInnerHTML={{ __html: embed.data.oembed.html ?? '' }} />;
+    return <figure className={classes} dangerouslySetInnerHTML={{ __html: embed.data.oembed.html ?? '' }} />;
   }
 
   return (


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3559
Usikker på om dette er noe vi vil gjøre på h5p'er vi ikke får fra oembed også. Hva tenkes? Kan testes ved å linke inn alt og sjekke ut http://localhost:3000/article/37927?disableSSR=true. Krever nok at nye pakker er inne i ndla-frontend, og at man kjører GQL lokalt. Når det er oppdatert er dette en enkel one-liner. Ulempen er at h5p'en tar litt mye plass inntil den har lastet, som kan være en stund for h5p'er som denne (18mb).