### PR TITLE
Expose heading level for accordion header

### DIFF
--- a/packages/ndla-accordion/src/AccordionHeader.tsx
+++ b/packages/ndla-accordion/src/AccordionHeader.tsx
@@ -10,6 +10,7 @@ import { SerializedStyles } from '@emotion/react';
 import styled from '@emotion/styled';
 import { colors, fonts, spacing } from '@ndla/core';
 import { ChevronDown } from '@ndla/icons/common';
+import { HeadingLevel } from '@ndla/ui';
 import { Header, Trigger } from '@radix-ui/react-accordion';
 import { forwardRef, HTMLAttributes, ReactNode } from 'react';
 
@@ -58,17 +59,22 @@ const StyledChevron = styled(ChevronDown)`
 interface Props extends HTMLAttributes<HTMLButtonElement> {
   indicator?: ReactNode;
   headerCSS?: SerializedStyles;
+  headingLevel?: HeadingLevel;
 }
 
-const AccordionHeader = forwardRef<HTMLButtonElement, Props>(({ indicator, headerCSS, children, ...rest }, ref) => {
-  return (
-    <StyledHeader css={headerCSS}>
-      <StyledTrigger ref={ref} {...rest}>
-        {children}
-        {indicator ?? <StyledChevron />}
-      </StyledTrigger>
-    </StyledHeader>
-  );
-});
+const AccordionHeader = forwardRef<HTMLButtonElement, Props>(
+  ({ indicator, headingLevel: Heading = 'h3', headerCSS, children, ...rest }, ref) => {
+    return (
+      <StyledHeader css={headerCSS} asChild>
+        <Heading>
+          <StyledTrigger ref={ref} {...rest}>
+            {children}
+            {indicator ?? <StyledChevron />}
+          </StyledTrigger>
+        </Heading>
+      </StyledHeader>
+    );
+  },
+);
 
 export default AccordionHeader;

--- a/packages/ndla-accordion/src/AccordionHeader.tsx
+++ b/packages/ndla-accordion/src/AccordionHeader.tsx
@@ -10,7 +10,6 @@ import { SerializedStyles } from '@emotion/react';
 import styled from '@emotion/styled';
 import { colors, fonts, spacing } from '@ndla/core';
 import { ChevronDown } from '@ndla/icons/common';
-import { HeadingLevel } from '@ndla/ui';
 import { Header, Trigger } from '@radix-ui/react-accordion';
 import { forwardRef, HTMLAttributes, ReactNode } from 'react';
 
@@ -59,7 +58,7 @@ const StyledChevron = styled(ChevronDown)`
 interface Props extends HTMLAttributes<HTMLButtonElement> {
   indicator?: ReactNode;
   headerCSS?: SerializedStyles;
-  headingLevel?: HeadingLevel;
+  headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 }
 
 const AccordionHeader = forwardRef<HTMLButtonElement, Props>(

--- a/packages/ndla-ui/src/Article/ArticleByline.tsx
+++ b/packages/ndla-ui/src/Article/ArticleByline.tsx
@@ -149,14 +149,14 @@ const ArticleByline = ({
       <AccordionRoot type="multiple" onValueChange={setOpenAccordions} value={openAccordions}>
         {licenseBox && (
           <AccordionItem value="rulesForUse">
-            <AccordionHeader>{t('article.useContent')}</AccordionHeader>
+            <AccordionHeader headingLevel="h2">{t('article.useContent')}</AccordionHeader>
             <AccordionContent>{licenseBox}</AccordionContent>
           </AccordionItem>
         )}
 
         {!!footnotes?.length && (
           <AccordionItem value={referencesAccordionId}>
-            <AccordionHeader>Referanser</AccordionHeader>
+            <AccordionHeader headingLevel="h2">{t('article.references')}</AccordionHeader>
             <AccordionContent forceMount>
               <ArticleFootNotes footNotes={footnotes} />
             </AccordionContent>

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -278,3 +278,4 @@ export { default as ContactBlock } from './ContactBlock';
 export type { HeartButtonType } from './Embed';
 export { CampaignBlock } from './CampaignBlock';
 export { Heading } from './Typography';
+export type { HeadingLevel } from './types';

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -478,6 +478,7 @@ const messages = {
       onlyTeacher: 'This resource is accessible only to teachers who are logged in with Feide.',
     },
     possiblyOutdated: 'The article is outdated',
+    references: 'References',
   },
   competenceGoals: {
     competenceGoal: 'competence-goal',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -477,6 +477,7 @@ const messages = {
       onlyTeacher: 'Denne ressursen er bare tilgjengelig for lærere som er pålogget med Feide.',
     },
     possiblyOutdated: 'Artikkelen er foreldet.',
+    references: 'Referanser',
   },
   competenceGoals: {
     competenceGoal: 'kompetansemål',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -477,6 +477,7 @@ const messages = {
       onlyTeacher: 'Denne ressursen er berre tilgjengeleg for lærarar som er pålogga med Feide.',
     },
     possiblyOutdated: 'Artikkelen er foreldet.',
+    references: 'Referanser',
   },
   competenceGoals: {
     competenceGoal: 'kompetansemål',

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -478,6 +478,7 @@ const messages = {
       onlyTeacher: 'Dát resursa lea dušše olamuttus oahpaheddjiide geat leat Feide bokte sisaloggejuvvon.',
     },
     possiblyOutdated: 'Artihkal lea boarásmuvvan.',
+    references: 'Referanser',
   },
   competenceGoals: {
     competenceGoal: 'Gealbomihttomearri',

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -478,6 +478,7 @@ const messages = {
       onlyTeacher: 'Daate vierhtie ajve dïllesisnie lohkehtæjjide mah tjaangeme Feidine.',
     },
     possiblyOutdated: 'Artikkelen er foreldet.',
+    references: 'Referanser',
   },
   competenceGoals: {
     competenceGoal: 'maahtoe-ulmie',


### PR DESCRIPTION
Gjør også accordion-headerne om til h2 i article-byline, da det passer bedre med flyten til artikkelen.
Andre småfikser her:
* i18n for "Referanser" i accordion-tittel.