### PR TITLE
Added styling for lists in table

### DIFF
--- a/packages/ndla-ui/src/Table/component.tables.scss
+++ b/packages/ndla-ui/src/Table/component.tables.scss
@@ -150,6 +150,11 @@ article table {
       @include font-size(15px, 30px);
     }
 
+    ol,
+    ul {
+      font-size: unset !important;
+    }
+
     p {
       line-height: 1.6em;
     }


### PR DESCRIPTION
Styling i lister i tabeller var mye større så fjerner font størrelsen som blir lagt på for lister