### PR TITLE
Changed from primaryAffiliation to only use affiliation

### DIFF
--- a/packages/ndla-ui/src/User/UserInfo.tsx
+++ b/packages/ndla-ui/src/User/UserInfo.tsx
@@ -23,6 +23,8 @@ const ShortInfoDiv = styled.div`
   margin: 2rem auto;
 `;
 
+const isTeacher = (affiliations: FeideUserApiType['eduPersonAffiliation']) => affiliations.includes('employee');
+
 export const UserInfo = ({ user }: Props) => {
   const { t } = useTranslation();
 
@@ -33,7 +35,7 @@ export const UserInfo = ({ user }: Props) => {
       {
         <p>
           {t('user.loggedInAs', {
-            role: t(`user.role.${parsedUser.primaryAffiliation}`),
+            role: t(`user.role.${isTeacher(parsedUser.eduPersonAffiliation) ? 'employee' : 'student'}`),
           })}
         </p>
       }

--- a/packages/ndla-ui/src/User/__tests__/parseUserObject-test.ts
+++ b/packages/ndla-ui/src/User/__tests__/parseUserObject-test.ts
@@ -162,9 +162,9 @@ describe('parseUserObject', () => {
   it('Correctly parses Feide user', () => {
     const expected = {
       uid: ['david_laerervgs'],
-      primaryAffiliation: 'employee',
       displayName: 'David LærerVGS Jonsen',
       mail: ['david_laerervgs@feide.no'],
+      eduPersonAffiliation: ['member', 'employee', 'faculty'],
       grepCodes: [],
       organizations: [
         {

--- a/packages/ndla-ui/src/User/parseUserObject.ts
+++ b/packages/ndla-ui/src/User/parseUserObject.ts
@@ -80,7 +80,7 @@ export const parseUserObject = (user: FeideUserApiType) => {
 
   return {
     uid: user.uid,
-    primaryAffiliation: user.eduPersonPrimaryAffiliation,
+    eduPersonAffiliation: user.eduPersonAffiliation,
     displayName: user.displayName,
     mail: user.mail,
     organizations: roots,

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -1067,8 +1067,6 @@ const messages = {
     loggedInAsButton: 'You are logged in as {{role}}',
     role: {
       employee: 'Employee',
-      faculty: 'Employee',
-      staff: 'Employee',
       student: 'Student',
     },
     buttonLogIn: 'Log in with Feide',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -1066,8 +1066,6 @@ const messages = {
     loggedInAsButton: 'Du er pålogget som {{role}}',
     role: {
       employee: 'ansatt',
-      faculty: 'ansatt',
-      staff: 'ansatt',
       student: 'elev',
     },
     buttonLogIn: 'Logg inn med Feide',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -1066,8 +1066,6 @@ const messages = {
     loggedInAsButton: 'Du er pålogga som {{role}}',
     role: {
       employee: 'tilsett',
-      faculty: 'tilsett',
-      staff: 'tilsett',
       student: 'elev',
     },
     buttonLogIn: 'Logg inn med Feide',

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -1067,8 +1067,6 @@ const messages = {
     loggedInAsButton: 'Don leat sisaloggejuvvon {{role}}',
     role: {
       employee: 'bargi',
-      faculty: 'bargi',
-      staff: 'bargi',
       student: 'oahppi',
     },
     buttonLogIn: 'Logge sisa Feide bokte',

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -1070,8 +1070,6 @@ const messages = {
     loggedInAsButton: 'Datne tjaangeme goh {{role}}',
     role: {
       employee: 'barkije',
-      faculty: 'barkije',
-      staff: 'barkije',
       student: 'learohke',
     },
     buttonLogIn: 'Tjaangh Feidine',


### PR DESCRIPTION
`primaryAffiliation` er ikke mandatory i feide. Vi bruker `eduPersonAffiliation` i backend og sjekker om den inneholder `employee` da det er felles for alle de ulike rollene. 

![image](https://github.com/NDLANO/frontend-packages/assets/35299038/142864ab-737a-41d8-be1b-a5f163eb30cc)
