### PR TITLE
Replace lodash isNumber with native behavior

### DIFF
--- a/packages/ndla-editor/package.json
+++ b/packages/ndla-editor/package.json
@@ -36,7 +36,6 @@
   "peerDependencies": {
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
-    "lodash": "^4.17.20",
     "react": "^16.4.2 || ^17.0.0",
     "react-i18next": "^11.18.6"
   },

--- a/packages/ndla-editor/src/FileListEditor.tsx
+++ b/packages/ndla-editor/src/FileListEditor.tsx
@@ -10,7 +10,6 @@ import React, { Component, MouseEvent as ReactMouseEvent, createRef, MutableRefO
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import Tooltip from '@ndla/tooltip';
-import isNumber from 'lodash/isNumber';
 import { DragHorizontal, DeleteForever } from '@ndla/icons/editor';
 import { Pencil } from '@ndla/icons/action';
 import { spacing, spacingUnit, fonts, colors, shadows, animations } from '@ndla/core';
@@ -344,7 +343,7 @@ class FileListEditor extends Component<Props, State> {
                     checked={file.display === 'block'}
                     value=""
                     id={index}
-                    onChange={(i) => isNumber(i) && onToggleRenderInline(i)}
+                    onChange={(i) => typeof i === 'number' && onToggleRenderInline(i)}
                   />
                 </Tooltip>
               )}


### PR DESCRIPTION
En liten forskjell her: Vi dekker ikke tilfellet der man oppretter et `Number`-objekt, altså `new Number(3)`. Såvidt jeg vet bruker vi ikke dette noe sted i kodebasen uansett.