### PR TITLE
Do not apply max-width constraints in ProgrammeCard component

### DIFF
--- a/packages/ndla-ui/src/ProgrammeCard/ProgrammeCard.tsx
+++ b/packages/ndla-ui/src/ProgrammeCard/ProgrammeCard.tsx
@@ -37,13 +37,6 @@ const StyledCardContainer = styled(SafeLink)`
     text-decoration: underline ${colors.text.primary};
     text-underline-offset: 3px;
   }
-
-  ${mq.range({ from: breakpoints.tablet })} {
-    min-height: 350px;
-    min-width: 250px;
-    max-height: 350px;
-    width: 250px;
-  }
 `;
 
 const StyledImg = styled.img`


### PR DESCRIPTION
Flytter ansvaret for å gjøre dette over til ndla-frontend istedenfor. Da kan vi sette max-width basert på om man er på mobil eller ei. 

Fixes https://trello.com/c/UXndKiC1/379-responsiv-bug-p%C3%A5-utdanningsprogram