### PR TITLE
Fall back to article page if a path cannot be found for a related content embed

### DIFF
--- a/packages/ndla-ui/src/Embed/RelatedContentEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/RelatedContentEmbed.tsx
@@ -30,7 +30,9 @@ const RelatedContentEmbed = ({ embed, isOembed, subject, ndlaFrontendDomain }: P
     const typeId = data.resource?.resourceTypes.find((rt) => contentTypeMapping[rt.id])?.id;
     const type = typeId ? contentTypeMapping[typeId] : undefined;
     const path =
-      data.resource?.paths.find((p) => p.split('/')[1] === subject?.replace('urn:', '')) ?? data.resource?.path;
+      data.resource?.paths.find((p) => p.split('/')[1] === subject?.replace('urn:', '')) ??
+      data.resource?.path ??
+      `/article/${embedData.articleId}`;
     return (
       <RelatedArticleV2
         title={data.article.title?.title ?? ''}


### PR DESCRIPTION
Faller altså tilbake til `/article/${id}`