### PR TITLE
Fix bug where characters are cut of at bottom in small select

### DIFF
--- a/packages/select/src/Select/ValueContainer.tsx
+++ b/packages/select/src/Select/ValueContainer.tsx
@@ -18,6 +18,7 @@ const StyledValueContainer = styled.div`
   display: grid;
   min-width: 0;
   align-items: center;
+  line-height: normal;
 `;
 
 const ValueContainer = <T extends boolean>({


### PR DESCRIPTION
Synne oppdaget at bokstaver i den minste selecten blir kuttet av på bunnen (man ser det om man zoomer inn). Denne fikser opp i det!

![Skjermbilde 2023-06-23 kl  06 56 49](https://github.com/NDLANO/frontend-packages/assets/26788204/1a78f008-1c18-46f2-80c3-d71322d47a5c)
