### PR TITLE
Move syntax highlighting out of CodeBlock

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@types/node": "^16.0.0",
     "@types/react": "^18.2.12",
     "@types/react-dom": "^18.2.5",
+    "@types/react-syntax-highlighter": "^15.5.5",
     "autoprefixer": "^9.4.7",
     "babel-jest": "^29.6.1",
     "camelcase": "^7.0.1",

--- a/packages/ndla-code/package.json
+++ b/packages/ndla-code/package.json
@@ -32,10 +32,8 @@
     "@ndla/core": "^4.1.6",
     "@ndla/icons": "^4.0.5",
     "@ndla/util": "^3.1.15",
-    "@types/react-syntax-highlighter": "^15.5.5",
     "prismjs": "^1.22.0",
-    "react-simple-code-editor": "^0.13.0",
-    "react-syntax-highlighter": "^15.5.0"
+    "react-simple-code-editor": "^0.13.0"
   },
   "peerDependencies": {
     "@emotion/react": "^11.10.4",

--- a/packages/ndla-code/src/CodeEmbed.tsx
+++ b/packages/ndla-code/src/CodeEmbed.tsx
@@ -18,6 +18,7 @@ const CodeEmbed = ({ embed }: Props) => {
       <Codeblock
         title={embed.embedData.title}
         code={embed.status === 'success' ? embed.data.decodedContent : ''}
+        highlightedCode={embed.status === 'success' ? embed.data.highlightedCode : ''}
         format={embed.embedData.codeFormat}
         showCopy
       />

--- a/packages/ndla-code/src/Codeblock/Codeblock.stories.tsx
+++ b/packages/ndla-code/src/Codeblock/Codeblock.stories.tsx
@@ -23,6 +23,21 @@ export default {
   args: {
     title: 'Codeblock',
     format: 'html',
+    highlightedCode: `<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>div</span> <span class="token attr-name">class</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>demo-content<span class="token punctuation">"</span></span><span class="token punctuation">></span></span>
+  <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>h2</span><span class="token punctuation">></span></span>Lorem ipsum<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>h2</span><span class="token punctuation">></span></span>
+  <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>p</span><span class="token punctuation">></span></span>
+    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>b</span><span class="token punctuation">></span></span>Lorem ipsum<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>b</span><span class="token punctuation">></span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>br</span><span class="token punctuation">/></span></span>
+    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>span</span><span class="token punctuation">></span></span>is simply dummy text of the printing and typesetting industry<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>span</span><span class="token punctuation">></span></span>
+  <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>p</span><span class="token punctuation">></span></span>
+  <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>p</span><span class="token punctuation">></span></span>
+    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>b</span><span class="token punctuation">></span></span>Lorem ipsum<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>b</span><span class="token punctuation">></span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>br</span><span class="token punctuation">/></span></span>
+    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>span</span><span class="token punctuation">></span></span>is simply dummy text of the printing and typesetting industry<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>span</span><span class="token punctuation">></span></span>
+  <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>p</span><span class="token punctuation">></span></span>
+  <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>p</span><span class="token punctuation">></span></span>
+    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>b</span><span class="token punctuation">></span></span>Lorem ipsum<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>b</span><span class="token punctuation">></span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>br</span><span class="token punctuation">/></span></span>
+    <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>span</span><span class="token punctuation">></span></span>is simply dummy text of the printing and typesetting industry<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>span</span><span class="token punctuation">></span></span>
+  <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>p</span><span class="token punctuation">></span></span>
+<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>div</span><span class="token punctuation">></span></span>`,
     code: `<div class="demo-content">
   <h2>Lorem ipsum</h2>
   <p>
@@ -65,6 +80,11 @@ export const HTML: StoryFn<typeof Codeblock> = (args) => {
 
 export const CSS: StoryObj<typeof Codeblock> = {
   args: {
+    highlightedCode: `<span class="token selector">body</span> <span class="token punctuation">{</span>
+  <span class="token property">padding</span><span class="token punctuation">:</span> <span class="token number">20</span><span class="token unit">px</span><span class="token punctuation">;</span>
+  <span class="token property">margin</span><span class="token punctuation">:</span> <span class="token number">10</span><span class="token unit">px</span><span class="token punctuation">;</span>
+  <span class="token property">background</span><span class="token punctuation">:</span> <span class="token hexcode color">#ccc</span><span class="token punctuation">;</span>
+<span class="token punctuation">}</span>`,
     code: `body {
   padding: 20px;
   margin: 10px;
@@ -76,6 +96,9 @@ export const CSS: StoryObj<typeof Codeblock> = {
 
 export const JS: StoryObj<typeof Codeblock> = {
   args: {
+    highlightedCode: `<span class="token keyword">const</span> arr <span class="token operator">=</span> <span class="token punctuation">[</span><span class="token string">"This"</span><span class="token punctuation">,</span> <span class="token string">"Little"</span><span class="token punctuation">,</span> <span class="token string">"Piggy"</span><span class="token punctuation">]</span><span class="token punctuation">;</span>
+<span class="token keyword">const</span> first <span class="token operator">=</span> arr<span class="token punctuation">.</span><span class="token method function property-access">shift</span><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+<span class="token console class-name">console</span><span class="token punctuation">.</span><span class="token method function property-access">log</span><span class="token punctuation">(</span>first<span class="token punctuation">)</span><span class="token punctuation">;</span>`,
     code: `const arr = ["This", "Little", "Piggy"];
 const first = arr.shift();
 console.log(first);`,
@@ -85,6 +108,7 @@ console.log(first);`,
 
 export const Text: StoryObj<typeof Codeblock> = {
   args: {
+    highlightedCode: `Pure text without highlighting and no title`,
     code: `Pure text without highlighting and no title`,
     format: 'text',
   },

--- a/packages/ndla-code/src/Codeblock/Codeblock.tsx
+++ b/packages/ndla-code/src/Codeblock/Codeblock.tsx
@@ -6,14 +6,8 @@
  *
  */
 
-/**
- * Be advised! This component breaks on SSR if you import CodeBlockEditor or languages.tsx.
- */
-
-import { useState, useEffect, CSSProperties, ReactNode } from 'react';
-import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
-import coy from 'react-syntax-highlighter/dist/cjs/styles/prism/coy';
-import { colors } from '@ndla/core';
+import { useState, useEffect, ReactNode, useMemo } from 'react';
+import { colors, fonts, spacing } from '@ndla/core';
 import styled from '@emotion/styled';
 import { copyTextToClipboard } from '@ndla/util';
 import { useTranslation } from 'react-i18next';
@@ -24,24 +18,6 @@ import { ICodeLangugeOption, languageOptions } from '../languageOptions';
 
 const Wrapper = styled.div`
   margin: 15px 0;
-  code {
-    margin: 0;
-    padding: 0;
-  }
-  [class^='language-'] {
-    & > span:first-of-type {
-      & span:first-of-type {
-        padding-top: 10px;
-        display: block;
-      }
-    }
-    & > span:last-of-type {
-      & span:first-of-type {
-        padding-bottom: 10px;
-        display: block;
-      }
-    }
-  }
 `;
 
 const TitleBar = styled.div`
@@ -61,34 +37,129 @@ const Title = styled.h3`
   margin: 5px 0;
 `;
 
-const syntaxHighlighterStyle = {
-  ...coy,
-  'code[class*="language-"]': {
-    ...coy['code[class*="language-"]'],
-    fontFamily: 'Source Code Pro, Monaco',
-    fontSize: '14px',
-    background: colors.brand.greyLighter,
-    borderLeft: `4px solid ${colors.brand.dark}`,
-    padding: '0',
-  },
-};
-
-const lineNumberStyle: CSSProperties = {
-  borderRight: '1px solid #D8D8D8',
-  borderLeft: 0,
-  marginRight: '10px',
-  marginLeft: '10px',
-  userSelect: 'none',
-  color: '#979797',
-};
-
 type Props = {
   code: string;
+  highlightedCode: string;
   format: string;
   title?: string | null;
   actionButton?: ReactNode;
   showCopy?: boolean;
 };
+
+const StyledPre = styled.pre`
+  border-left: 4px solid ${colors.brand.dark};
+  box-sizing: border-box;
+  overflow-x: auto;
+  .linenumber {
+    display: inline-block;
+    padding: 0 ${spacing.small};
+    border-right: 1px solid #d8d8d8;
+    margin-right: ${spacing.small};
+    color: #7d8b99;
+    text-align: right;
+    width: 40px;
+  }
+  .linenumber[data-first] {
+    padding-top: ${spacing.small};
+  }
+  .linenumber[data-last] {
+    padding-bottom: ${spacing.small};
+  }
+  code {
+    display: block;
+    ${fonts.sizes('14px', '20px')};
+    font-family: Source Code Pro, Monaco;
+    margin: 0;
+    padding: 0;
+    white-space: pre;
+  }
+  code::before {
+    content: none;
+  }
+  &::before,
+  &::after {
+    content: none !important;
+  }
+
+  /* The remaining css is copied from the coy theme in prismjs. A lot of css is omitted due to styling clashes */
+  .token.comment,
+  .token.block-comment,
+  .token.prolog,
+  .token.doctype,
+  .token.cdata {
+    color: #7d8b99;
+  }
+
+  .token.punctuation {
+    color: #5f6364;
+  }
+
+  .token.property,
+  .token.tag,
+  .token.boolean,
+  .token.number,
+  .token.function-name,
+  .token.constant,
+  .token.symbol,
+  .token.deleted {
+    color: #c92c2c;
+  }
+
+  .token.selector,
+  .token.attr-name,
+  .token.string,
+  .token.char,
+  .token.function,
+  .token.builtin,
+  .token.inserted {
+    color: #2f9c0a;
+  }
+
+  .token.operator,
+  .token.entity,
+  .token.url,
+  .token.variable {
+    color: #a67f59;
+    background: rgba(255, 255, 255, 0.5);
+  }
+
+  .token.atrule,
+  .token.attr-value,
+  .token.keyword,
+  .token.class-name {
+    color: #1990b8;
+  }
+
+  .token.regex,
+  .token.important {
+    color: #e90;
+  }
+
+  .language-css .token.string,
+  .style .token.string {
+    color: #a67f59;
+    background: rgba(255, 255, 255, 0.5);
+  }
+
+  .token.important {
+    font-weight: normal;
+  }
+
+  .token.bold {
+    font-weight: bold;
+  }
+  .token.italic {
+    font-style: italic;
+  }
+
+  .token.entity {
+    cursor: help;
+  }
+
+  .token.namespace {
+    opacity: 0.7;
+  }
+`;
 
 const getTitleFromFormat = (format: string) => {
   const selectedLanguage = languageOptions.find((item: ICodeLangugeOption) => item.format === format);
@@ -98,9 +169,20 @@ const getTitleFromFormat = (format: string) => {
   return;
 };
 
-export const Codeblock = ({ actionButton, code, format, showCopy = false, title }: Props) => {
+export const Codeblock = ({ actionButton, code, highlightedCode, format, showCopy = false, title }: Props) => {
   const { t } = useTranslation();
   const [isCopied, setIsCopied] = useState(false);
+
+  const codeWithLineNumbers = useMemo(() => {
+    return highlightedCode
+      .split('\n')
+      .map((line, i, arr) => {
+        return `<span><span class="linenumber" ${i === 0 ? 'data-first=""' : ''} ${
+          i === arr.length - 1 ? 'data-last=""' : ''
+        }>${i + 1}</span>${line}</span>`;
+      })
+      .join('\n');
+  }, [highlightedCode]);
 
   useEffect(() => {
     if (isCopied) {
@@ -118,16 +200,9 @@ export const Codeblock = ({ actionButton, code, format, showCopy = false, title 
         <Title>{title || getTitleFromFormat(format)}</Title>
         {actionButton}
       </TitleBar>
-      <SyntaxHighlighter
-        lineNumberStyle={lineNumberStyle}
-        style={syntaxHighlighterStyle}
-        language={format}
-        wrapLines
-        showInlineLineNumbers
-        showLineNumbers
-      >
-        {code}
-      </SyntaxHighlighter>
+      <StyledPre>
+        <code className={`language-${format}`} dangerouslySetInnerHTML={{ __html: codeWithLineNumbers }} />
+      </StyledPre>
       {showCopy && (
         <ButtonV2
           title={t('codeBlock.copyButton')}

--- a/packages/types-embed/src/codeTypes.ts
+++ b/packages/types-embed/src/codeTypes.ts
@@ -17,6 +17,7 @@ export interface CodeEmbedData {
 
 export interface CodeData {
   decodedContent: string;
+  highlightedCode: string;
 }
 
 export type CodeMetaData = MetaData<CodeEmbedData, CodeData>;

--- a/stories/wrappers/SyntaxHiglighter.tsx
+++ b/stories/wrappers/SyntaxHiglighter.tsx
@@ -1,5 +1,8 @@
+//@ts-ignore
 import jsx from 'react-syntax-highlighter/dist/cjs/languages/prism/jsx';
+//@ts-ignore
 import ReactSyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/prism-light';
+//@ts-ignore
 import { prism } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
 ReactSyntaxHighlighter.registerLanguage('jsx', jsx);


### PR DESCRIPTION
https://github.com/NDLANO/Issues/issues/3662
Tar over for https://github.com/NDLANO/frontend-packages/pull/1770

Veldig breaking.

Bakgrunn: `React-syntax-highlighter` fungerer ikke særlig bra på server-siden. I dag fører det til at vi får hydreringsfeil på alle sider som har kodeblokker i seg. En potensiell løsning har vært å ta i bruk en større del av `React-syntax-highlighter`, på bekostning av en stor økning i bundle-size.

Denne PR'en prøver å løse dette ved å fjerne syntax-highlighting fra `CodeBlock`. Vi krever nå istedenfor at komponenten mottar kode som allerede har blitt prosessert av Prismjs. Ansvaret for å kjøre kode gjennom Prismjs har blitt gitt til `article-converter`-delen av GQL. Det er en korresponderende PR der.

Ndla-frontend krever ingen endringer. I ED må vi nok få inn Prism i slate-pluginen til kodeblokker, slik at koden kan highlightes mens man ikke redigerer. Merk: Kode-editoren er urørt. Dette påvirker kun fremvisning av kode. 

