### PR TITLE
Fix image alt-text not being read by screen readers

### DIFF
--- a/packages/ndla-ui/src/Embed/ImageEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/ImageEmbed.tsx
@@ -12,6 +12,8 @@ import { MouseEventHandler, useState } from 'react';
 import { ExpandTwoArrows } from '@ndla/icons/action';
 import { COPYRIGHTED } from '@ndla/licenses';
 import { ArrowCollapse, ChevronDown, ChevronUp } from '@ndla/icons/common';
+import { utils } from '@ndla/core';
+import styled from '@emotion/styled';
 import { Figure, FigureType } from '../Figure';
 import Image, { ImageLink } from '../Image';
 import { EmbedByline } from '../LicenseByline';
@@ -170,6 +172,10 @@ const ImageEmbed = ({ embed, previewAlt, heartButton: HeartButton, inGrid, path 
   );
 };
 
+const HiddenSpan = styled.span`
+  ${utils.visuallyHidden};
+`;
+
 interface ImageWrapperProps {
   src?: string;
   children: React.ReactNode;
@@ -193,8 +199,9 @@ const ImageWrapper = ({ src, crop, size, children, pagePath }: ImageWrapperProps
   }
 
   return (
-    <ImageLink src={src} crop={crop} aria-label={t('license.images.itemImage.ariaLabel')}>
+    <ImageLink src={src} crop={crop}>
       {children}
+      <HiddenSpan>{t('license.images.itemImage.ariaLabel')}</HiddenSpan>
     </ImageLink>
   );
 };


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/3682

Det var aria-label på lenken som opplyser om at lenken åpnes i nytt vindu som tar presedens over alt-tekst på bilde som gjorde at alt-teksten ikke ble lest opp av skjemlesere.
Løses ved å fjerne aria-label fra lenken og legge denne teksten som et visuelt skjult element istedet.