### PR TITLE
Add an inModal prop to select in order to support the new modal

### DIFF
--- a/packages/select/src/Select/BaseMenu.tsx
+++ b/packages/select/src/Select/BaseMenu.tsx
@@ -23,6 +23,7 @@ const menuStyle = css`
 const StyledBaseMenu = styled.div<StyledProps>`
   overflow: hidden;
   background-color: ${colors.white};
+  pointer-events: auto;
   border: 1px solid ${colors.brand.light};
   border-radius: ${({ small }) => (small ? '4px' : '8px')};
   margin: 4px 0;

--- a/packages/select/src/Select/Select.tsx
+++ b/packages/select/src/Select/Select.tsx
@@ -48,6 +48,7 @@ interface Props<T extends boolean> {
   isDisabled?: boolean;
   id?: string;
   defaultValue?: PropsValue<Option>;
+  inModal?: boolean;
 }
 
 const Select = <T extends boolean>({
@@ -58,10 +59,11 @@ const Select = <T extends boolean>({
   colorTheme = 'blue',
   isSearchable = false,
   matchFrom = 'start',
+  inModal,
   isMulti,
   ...rest
 }: Props<T>) => {
-  const portalTarget = useMemo(() => (typeof document !== 'undefined' ? document?.querySelector('body') : null), []);
+  const portalTarget = useMemo(() => (typeof document !== 'undefined' ? document.body : null), []);
 
   return (
     <ReactSelect<Option, T>
@@ -74,7 +76,8 @@ const Select = <T extends boolean>({
       menuPlacement={menuPlacement}
       hideSelectedOptions={false}
       unstyled
-      menuPortalTarget={portalTarget}
+      // wait for https://github.com/radix-ui/primitives/issues/1159 to be closed to remove this.
+      menuPortalTarget={inModal ? null : portalTarget}
       filterOption={matchFrom === 'start' ? createFilter({ matchFrom: 'start' }) : undefined}
       styles={{ menuPortal: (base) => ({ ...base, zIndex: 99999 }) }}
       components={{


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3590
En litt -ish løsning, men den beste vi kan få til inntil videre radix fikser problemet sitt. Dersom man ikke bruker en portal og eksplisitt setter `pointer-events: auto` på select vil den fungere fint inni modaler. 