### PR TITLE
Fix margin in h2 in Folder-component

### DIFF
--- a/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
+++ b/packages/ndla-ui/src/MyNdla/Resource/Folder.tsx
@@ -74,7 +74,7 @@ const IconWrapper = styled.div`
 const FolderTitle = styled.h2`
   ${fonts.sizes('16px', '20px')};
   font-weight: ${fonts.weight.semibold};
-  margin: 0;
+  margin: 0px !important;
   flex: 1;
 
   overflow: hidden;


### PR DESCRIPTION
Oppdaget at når `Folder` brukes inne i feks `ModalBody` så vil h2-styling overskrives(se bilde), regner med at vi alltid ønsker at margin skal settes til 0  for `FolderTitle`.

![Skjermbilde 2023-08-25 kl  13 20 58](https://github.com/NDLANO/frontend-packages/assets/26788204/8dd72e08-8a55-452e-93ef-061135c2723f)
