### PR TITLE
Article by line frontpage article

### DIFF
--- a/packages/ndla-ui/src/Article/ArticleByline.tsx
+++ b/packages/ndla-ui/src/Article/ArticleByline.tsx
@@ -59,6 +59,7 @@ type Props = {
   licenseBox?: ReactNode;
   locale?: string;
   footnotes?: FootNote[];
+  isFrontpageArticle?: boolean;
 };
 
 const renderContributors = (contributors: SupplierProps[] | AuthorProps[], t: TFunction) => {
@@ -85,7 +86,7 @@ const getSuppliersText = (suppliers: SupplierProps[], t: TFunction) => {
 const LicenseWrapper = styled.div`
   display: flex;
   gap: ${spacing.small};
-  padding-right: ${spacing.xsmall}}
+  padding-right: ${spacing.xsmall};
 `;
 
 const StyledAccordionHeader = styled(AccordionHeader)`
@@ -93,6 +94,10 @@ const StyledAccordionHeader = styled(AccordionHeader)`
   border: 1px solid ${colors.brand.tertiary};
   font-size: ${fonts.sizes('16px', '29px')};
   font-weight: ${fonts.weight.semibold};
+
+  &[data-background-color='white'] {
+    background-color: ${colors.background.default};
+  }
 `;
 
 const refRegexp = /note\d/;
@@ -106,6 +111,7 @@ const ArticleByline = ({
   licenseBox,
   published,
   locale,
+  isFrontpageArticle,
 }: Props) => {
   const { t } = useTranslation();
   const [openAccordions, setOpenAccordions] = useState<string[]>([]);
@@ -157,7 +163,9 @@ const ArticleByline = ({
       <AccordionRoot type="multiple" onValueChange={setOpenAccordions} value={openAccordions}>
         {licenseBox && (
           <AccordionItem value="rulesForUse">
-            <StyledAccordionHeader headingLevel="h2">{t('article.useContent')}</StyledAccordionHeader>
+            <StyledAccordionHeader headingLevel="h2" data-background-color={!!isFrontpageArticle && 'white'}>
+              {t('article.useContent')}
+            </StyledAccordionHeader>
             <AccordionContent>{licenseBox}</AccordionContent>
           </AccordionItem>
         )}

--- a/packages/ndla-ui/src/Article/ArticleByline.tsx
+++ b/packages/ndla-ui/src/Article/ArticleByline.tsx
@@ -51,6 +51,8 @@ type SupplierProps = {
   name: string;
 };
 
+type AccordionHeaderVariants = 'white' | 'blue';
+
 type Props = {
   authors?: AuthorProps[];
   suppliers?: SupplierProps[];
@@ -59,7 +61,7 @@ type Props = {
   licenseBox?: ReactNode;
   locale?: string;
   footnotes?: FootNote[];
-  isFrontpageArticle?: boolean;
+  accordionHeaderVariant?: AccordionHeaderVariants;
 };
 
 const renderContributors = (contributors: SupplierProps[] | AuthorProps[], t: TFunction) => {
@@ -111,7 +113,7 @@ const ArticleByline = ({
   licenseBox,
   published,
   locale,
-  isFrontpageArticle,
+  accordionHeaderVariant = 'blue',
 }: Props) => {
   const { t } = useTranslation();
   const [openAccordions, setOpenAccordions] = useState<string[]>([]);
@@ -163,7 +165,7 @@ const ArticleByline = ({
       <AccordionRoot type="multiple" onValueChange={setOpenAccordions} value={openAccordions}>
         {licenseBox && (
           <AccordionItem value="rulesForUse">
-            <StyledAccordionHeader headingLevel="h2" data-background-color={!!isFrontpageArticle && 'white'}>
+            <StyledAccordionHeader headingLevel="h2" data-background-color={accordionHeaderVariant}>
               {t('article.useContent')}
             </StyledAccordionHeader>
             <AccordionContent>{licenseBox}</AccordionContent>

--- a/packages/ndla-ui/src/FrontpageArticle/FrontpageArticle.tsx
+++ b/packages/ndla-ui/src/FrontpageArticle/FrontpageArticle.tsx
@@ -12,12 +12,13 @@ import styled from '@emotion/styled';
 import { Article } from '../types';
 import LayoutItem from '../Layout';
 import { Heading } from '../Typography';
+import { ArticleByline } from '../Article';
 
 interface Props {
   article: Article;
   children?: ReactNode;
-  id: string;
   isWide?: boolean;
+  id: string;
 }
 
 const StyledArticle = styled.article`
@@ -59,6 +60,11 @@ export const FrontpageArticle = ({ article, id, isWide }: Props) => {
         <StyledIntroduction>{introduction}</StyledIntroduction>
       </LayoutItem>
       <LayoutItem>{content}</LayoutItem>
+      <ArticleByline
+        authors={article.copyright.creators}
+        license={article.copyright.license?.license!}
+        published={article.published}
+      />
     </StyledArticle>
   );
 };

--- a/packages/ndla-ui/src/FrontpageArticle/FrontpageArticle.tsx
+++ b/packages/ndla-ui/src/FrontpageArticle/FrontpageArticle.tsx
@@ -71,7 +71,7 @@ export const FrontpageArticle = ({ article, id, isWide, licenseBox }: Props) => 
         license={article.copyright.license?.license!}
         published={article.published}
         footnotes={article.footNotes}
-        isFrontpageArticle={true}
+        accordionHeaderVariant={'white'}
         licenseBox={licenseBox}
       />
     </StyledArticle>

--- a/packages/ndla-ui/src/FrontpageArticle/FrontpageArticle.tsx
+++ b/packages/ndla-ui/src/FrontpageArticle/FrontpageArticle.tsx
@@ -7,7 +7,7 @@
  */
 
 import { ReactNode } from 'react';
-import { breakpoints, fonts, mq, spacing, utils } from '@ndla/core';
+import { breakpoints, fonts, mq, spacing } from '@ndla/core';
 import styled from '@emotion/styled';
 import { Article } from '../types';
 import LayoutItem from '../Layout';
@@ -17,8 +17,9 @@ import { ArticleByline } from '../Article';
 interface Props {
   article: Article;
   children?: ReactNode;
-  isWide?: boolean;
   id: string;
+  isWide?: boolean;
+  licenseBox?: ReactNode;
 }
 
 const StyledArticle = styled.article`
@@ -40,7 +41,7 @@ const StyledIntroduction = styled.div`
   }
 `;
 
-export const FrontpageArticle = ({ article, id, isWide }: Props) => {
+export const FrontpageArticle = ({ article, id, isWide, licenseBox }: Props) => {
   const { title, introduction, content } = article;
 
   if (isWide) {
@@ -51,6 +52,10 @@ export const FrontpageArticle = ({ article, id, isWide }: Props) => {
     );
   }
 
+  const authors =
+    article.copyright.creators.length || article.copyright.rightsholders.length
+      ? article.copyright.creators
+      : article.copyright.processors;
   return (
     <StyledArticle>
       <LayoutItem>
@@ -61,9 +66,13 @@ export const FrontpageArticle = ({ article, id, isWide }: Props) => {
       </LayoutItem>
       <LayoutItem>{content}</LayoutItem>
       <ArticleByline
-        authors={article.copyright.creators}
+        authors={authors}
+        suppliers={article.copyright.rightsholders}
         license={article.copyright.license?.license!}
         published={article.published}
+        footnotes={article.footNotes}
+        isFrontpageArticle={true}
+        licenseBox={licenseBox}
       />
     </StyledArticle>
   );

--- a/packages/ndla-ui/src/Hero/Hero.tsx
+++ b/packages/ndla-ui/src/Hero/Hero.tsx
@@ -56,6 +56,10 @@ const StyledDiv = styled.div`
     background-color: ${colors.brand.primary};
   }
 
