### PR TITLE
Add ability to still show overlay even if a dialog is not a modal

### DIFF
--- a/packages/ndla-modal/src/Modal.tsx
+++ b/packages/ndla-modal/src/Modal.tsx
@@ -153,6 +153,7 @@ export const ModalContent = ({
   animationDuration = 400,
   animation = 'zoom',
   expands,
+  forceOverlay,
   ...rest
 }: ModalContentProps) => {
   const styledVars = useMemo(
@@ -165,9 +166,13 @@ export const ModalContent = ({
 
   return (
     <Portal>
-      <Overlay asChild>
+      {forceOverlay ? (
         <StyledOverlay aria-hidden key="modal-backdrop" style={styledVars} />
-      </Overlay>
+      ) : (
+        <Overlay asChild>
+          <StyledOverlay aria-hidden key="modal-backdrop" style={styledVars} />
+        </Overlay>
+      )}
       <DialogContent
         data-animation-name={animation}
         data-position={position}

--- a/packages/ndla-modal/src/types.ts
+++ b/packages/ndla-modal/src/types.ts
@@ -30,6 +30,7 @@ export interface ModalContentProps extends DialogContentProps {
   position?: ModalPosition;
   modalMargin?: ModalMargin;
   expands?: boolean;
+  forceOverlay?: boolean;
 }
 
 export interface Animation {


### PR DESCRIPTION
Modal-komponenten har som default satt `modal`-propen til true, som skjuler resten av siden for skjemlesere. Man kan velge å manuelt overstyre dette. Å sette `modal` til false fikser problemet med TagSelector, men fjerner `Overlay` fullstendig. Dette gir oss hvertfall en semi-funksjonell `Overlay` når `modal` er false.