### PR TITLE
Fix floated image sizes on some tablet sizes

### DIFF
--- a/packages/core/scss/global/utilities/utilities.grids.scss
+++ b/packages/core/scss/global/utilities/utilities.grids.scss
@@ -1,9 +1,12 @@
-@mixin float($cols, $maxcols, $direction) {
+@mixin float($cols, $maxcols, $direction, $override-cols-tablet: null) {
   z-index: 1;
   $colDifference: $maxcols - $cols;
   $cols-tablet: $cols - 1;
   @if ($cols == 1) {
     $cols-tablet: 1;
+  }
+  @if $override-cols-tablet {
+    $cols-tablet: $override-cols-tablet;
   }
 
   @if $direction == left {

--- a/packages/core/scss/global/utilities/utilities.helpers.scss
+++ b/packages/core/scss/global/utilities/utilities.helpers.scss
@@ -14,10 +14,10 @@
 
 /* Float article objects */
 .u-float-left {
-  @include float(2, 3, 'left');
+  @include float(13, 20, 'left', 10);
 }
 .u-float-right {
-  @include float(2, 3, 'right');
+  @include float(13, 20, 'right', 10);
 }
 .u-float-small-left {
   @include float(2, 4, 'left');

--- a/packages/ndla-ui/src/LicenseByline/EmbedByline.tsx
+++ b/packages/ndla-ui/src/LicenseByline/EmbedByline.tsx
@@ -113,7 +113,7 @@ const RightsWrapper = styled.div`
     ${mobileStyling}
   }
 
-  ${mq.range({ until: breakpoints.tablet })} {
+  ${mq.range({ until: breakpoints.tabletWide })} {
     ${mobileStyling}
   }
 `;


### PR DESCRIPTION
Fixes https://trello.com/c/vRMzBySM/388-bildeinfo-og-hjerte-flyttes-utenfor-boksen-i-mindre-st%C3%B8rrelser
Skikkelig knotete opplegg med disse float-klassene, altså. Float fungerer nå slik:
* Til tablet: 65% (13/20)
* Til desktop/stor tablet: 50%
* Mobil: 100% (samme som før)

Kan testes ved linking på http://localhost:3000/article/26617