### PR TITLE
Width ruins border overflow

### DIFF
--- a/packages/ndla-ui/src/Grid/Grid.tsx
+++ b/packages/ndla-ui/src/Grid/Grid.tsx
@@ -18,8 +18,7 @@ export interface GridProps {
 }
 
 const GridContainer = styled.div`
-  width: 100%;
-  display: inline-grid;
+  display: grid;
   grid-template-columns: auto;
   justify-content: center;
   grid-gap: ${spacing.large};


### PR DESCRIPTION
Width ble satt for å få elementene i slate til å kunne ta sin orginale størrelse, det ødelegger for border ved forhåndsvisning/visning. Legger heller den stylingen til i slate så vi opprettholder border styling generelt