### PR TITLE
Add min-height to fix overlapping li element

### DIFF
--- a/packages/ndla-ui/src/List/OrderedList.tsx
+++ b/packages/ndla-ui/src/List/OrderedList.tsx
@@ -64,7 +64,7 @@ const StyledOl = styled.ol`
   }
 
   > li {
-    min-height: 29px;
+    min-height: ${spacing.normal};
     counter-increment: level1;
     &:before {
       position: absolute;

--- a/packages/ndla-ui/src/List/OrderedList.tsx
+++ b/packages/ndla-ui/src/List/OrderedList.tsx
@@ -64,6 +64,7 @@ const StyledOl = styled.ol`
   }
 
   > li {
+    min-height: 29px;
     counter-increment: level1;
     &:before {
       position: absolute;


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/3699

Dette var visst ikke et slate issue, men heller et styling issue!

**Teste**:
Lag en nummerert liste og la siste element være tomt, legg et avsnitt med tekst rett under og se på forhåndsvisning av artikkelen

**Før**:
![Skjermbilde 2023-09-06 kl  08 44 35](https://github.com/NDLANO/frontend-packages/assets/26788204/297db66c-0df3-4dc5-8ce0-64111b1d5444)

**Nå**:
![Skjermbilde 2023-09-06 kl  08 44 50](https://github.com/NDLANO/frontend-packages/assets/26788204/1868dfe9-a075-4b4b-808a-dade35f1f70a)