+  &[data-contenttype='frontpage-article'] {
+    background-color: ${colors.background.lightBlue};
+  }
+
   &[data-contenttype='ndla-film has-image'],
   &[data-contenttype='ndla-film'] {
     background: ${colors.ndlaFilm.filmColor};
@@ -112,7 +116,6 @@ interface HeroProps extends HTMLAttributes<HTMLDivElement> {
 export const Hero = ({ children, contentType }: HeroProps) => (
   <StyledDiv data-contenttype={contentType}>{children || null}</StyledDiv>
 );
-
 interface Props {
   children?: ReactNode;
   hasImage?: boolean;

--- a/packages/ndla-ui/src/Layout/OneColumn.tsx
+++ b/packages/ndla-ui/src/Layout/OneColumn.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React, { ReactNode } from 'react';
+import React, { HTMLAttributes, ReactNode } from 'react';
 import BEMHelper from 'react-bem-helper';
 
 const classes = BEMHelper({
@@ -15,7 +15,7 @@ const classes = BEMHelper({
   outputIsString: true,
 });
 
-interface Props {
+interface Props extends HTMLAttributes<HTMLDivElement> {
   children?: ReactNode;
   className?: string;
   cssModifier?: string;
@@ -24,7 +24,7 @@ interface Props {
   extraPadding?: boolean;
 }
 
-export const OneColumn = ({ children, className, cssModifier, wide, noPadding, extraPadding }: Props) => {
+export const OneColumn = ({ children, className, cssModifier, wide, noPadding, extraPadding, ...rest }: Props) => {
   const modifiers = [];
 
   if (cssModifier) {
@@ -43,7 +43,11 @@ export const OneColumn = ({ children, className, cssModifier, wide, noPadding, e
     modifiers.push('extra-padding');
   }
 
-  return <div className={`${classes('', modifiers)} ${className}`}>{children}</div>;
+  return (
+    <div className={`${classes('', modifiers)} ${className}`} {...rest}>
+      {children}
+    </div>
+  );
 };
 
 export default OneColumn;


### PR DESCRIPTION
Legger til støtte for blå farge i header på hero for forsideartikler da det så veldig dårlig ut med grå header over det blå. 
Legger til mulighet for kvit default farge på accordion lisens boks.
 

![image](https://github.com/NDLANO/frontend-packages/assets/35299038/0686dd72-121b-403e-931b-f413d934939b)
