### PR TITLE
Add a hook for matomo tracking

### DIFF
--- a/packages/ndla-tracker/package.json
+++ b/packages/ndla-tracker/package.json
@@ -30,7 +30,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.10.4",
     "react": ">= 16.8.0",
-    "react-helmet-async": "^1.3.0"
+    "react-helmet-async": "^1.3.0",
+    "react-router-dom": ">= 5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ndla-tracker/package.json
+++ b/packages/ndla-tracker/package.json
@@ -36,6 +36,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@ndla/util": "^3.1.15",
     "hoist-non-react-statics": "^3.3.2",
     "tiny-warning": "^1.0.3"
   },

--- a/packages/ndla-tracker/src/HelmetWithTracker.tsx
+++ b/packages/ndla-tracker/src/HelmetWithTracker.tsx
@@ -6,10 +6,11 @@
  *
  */
 
-import { Component, ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
 import warning from 'tiny-warning';
-import withTracker from './withTracker';
+import { usePrevious } from '@ndla/util';
+import useTracker from './useTracker';
 
 interface Props {
   title: string;
@@ -21,21 +22,23 @@ interface Props {
  *
  * Since we only can track a page once, changes to the title prop will trigger a warning.
  */
-class HelmetWithTracker extends Component<Props> {
-  componentDidUpdate(prevProps: Props) {
-    warning(
-      !(prevProps.title !== this.props.title),
-      'N.B! Title changes are not supported because of page view tracking. \n\n Please use willTrackPageView provided by withTracker for more lowlevel control over which title to track.',
-    );
-  }
 
-  static getDocumentTitle(props: Props) {
-    return props.title;
-  }
+const HelmetWithTracker = ({ title, children }: Props) => {
+  const { hasTracked, trackPageView } = useTracker();
+  const previousTitle = usePrevious(title);
 
-  render() {
-    return <Helmet {...this.props} />;
-  }
-}
+  useEffect(() => {
+    if (hasTracked && title !== previousTitle) {
+      warning(
+        true,
+        'N.B! Title changes are not supported because of page view tracking. \n\n Please use trackPageView provided by useTracker for more lowlevel control over when to track a page view.',
+      );
+    } else {
+      trackPageView({ title });
+    }
+  }, [hasTracked, previousTitle, title, trackPageView]);
 
-export default withTracker(HelmetWithTracker);
+  return <Helmet title={title}>{children}</Helmet>;
+};
+
+export default HelmetWithTracker;

--- a/packages/ndla-tracker/src/index.ts
+++ b/packages/ndla-tracker/src/index.ts
@@ -11,3 +11,4 @@ export { default as HelmetWithTracker } from './HelmetWithTracker';
 export { default as MatomoTagManager } from './MatomoTagManager';
 export { default as MatomoTracker } from './MatomoTracker';
 export { configureTracker, sendPageView } from './tracker';
+export { default as useTracker } from './useTracker';

--- a/packages/ndla-tracker/src/useTracker.ts
+++ b/packages/ndla-tracker/src/useTracker.ts
@@ -6,7 +6,9 @@
  *
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { usePrevious } from '@ndla/util';
+import { useLocation } from 'react-router-dom';
 
 interface TrackPageViewProps {
   title: string;
@@ -15,6 +17,14 @@ interface TrackPageViewProps {
 
 const useTracker = () => {
   const [hasTracked, setHasTracked] = useState(false);
+  const { pathname } = useLocation();
+  const previousPath = usePrevious(pathname);
+
+  useEffect(() => {
+    if (hasTracked && previousPath !== pathname) {
+      setHasTracked(false);
+    }
+  }, [hasTracked, pathname, previousPath]);
 
   const trackPageView = useCallback(
     ({ title, dimensions = {} }: TrackPageViewProps) => {

--- a/packages/ndla-tracker/src/useTracker.ts
+++ b/packages/ndla-tracker/src/useTracker.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useCallback, useState } from 'react';
+
+interface TrackPageViewProps {
+  title: string;
+  dimensions?: Record<string | number, any>;
+}
+
+const useTracker = () => {
+  const [hasTracked, setHasTracked] = useState(false);
+
+  const trackPageView = useCallback(
+    ({ title, dimensions = {} }: TrackPageViewProps) => {
+      if (!hasTracked) {
+        setHasTracked(true);
+        window._mtm?.push({ page_title: title, event: 'Pageview', ...dimensions });
+      }
+    },
+    [hasTracked],
+  );
+
+  return { trackPageView, hasTracked };
+};
+
+export default useTracker;

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -22,3 +22,4 @@ export { validateTranslationFiles } from './translationValidation';
 export { default as useForwardedRef } from './useForwardedRef';
 export { default as NoSSR } from './nossr/NoSSR';
 export { default as withNoSSR } from './nossr/withNoSSR';
+export { default as usePrevious } from './usePrevious';

--- a/packages/util/src/usePrevious.ts
+++ b/packages/util/src/usePrevious.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useEffect, useRef } from 'react';
+
+const usePrevious = <T>(value: T) => {
+  const ref = useRef<T | undefined>(undefined);
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};
+
+export default usePrevious;


### PR DESCRIPTION
Veldig rudimentær implementasjon av en `useTracker`-hook. Er faktisk usikker på om vi trenger noe mer enn dette. Krever nok en del testing før vi kan gå videre. Har ikke fått testet `HelmetWithTracker` ennå.

Den fungerer på følgende måte: Når en kaller på `trackPageView` vil det sendes et `Pageview`-event til Matomo. Dersom et event allerede har blitt sendt for siden vil den aldri sendes igjen. Man trenger med andre ord ikke å bekymre seg for å kalle den fra en `useEffect`. 

Kan brukes på følgende måte:

```jsx
const TestComponent = () => {
  const {trackPageView} = useTracker();

  useEffect(() => {
        if(!article || !condB) return;
        const dims = getAllDimensions({article});
        trackPageView({dimensions: dims, title: 'Test title'});
      }, [condA, condB])

  return <div>Test</div>
}
```

Jeg så på litt forskjellige løsninger for å ordne dette, men det greieste var å skrive en helt ordinær hook. Da kan vi beholde `MatomoTagManager`- og `MatomoTracker`-komponentene.

`HelmetWithTracker` brukes i ED, ndla-frontend og learningpath-frontend. `withTracker` brukes i `ndla-frontend` og i `learningpath-frontend`. Har laget en PR for å fjerne `withTracker` fra ndla-frontend. Skal jeg lage noe lignende for learningpath-frontend?