### PR TITLE
Rewrite volume popover to headless

### DIFF
--- a/packages/ndla-ui/package.json
+++ b/packages/ndla-ui/package.json
@@ -51,6 +51,7 @@
     "@radix-ui/react-popover": "^1.0.3",
     "@reach/menu-button": "^0.16.2",
     "@reach/slider": "^0.16.0",
+    "@headlessui/react": "^1.7.14",
     "focus-trap-react": "^8.9.2",
     "framer-motion": "^6.5.1",
     "html-react-parser": "^3.0.8",

--- a/packages/ndla-ui/src/AudioPlayer/Controls.tsx
+++ b/packages/ndla-ui/src/AudioPlayer/Controls.tsx
@@ -10,6 +10,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import styled from '@emotion/styled';
 import { Menu, MenuButton, MenuItem, MenuPopover, MenuItems, MenuItemProps } from '@reach/menu-button';
 import { SliderInput, SliderTrack, SliderRange, SliderHandle, SliderOrientation } from '@reach/slider';
+import { Popover } from '@headlessui/react';
 import { Play, Pause, VolumeUp } from '@ndla/icons/common';
 import { breakpoints, colors, fonts, misc, mq, spacing } from '@ndla/core';
 import { useTranslation } from 'react-i18next';
@@ -235,7 +236,7 @@ const ProgressHandle = styled(SliderHandle)`
   top: -8px;
 `;
 
-const VolumeWrapper = styled.div`
+const VolumeWrapper = styled(Popover)`
   position: relative;
   display: flex;
   justify-content: center;
@@ -256,7 +257,7 @@ const WardButtonWrapper = styled.div<{ order: number }>`
   }
 `;
 
-const VolumeButton = styled(MenuButton)`
+const VolumeButton = styled(Popover.Button)`
   background-color: inherit;
   width: 48px;
   height: 48px;
@@ -280,13 +281,10 @@ const VolumeButton = styled(MenuButton)`
   }
 `;
 
-const VolumeMenu = styled(MenuPopover)`
+const VolumeList = styled(Popover.Panel)`
   position: absolute;
   bottom: 52px;
   z-index: 99;
-`;
-
-const VolumeList = styled.div`
   box-shadow: 0 14px 20px -5px rgba(32, 88, 143, 0.17);
   border-radius: 60px;
   background: #ffffff;
@@ -507,33 +505,23 @@ const Controls = ({ src, title }: Props) => {
           <Time>-{formatTime(remainingTime)}</Time>
         </ProgressWrapper>
         <VolumeWrapper>
-          <Menu>
-            {/* @ts-ignore */}
-            <VolumeButton
-              type="button"
-              as="button"
-              title={t('audio.controls.adjustVolume')}
-              aria-label={t('audio.controls.adjustVolume')}
-            >
-              <VolumeUp />
-            </VolumeButton>
-            <VolumeMenu as="div" portal={false}>
-              <VolumeList>
-                <VolumeSliderWrapper>
-                  <SliderInput
-                    orientation={SliderOrientation.Vertical}
-                    onChange={handleVolumeSliderChange}
-                    value={volumeValue}
-                  >
-                    <VolumeSliderBackground as="div">
-                      <VolumeSliderSelected as="div" />
-                      <VolumeSliderHandle as="div" />
-                    </VolumeSliderBackground>
-                  </SliderInput>
-                </VolumeSliderWrapper>
-              </VolumeList>
-            </VolumeMenu>
-          </Menu>
+          <VolumeButton aria-label={t('audio.controls.adjustVolume')}>
+            <VolumeUp />
+          </VolumeButton>
+          <VolumeList>
+            <VolumeSliderWrapper>
+              <SliderInput
+                orientation={SliderOrientation.Vertical}
+                onChange={handleVolumeSliderChange}
+                value={volumeValue}
+              >
+                <VolumeSliderBackground as="div">
+                  <VolumeSliderSelected as="div" />
+                  <VolumeSliderHandle as="div" />
+                </VolumeSliderBackground>
+              </SliderInput>
+            </VolumeSliderWrapper>
+          </VolumeList>
         </VolumeWrapper>
       </ControlsWrapper>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1475,6 +1475,13 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
+"@headlessui/react@^1.7.14":
+  version "1.7.14"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.14.tgz#75f19552c535113640fe8a3a40e71474f49e89c9"
+  integrity sha512-znzdq9PG8rkwcu9oQ2FwIy0ZFtP9Z7ycS+BAqJ3R5EIqC/0bJGvhT7193rFf+45i9nnPsYvCQVW4V/bB9Xc+gA==
+  dependencies:
+    client-only "^0.0.1"
+
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
@@ -6089,6 +6096,11 @@ cli-width@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
+client-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
+  integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
 clipboardy@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Bruker popover fra headless for volumjustering. 

NB: ser Reach fortsatt brukes flere steder inne i Controls, burde det skrives om i egne PRer?