### PR TITLE
Remove the unique sequence requirement for embeds

### DIFF
--- a/packages/article-converter/src/plugins/embed/fileEmbedPlugin.tsx
+++ b/packages/article-converter/src/plugins/embed/fileEmbedPlugin.tsx
@@ -20,7 +20,6 @@ export const fileEmbedPlugin: PluginType = (element) => {
   } else {
     return (
       <FileV2
-        id={`file-${data.seq}`}
         url={url}
         title={title}
         fileExists={data.status === 'success' ? !!data.data.exists : false}

--- a/packages/ndla-ui/src/Embed/AudioEmbed.stories.tsx
+++ b/packages/ndla-ui/src/Embed/AudioEmbed.stories.tsx
@@ -203,7 +203,6 @@ export const AudioEmbedStory: StoryObj<typeof AudioEmbed> = {
     embed: {
       resource: 'audio',
       status: 'success',
-      seq: 1,
       embedData: embedData,
       data: successData,
     },
@@ -216,7 +215,6 @@ export const AudioEmbedFailed: StoryObj<typeof AudioEmbed> = {
     embed: {
       resource: 'audio',
       status: 'error',
-      seq: 1,
       embedData: embedData,
     },
   },
@@ -228,7 +226,6 @@ export const Podcast: StoryObj<typeof AudioEmbed> = {
     embed: {
       resource: 'audio',
       status: 'success',
-      seq: 1,
       embedData: podcastEmbedData,
       data: podcastSuccessData,
     },
@@ -241,7 +238,6 @@ export const PodcastFailed: StoryObj<typeof AudioEmbed> = {
     embed: {
       resource: 'audio',
       status: 'error',
-      seq: 1,
       embedData: podcastEmbedData,
     },
   },

--- a/packages/ndla-ui/src/Embed/AudioEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/AudioEmbed.tsx
@@ -39,8 +39,6 @@ const imageMetaToMockEmbed = (
 ): Extract<ImageMetaData, { status: 'success' }> => ({
   resource: 'image',
   status: 'success',
-  // Make sure the seq is unused. It's rarely used, but it's nice to ensure uniqueness.
-  seq: imageMeta.seq + 0.1,
   // We check that this exists where the function is used.
   data: imageMeta.data.imageMeta!,
   embedData: {
@@ -55,7 +53,7 @@ const AudioEmbed = ({ embed, heartButton: HeartButton }: Props) => {
     return <EmbedErrorPlaceholder type={embed.embedData.type === 'standard' ? 'audio' : 'podcast'} />;
   }
 
-  const { data, embedData, seq } = embed;
+  const { data, embedData } = embed;
 
   if (embedData.type === 'minimal') {
     return <AudioPlayer speech src={data.audioFile.url} title={data.title.title} />;
@@ -69,10 +67,8 @@ const AudioEmbed = ({ embed, heartButton: HeartButton }: Props) => {
 
   const img = coverPhoto && { url: coverPhoto.url, alt: coverPhoto.altText };
 
-  const figureId = `figure-${seq}-${data.id}`;
-
   return (
-    <Figure id={figureId} type="full">
+    <Figure type="full">
       <AudioPlayer
         description={data.podcastMeta?.introduction ?? ''}
         img={img}

--- a/packages/ndla-ui/src/Embed/BrightcoveEmbed.stories.tsx
+++ b/packages/ndla-ui/src/Embed/BrightcoveEmbed.stories.tsx
@@ -82,7 +82,6 @@ const metaData: BrightcoveData = {
 
 const visuallyInterpretedEmbedMetaData: BrightcoveMetaData = {
   resource: 'brightcove',
-  seq: 3,
   status: 'success',
   embedData: {
     resource: 'brightcove',
@@ -183,7 +182,6 @@ export const BrightcoveEmbedStory: StoryObj<typeof BrightcoveEmbed> = {
     embed: {
       resource: 'brightcove',
       status: 'success',
-      seq: 1,
       embedData: embedData,
       data: metaData,
     },
@@ -203,7 +201,6 @@ export const BrightcoveFailed: StoryObj<typeof BrightcoveEmbed> = {
     embed: {
       resource: 'brightcove',
       status: 'error',
-      seq: 1,
       embedData: embedData,
     },
   },

--- a/packages/ndla-ui/src/Embed/BrightcoveEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/BrightcoveEmbed.tsx
@@ -86,18 +86,17 @@ const BrightcoveEmbed = ({ embed, isConcept, heartButton: HeartButton }: Props) 
       </EmbedErrorPlaceholder>
     );
   }
-  const { data, seq } = embed;
+  const { data } = embed;
 
   const linkedVideoId = isNumeric(data.link?.text) ? data.link?.text : undefined;
 
-  const figureId = `figure-${seq}-${data.id}`;
   const originalVideoProps = getIframeProps(embedData, data.sources);
   const alternativeVideoProps = linkedVideoId
     ? getIframeProps({ ...embedData, videoid: linkedVideoId }, data.sources)
     : undefined;
 
   return (
-    <Figure id={figureId} type={isConcept ? 'full-column' : 'full'} resizeIframe>
+    <Figure type={isConcept ? 'full-column' : 'full'} resizeIframe>
       <div className="brightcove-video">
         <BrightcoveIframe
           ref={iframeRef}

--- a/packages/ndla-ui/src/Embed/ConceptEmbed.stories.tsx
+++ b/packages/ndla-ui/src/Embed/ConceptEmbed.stories.tsx
@@ -72,7 +72,6 @@ const conceptMetaData: ConceptData['concept'] = {
 const visualElementData: ConceptData['visualElement'] = {
   resource: 'image',
   status: 'success',
-  seq: 6,
   embedData: {
     resource: 'image',
     resourceId: '52863',
@@ -170,7 +169,6 @@ export const Block: StoryObj<typeof ConceptEmbed> = {
     embed: {
       resource: 'concept',
       status: 'success',
-      seq: 1,
       embedData: blockEmbedData,
       data: blockMetaData,
     },
@@ -183,7 +181,6 @@ export const BlockFailed: StoryObj<typeof ConceptEmbed> = {
     embed: {
       resource: 'concept',
       status: 'error',
-      seq: 1,
       embedData: blockEmbedData,
     },
   },
@@ -195,7 +192,6 @@ export const Inline: StoryObj<typeof ConceptEmbed> = {
     embed: {
       resource: 'concept',
       status: 'success',
-      seq: 1,
       embedData: inlineEmbedData,
       data: blockMetaData,
     },
@@ -208,7 +204,6 @@ export const InlineFailed: StoryObj<typeof ConceptEmbed> = {
     embed: {
       resource: 'concept',
       status: 'error',
-      seq: 1,
       embedData: inlineEmbedData,
     },
   },

--- a/packages/ndla-ui/src/Embed/ExternalEmbed.stories.tsx
+++ b/packages/ndla-ui/src/Embed/ExternalEmbed.stories.tsx
@@ -66,7 +66,6 @@ export const Regular: StoryObj<typeof ExternalEmbed> = {
     embed: {
       resource: 'external',
       status: 'success',
-      seq: 8,
       embedData: embedData,
       data: metaData,
     },
@@ -78,7 +77,6 @@ export const Failed: StoryObj<typeof ExternalEmbed> = {
     embed: {
       resource: 'external',
       status: 'error',
-      seq: 3,
       embedData: embedData,
     },
   },

--- a/packages/ndla-ui/src/Embed/H5pEmbed.stories.tsx
+++ b/packages/ndla-ui/src/Embed/H5pEmbed.stories.tsx
@@ -72,7 +72,6 @@ export const Regular: StoryObj<typeof H5pEmbed> = {
     embed: {
       resource: 'h5p',
       status: 'success',
-      seq: 5,
       embedData: embedData,
       data: metaData,
     },
@@ -84,7 +83,6 @@ export const Failed: StoryObj<typeof H5pEmbed> = {
     embed: {
       resource: 'h5p',
       status: 'error',
-      seq: 3,
       embedData: embedData,
     },
   },

--- a/packages/ndla-ui/src/Embed/IframeEmbed.stories.tsx
+++ b/packages/ndla-ui/src/Embed/IframeEmbed.stories.tsx
@@ -47,7 +47,6 @@ export const Regular: StoryObj<typeof IframeEmbed> = {
     embed: {
       resource: 'iframe',
       status: 'success',
-      seq: 3,
       embedData: embedData,
       data: {},
     },
@@ -59,7 +58,6 @@ export const Failed: StoryObj<typeof IframeEmbed> = {
     embed: {
       resource: 'iframe',
       status: 'error',
-      seq: 3,
       embedData: embedData,
     },
   },
@@ -132,7 +130,6 @@ export const OpensInNewWindow: StoryObj<typeof IframeEmbed> = {
     embed: {
       resource: 'iframe',
       status: 'success',
-      seq: 4,
       embedData: opensInNewEmbedData,
       data: opensInnewMetaData,
     },
@@ -144,7 +141,6 @@ export const OpensInNewWindowFailed: StoryObj<typeof IframeEmbed> = {
     embed: {
       resource: 'iframe',
       status: 'error',
-      seq: 4,
       embedData: opensInNewEmbedData,
     },
   },

--- a/packages/ndla-ui/src/Embed/ImageEmbed.stories.tsx
+++ b/packages/ndla-ui/src/Embed/ImageEmbed.stories.tsx
@@ -111,7 +111,6 @@ export const ImageEmbedStory: StoryObj<typeof ImageEmbed> = {
     embed: {
       resource: 'image',
       status: 'success',
-      seq: 1,
       embedData: embedData,
       data: metaData,
     },
@@ -124,7 +123,6 @@ export const Failed: StoryObj<typeof ImageEmbed> = {
     embed: {
       resource: 'image',
       status: 'error',
-      seq: 1,
       embedData: embedData,
     },
   },

--- a/packages/ndla-ui/src/Embed/ImageEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/ImageEmbed.tsx
@@ -111,7 +111,7 @@ const ImageEmbed = ({ embed, previewAlt, heartButton: HeartButton, inGrid, path 
     return <EmbedErrorPlaceholder type={'image'} figureType={figureType} />;
   }
 
-  const { data, embedData, seq } = embed;
+  const { data, embedData } = embed;
 
   const altText = embedData.alt || '';
 
@@ -121,13 +121,10 @@ const ImageEmbed = ({ embed, previewAlt, heartButton: HeartButton, inGrid, path 
   const focalPoint = getFocalPoint(embedData);
   const crop = getCrop(embedData);
 
-  const figureId = `figure-${seq}-${data.id}`;
-
   const isCopyrighted = data.copyright.license.license.toLowerCase() === COPYRIGHTED;
 
   return (
     <Figure
-      id={figureId}
       type={imageSizes ? undefined : figureType}
       className={imageSizes ? `c-figure--${embedData.align} expanded` : ''}
     >

--- a/packages/ndla-ui/src/FileList/File.tsx
+++ b/packages/ndla-ui/src/FileList/File.tsx
@@ -31,10 +31,8 @@ const FileLink = styled(SafeLink)`
   }
 `;
 
-const renderFormat = (format: FileFormat, title: string, isPrimary: boolean, id: string, isDeadLink: boolean) => {
+const renderFormat = (format: FileFormat, title: string, isPrimary: boolean, isDeadLink: boolean) => {
   const titleWithFormat = `${title} (${format.fileType.toUpperCase()})`;
-
-  const formatId = `${id}_${format.fileType}`;
 
   if (isDeadLink) {
     return (
@@ -46,7 +44,7 @@ const renderFormat = (format: FileFormat, title: string, isPrimary: boolean, id:
   }
 
   return (
-    <FileLink key={format.url} to={format.url} target="_blank" aria-label={titleWithFormat} aria-describedby={formatId}>
+    <FileLink key={format.url} to={format.url} target="_blank" aria-label={titleWithFormat}>
       <Download />
       <Tooltip tooltip={format.tooltip}>
         <LinkTextWrapper>
@@ -58,7 +56,6 @@ const renderFormat = (format: FileFormat, title: string, isPrimary: boolean, id:
 };
 
 interface Props {
-  id: string;
   file: FileType;
 }
 
@@ -77,9 +74,9 @@ const FileListItem = styled.li`
   }
 `;
 
-const File = ({ file, id }: Props) => {
+const File = ({ file }: Props) => {
   const formatLinks = file.formats.map((format, index) =>
-    renderFormat(format, file.title, index === 0, id, !file.fileExists),
+    renderFormat(format, file.title, index === 0, !file.fileExists),
   );
 
   return <FileListItem key={file.title}>{formatLinks}</FileListItem>;

--- a/packages/ndla-ui/src/FileList/FileList.tsx
+++ b/packages/ndla-ui/src/FileList/FileList.tsx
@@ -55,7 +55,7 @@ const FileList = ({ files, heading, id }: Props) => (
     <FileListHeading>{heading}</FileListHeading>
     <FilesList>
       {files.map((file) => (
-        <File key={`file-${id}-${file.title}`} file={file} id={id} />
+        <File key={`file-${id}-${file.title}`} file={file} />
       ))}
     </FilesList>
   </FileListSection>

--- a/packages/ndla-ui/src/FileList/FileV2.tsx
+++ b/packages/ndla-ui/src/FileList/FileV2.tsx
@@ -10,19 +10,17 @@ import { useTranslation } from 'react-i18next';
 import File from './File';
 
 interface Props {
-  id: string;
   title: string;
   url: string;
   fileExists: boolean;
   fileType: string;
 }
 
-const FileV2 = ({ title, url, id, fileExists, fileType }: Props) => {
+const FileV2 = ({ title, url, fileExists, fileType }: Props) => {
   const { t } = useTranslation();
   const tooltip = `${t('download')} ${url.split('/').pop()}`;
   return (
     <File
-      id={id}
       file={{
         title,
         fileExists,

--- a/packages/types-embed/src/index.ts
+++ b/packages/types-embed/src/index.ts
@@ -148,7 +148,6 @@ interface MetaDataFailure<T extends EmbedData> {
   resource: T['resource'];
   embedData: T;
   status: 'error';
-  seq: number;
   message?: string;
 }
 
@@ -156,7 +155,6 @@ interface MetaDataSuccess<T extends EmbedData, Data> {
   resource: T['resource'];
   embedData: T;
   data: Data;
-  seq: number;
   status: 'success';
 }
 


### PR DESCRIPTION
Den brukes egentlig ikke til noe nyttlig.
* `Figure` trenger ikke lenger ID'er.
* `File` genererte en ID, men brukte den på en `aria-describedby` uten å faktisk ha et element å peke til.