### PR TITLE
Added story to easier fix padding error in learningpath menu

### DIFF
--- a/packages/ndla-ui/src/LearningPaths/LearningPathMenu.stories.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathMenu.stories.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import { defaultParameters } from '../../../../stories/defaults';
+import { contentTypes } from '../model/ContentType';
+import LearningPathMenu from './LearningPathMenu';
+const args = {
+  name: 'Læringssti',
+  LearningPathId: 1,
+  lastUpdated: '2023-06-01',
+  copyright: {
+    contributors: [
+      {
+        type: 'originator',
+        name: 'NDLA',
+      },
+    ],
+    license: {
+      license: 'CC-BY-SA-4.0',
+    },
+  },
+  learningPathUrl: 'https://stier.ndla.no',
+  currentIndex: 1,
+  cookies: {},
+  learningsteps: [
+    {
+      id: 1,
+      title: 'Introduksjon',
+      type: contentTypes.LEARNING_PATH,
+    },
+    {
+      id: 2,
+      title: 'Steg 1',
+      type: contentTypes.SUBJECT_MATERIAL,
+    },
+    {
+      id: 3,
+      title: 'Steg 2',
+      type: contentTypes.TASKS_AND_ACTIVITIES,
+    },
+  ],
+  toLearningPathUrl: (pathId: number, stepId: number) => '',
+};
+
+export default {
+  title: 'Sammensatte moduler/Læringssti-meny',
+  component: LearningPathMenu,
+  tags: ['autodocs'],
+  parameters: {
+    ...defaultParameters,
+    layout: 'centered',
+  },
+  args: args,
+} as Meta<typeof LearningPathMenu>;
+
+export const LearningPathMenuStory: StoryFn<typeof LearningPathMenu> = ({ ...args }) => {
+  return <LearningPathMenu {...args} />;
+};
+
+LearningPathMenuStory.args = args;
+LearningPathMenuStory.storyName = 'Læringssti-meny';

--- a/packages/ndla-ui/src/LearningPaths/LearningPathMenuContent.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathMenuContent.tsx
@@ -139,7 +139,7 @@ const StyledContentType = styled.div`
   position: relative;
   z-index: 1;
   margin-right: ${spacingUnit * 0.75}px;
-  max-height: 36px;
+  max-height: 35px;
 `;
 
 const HiddenSpan = styled.span`

--- a/packages/ndla-ui/src/LearningPaths/LearningPathMenuIntro.tsx
+++ b/packages/ndla-ui/src/LearningPaths/LearningPathMenuIntro.tsx
@@ -49,7 +49,7 @@ const StyledMenuIntro = styled.div<StyledMenuIntroProps>`
     padding: 0 0 ${spacing.medium} ${spacing.normal};
   }
   ${mq.range({ from: breakpoints.tablet })} {
-    margin-left: ${spacingUnit + BORDER_WIDTH / 2}px;
+    margin-left: ${spacingUnit + BORDER_WIDTH}px;
     margin-top: ${spacing.normal};
   }
   ${mq.range({ from: breakpoints.tablet, until: breakpoints.desktop })} {


### PR DESCRIPTION
Padding i læringssti-menyen har blitt ødelagt etter endring av base unit. Denne fikser det. 
La til en story for lettere å fikse css.

Test:
Sjekk /?path=/docs/sammensatte-moduler-læringssti-meny--docs og sjå at ting ser bra ut i forhold til stier i test.