### PR TITLE
Reduce medium image size from 75% to 66%

### DIFF
--- a/packages/core/scss/global/utilities/utilities.helpers.scss
+++ b/packages/core/scss/global/utilities/utilities.helpers.scss
@@ -14,10 +14,10 @@
 
 /* Float article objects */
 .u-float-left {
-  @include float(3, 4, 'left');
+  @include float(2, 3, 'left');
 }
 .u-float-right {
-  @include float(3, 4, 'right');
+  @include float(2, 3, 'right');
 }
 .u-float-small-left {
   @include float(2, 4, 'left');


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3668
Kan eventuelt få 65% dersom vi setter opp kolonne-mengden ved å ha `65, 100` istedenfor, men tror det kommer til å tukle med tablet.