### PR TITLE
Update copyright on Article type to possible be undefined

### DIFF
--- a/packages/ndla-ui/src/Article/Article.tsx
+++ b/packages/ndla-ui/src/Article/Article.tsx
@@ -184,16 +184,10 @@ export const Article = ({
     }
   }, [wrapperRef]);
 
-  const {
-    title,
-    introduction,
-    published,
-    content,
-    footNotes,
-    copyright: { license: licenseObj, creators, rightsholders, processors },
-  } = article;
+  const { title, introduction, published, content, footNotes, copyright } = article;
 
-  const authors = creators.length || rightsholders.length ? creators : processors;
+  const authors =
+    copyright?.creators.length || copyright?.rightsholders.length ? copyright.creators : copyright?.processors;
 
   return (
     <div ref={wrapperRef}>
@@ -226,9 +220,9 @@ export const Article = ({
           <ArticleByline
             footnotes={footNotes}
             authors={authors}
-            suppliers={rightsholders}
+            suppliers={copyright?.rightsholders}
             published={published}
-            license={licenseObj?.license ?? ''}
+            license={copyright?.license?.license ?? ''}
             licenseBox={licenseBox}
           />
         </LayoutItem>

--- a/packages/ndla-ui/src/FrontpageArticle/FrontpageArticle.tsx
+++ b/packages/ndla-ui/src/FrontpageArticle/FrontpageArticle.tsx
@@ -78,9 +78,9 @@ export const FrontpageArticle = ({ article, id, isWide, licenseBox }: Props) => 
   }
 
   const authors =
-    article.copyright.creators.length || article.copyright.rightsholders.length
+    article.copyright?.creators.length || article.copyright?.rightsholders.length
       ? article.copyright.creators
-      : article.copyright.processors;
+      : article.copyright?.processors;
   return (
     <StyledArticle style={cssVars}>
       <LayoutItem>
@@ -92,8 +92,8 @@ export const FrontpageArticle = ({ article, id, isWide, licenseBox }: Props) => 
       <LayoutItem>{content}</LayoutItem>
       <ArticleByline
         authors={authors}
-        suppliers={article.copyright.rightsholders}
-        license={article.copyright.license?.license!}
+        suppliers={article.copyright?.rightsholders}
+        license={article.copyright?.license?.license!}
         published={article.published}
         accordionHeaderVariant={'white'}
         licenseBox={licenseBox}

--- a/packages/ndla-ui/src/types.ts
+++ b/packages/ndla-ui/src/types.ts
@@ -70,7 +70,7 @@ export interface Article {
   introduction: string;
   content: ReactNode;
   footNotes: Array<FootNote>;
-  copyright: Copyright;
+  copyright?: Copyright;
   published: string;
 }
 


### PR DESCRIPTION
Oppdaget en bug som gjør at ed krasjer når man prøver å forhåndsvise en artikkel i fra html-editor når artikkelen ikke er lagret tidligere. Dette er på grunn av at copyright ikke eksisterer .. Oppdaterer derfor typen til å kunne være undefined