### PR TITLE
Replaced counters to more static alternative counter

### DIFF
--- a/packages/ndla-ui/src/List/OrderedList.tsx
+++ b/packages/ndla-ui/src/List/OrderedList.tsx
@@ -41,51 +41,60 @@ const StyledOl = styled.ol`
       margin-bottom: ${spacing.nsmall} !important;
     }
   }
+  counter-reset: level1;
 
   &[data-type='letters'] {
-    counter-reset: item 0;
     > li {
-      counter-increment: item;
       &:before {
-        position: absolute;
-        transform: translateX(-100%);
-        content: counter(item, upper-alpha) '.';
-        padding-right: ${spacing.nsmall};
+        content: counter(level1, upper-alpha) '.';
       }
 
       > ol[data-type='letters'] {
         > li:before {
-          content: counter(item, lower-alpha) '.';
+          content: counter(level1, lower-alpha) '.';
         }
         ol[data-type='letters'] {
           > li:before {
-            content: counter(item, lower-roman) '.';
+            content: counter(level1, lower-roman) '.';
           }
         }
       }
     }
   }
 
-  &:not([data-type='letters']) {
-    counter-reset: item 0;
-    > li {
-      counter-increment: item;
-      &:before {
-        position: absolute;
-        transform: translateX(-100%);
-        content: counters(item, '.') '.';
-        padding-right: ${spacing.nsmall};
-      }
+  > li {
+    counter-increment: level1;
+    &:before {
+      position: absolute;
+      transform: translateX(-100%);
+      content: counter(level1, decimal) '.';
+      padding-right: ${spacing.nsmall};
+    }
 
-      > ol:not([data-type='letters']) {
-        > li {
-          padding-left: ${spacing.nsmall};
-          > ol:not([data-type='letters']) {
-            > li {
-              padding-left: ${spacing.medium};
-              > ol:not([data-type='letters']) {
-                > li {
-                  padding-left: ${spacing.large};
+    > ol:not([data-type='letters']) {
+      counter-reset: level2;
+      > li {
+        padding-left: ${spacing.nsmall};
+        counter-increment: level2;
+        &:before {
+          content: counter(level1, decimal) '.' counter(level2, decimal) '.';
+        }
+        > ol:not([data-type='letters']) {
+          counter-reset: level3;
+          > li {
+            padding-left: ${spacing.medium};
+            counter-increment: level3;
+            &:before {
+              content: counter(level1, decimal) '.' counter(level2, decimal) '.' counter(level3, decimal) '.';
+            }
+            > ol:not([data-type='letters']) {
+              counter-reset: level4;
+              > li {
+                padding-left: ${spacing.large};
+                counter-increment: level4;
+                &:before {
+                  content: counter(level1, decimal) '.' counter(level2, decimal) '.' counter(level3, decimal) '.'
+                    counter(level4, decimal) '.';
                 }
               }
             }

--- a/packages/ndla-ui/src/global/components/component.bodybox.scss
+++ b/packages/ndla-ui/src/global/components/component.bodybox.scss
@@ -31,22 +31,6 @@
   }
 }
 
-/* Hacks for complex content fetched inside bodybox */
-.c-bodybox > ul:not([class]),
-.c-bodybox :not(li) > ul:not([class]) {
-  @include mq(desktop) {
-    margin-left: $spacing;
-  }
-}
-
-.c-bodybox > ol:not([class]),
-.c-bodybox :not(li) > ol:not([class]),
-.c-bodybox .ol-list--roman {
-  @include mq(desktop) {
-    margin-left: $spacing--large;
-  }
-}
-
 .c-bodybox {
   .c-figure {
     width: 100% !important;


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/3631

CSS funksjonen `counters` tar hensyn for også dybde når man er i andre elementer enn div og gjør at rekkefølgen og dybden i list element identifikasjonen. 

Siden vi kun har enten `bokstav` eller `numerisk` fjernet jeg den ene sjekken om den ikke var `letters` for å rydde litt i koden. 