### PR TITLE
Only allow one image at a time in a campaign block

### DIFF
--- a/packages/article-converter/src/plugins/embed/campaignBlockPlugin.tsx
+++ b/packages/article-converter/src/plugins/embed/campaignBlockPlugin.tsx
@@ -21,14 +21,10 @@ export const campaignBlockPlugin: PluginType = (element, _, opts) => {
       description={{ text: embed.description, language: embed.descriptionLanguage }}
       url={{ url: embed.url, text: embed.urlText }}
       path={opts.path}
-      imageAfter={
-        data.status === 'success' && data.data.imageAfter
-          ? { src: data.data.imageAfter.image.imageUrl, alt: data.data.imageAfter.alttext.alttext }
-          : undefined
-      }
-      imageBefore={
-        data.status === 'success' && data.data.imageBefore
-          ? { src: data.data.imageBefore.image.imageUrl, alt: data.data.imageBefore.alttext.alttext }
+      imageSide={embed.imageSide}
+      image={
+        data.status === 'success' && data.data.image
+          ? { src: data.data.image.image.imageUrl, alt: data.data.image.alttext.alttext }
           : undefined
       }
     />

--- a/packages/ndla-ui/src/CampaignBlock/CampaignBlock.stories.tsx
+++ b/packages/ndla-ui/src/CampaignBlock/CampaignBlock.stories.tsx
@@ -20,7 +20,7 @@ export default {
   args: {},
 } as Meta<typeof CampaignBlock>;
 
-export const BothImages: StoryObj<typeof CampaignBlock> = {
+export const ImageLeft: StoryObj<typeof CampaignBlock> = {
   args: {
     title: { title: 'NDLA film', language: 'nb-no' },
     description: {
@@ -32,18 +32,14 @@ export const BothImages: StoryObj<typeof CampaignBlock> = {
       url: '#',
       text: 'Gå til NDLA film',
     },
-    imageBefore: {
+    image: {
       alt: '',
       src: 'https://api.test.ndla.no/image-api/raw/n2UYRxEG.png',
-    },
-    imageAfter: {
-      alt: '',
-      src: 'https://api.test.ndla.no/image-api/raw/8GOxOhjr.png',
     },
   },
 };
 
-export const SingleImage: StoryObj<typeof CampaignBlock> = {
+export const ImageRight: StoryObj<typeof CampaignBlock> = {
   args: {
     title: { title: 'FN-dagen 24. oktober!', language: 'nb-no' },
     description: {
@@ -54,9 +50,10 @@ export const SingleImage: StoryObj<typeof CampaignBlock> = {
       url: '#',
       text: 'Les mer om FN-dagen',
     },
-    imageAfter: {
+    image: {
       alt: 'FN-symbol',
       src: 'https://api.test.ndla.no/image-api/raw/LkmDGtip.png',
     },
+    imageSide: 'right',
   },
 };

--- a/packages/ndla-ui/src/CampaignBlock/CampaignBlock.tsx
+++ b/packages/ndla-ui/src/CampaignBlock/CampaignBlock.tsx
@@ -33,8 +33,8 @@ interface Props {
     url: string;
     text: string;
   };
-  imageBefore?: Image;
-  imageAfter?: Image;
+  image?: Image;
+  imageSide?: 'left' | 'right';
   className?: string;
   path?: string;
 }
@@ -43,14 +43,20 @@ const Container = styled.div`
   max-width: 390px;
   display: flex;
   flex-direction: column;
-  gap: ${spacing.xsmall};
+  gap: ${spacing.normal};
   border: 1px ${colors.brand.lighter} solid;
   border-radius: ${misc.borderRadius};
-  padding: ${spacing.normal} ${spacing.small};
+  padding: ${spacing.normal};
   background-color: ${colors.white};
+  &[data-image-side='right'] {
+    flex-direction: column-reverse;
+  }
   ${mq.range({ from: breakpoints.tabletWide })} {
     max-width: 1100px;
     flex-direction: row;
+    &[data-image-side='right'] {
+      flex-direction: row-reverse;
+    }
   }
 `;
 
@@ -81,18 +87,18 @@ const TextWrapper = styled.div`
 
 const CampaignBlock = ({
   title,
-  imageBefore,
+  image,
+  imageSide = 'left',
   description,
   headingLevel: Heading = 'h2',
-  imageAfter,
   url,
   path,
   className,
 }: Props) => {
   const href = usePossiblyRelativeUrl(url.url, path);
   return (
-    <Container className={className} data-type="campaign-block">
-      {imageBefore && <StyledImg src={imageBefore.src} height={200} width={240} alt="" />}
+    <Container className={className} data-type="campaign-block" data-image-side={imageSide}>
+      {image && <StyledImg src={image.src} height={200} width={240} alt="" />}
       <TextWrapper>
         <Heading css={headingStyle}>{title.title}</Heading>
         <StyledDescription>{description.text}</StyledDescription>
@@ -101,7 +107,6 @@ const CampaignBlock = ({
           <Forward />
         </StyledLink>
       </TextWrapper>
-      {imageAfter && <StyledImg src={imageAfter.src} height={200} width={240} alt="" />}
     </Container>
   );
 };

--- a/packages/types-embed/src/campaignBlockTypes.ts
+++ b/packages/types-embed/src/campaignBlockTypes.ts
@@ -18,13 +18,12 @@ export interface CampaignBlockEmbedData {
   headingLevel: 'h1' | 'h2' | 'h3' | 'h4' | 'h5';
   url: string;
   urlText: string;
-  imageBeforeId?: string;
-  imageAfterId?: string;
+  imageId?: string;
+  imageSide?: 'left' | 'right';
 }
 
 export interface CampaignBlockMeta {
-  imageBefore?: IImageMetaInformationV3;
-  imageAfter?: IImageMetaInformationV3;
+  image?: IImageMetaInformationV3;
 }
 
 export type CampaignBlockMetaData = MetaData<CampaignBlockEmbedData, CampaignBlockMeta>;


### PR DESCRIPTION
Denne er breaking. Oppdaterer `CampaignBlock` til å kun ta imot ett bilde. Det kan enten plasseres på venstre- eller høyresiden, og defaulter til venstre.