### PR TITLE
Remove roman-list from wide margin

### DIFF
--- a/packages/core/scss/global/elements/_elements.details.scss
+++ b/packages/core/scss/global/elements/_elements.details.scss
@@ -51,8 +51,7 @@ details :not(li) > ul:not([class]) {
 }
 
 details > ol:not([class]),
-details :not(li) > ol:not([class]),
-details .ol-list--roman {
+details :not(li) > ol:not([class]) {
   @include mq(desktop) {
     margin-left: $spacing--large;
   }

--- a/packages/ndla-ui/src/Aside/component.aside.scss
+++ b/packages/ndla-ui/src/Aside/component.aside.scss
@@ -84,8 +84,7 @@
 }
 
 .c-aside__content > ol:not([class]),
-.c-aside__content :not(li) > ol:not([class]),
-.c-aside__content .ol-list--roman {
+.c-aside__content :not(li) > ol:not([class]) {
   @include mq(desktop) {
     margin-left: $spacing--large;
   }

--- a/packages/ndla-ui/src/FactBox/component.factbox.scss
+++ b/packages/ndla-ui/src/FactBox/component.factbox.scss
@@ -41,8 +41,7 @@ $padding-bottom: 17px;
     }
 
     & > ol:not([class]),
-    :not(li) > ol:not([class]),
-    .ol-list--roman {
+    :not(li) > ol:not([class]) {
       @include mq(desktop) {
         margin-left: $spacing--large;
       }


### PR DESCRIPTION
Nummerert bokstavliste i bokser har ekstra marg i forhold til talliste. Det ser litt rart ut og er ikkje i sync med designet.
Kan sjekkes på http://localhost:3000/subject-matter/learning-resource/38289/edit/nb med innlinka endringer.