### PR TITLE
Added  focus on picker type on useEffect

### DIFF
--- a/packages/ndla-ui/src/TreeStructure/FolderItem.tsx
+++ b/packages/ndla-ui/src/TreeStructure/FolderItem.tsx
@@ -165,9 +165,10 @@ const FolderItem = ({
         ref.current?.focus();
       }
       if (type === 'picker') {
+        ref.current?.focus();
         ref.current?.scrollIntoView({
           behavior: 'smooth',
-          block: 'nearest',
+          block: 'start',
         });
       }
     }


### PR DESCRIPTION
fixes https://trello.com/c/db2cUopy/327-n%C3%A5r-jeg-%C3%A5pner-en-undermappe-nederst-p%C3%A5-listen-b%C3%B8r-listen-scrolle-nedover-slik-at-jeg-ser-undermappene

Gjør så at om du klikker på nederste element så vil den scrolle videre nedover og vise alt innhold