### PR TITLE
Remove Prism dependency from ndla/code entirely. Loading Prism languages

### DIFF
--- a/packages/ndla-code/README.md
+++ b/packages/ndla-code/README.md
@@ -19,6 +19,8 @@ import { Codeblock } from '@ndla/code';
 ```
 
 editor:
+The user is responsible for loading prism syntaxes, the code editor does not do it for you.
+The `highlight` function is expecting a properly tokenized Prism string as its return value.
 
 ```js
 import { CodeBlockEditor } from '@ndla/code';

--- a/packages/ndla-code/package.json
+++ b/packages/ndla-code/package.json
@@ -32,7 +32,6 @@
     "@ndla/core": "^4.1.7",
     "@ndla/icons": "^4.0.6",
     "@ndla/util": "^3.2.0",
-    "prismjs": "^1.22.0",
     "react-simple-code-editor": "^0.13.0"
   },
   "peerDependencies": {

--- a/packages/ndla-code/src/CodeBlockEditor/CodeBlockEditor.tsx
+++ b/packages/ndla-code/src/CodeBlockEditor/CodeBlockEditor.tsx
@@ -6,53 +6,21 @@
  *
  */
 
-import { ChangeEvent, createRef, useState } from 'react';
+import { ChangeEvent, createRef, useCallback, useState } from 'react';
 import Editor from 'react-simple-code-editor';
 import { useTranslation } from 'react-i18next';
 import { Code } from '@ndla/icons/editor';
 import { ButtonV2 } from '@ndla/button';
 // @ts-ignore
-import { highlight, languages } from 'prismjs/components/prism-core';
 import styled from '@emotion/styled';
 import { colors, fonts, spacing } from '@ndla/core';
 import { Wrapper, FlexContainer, FlexElement } from './style';
 import { languageOptions, ICodeLangugeOption } from '../languageOptions';
-import 'prismjs/components/prism-clike';
-import 'prismjs/components/prism-markup';
-import 'prismjs/components/prism-markup-templating';
-import 'prismjs/components/prism-php';
-import 'prismjs/components/prism-css';
-import 'prismjs/components/prism-javascript';
-import 'prismjs/components/prism-jsx';
-import 'prismjs/components/prism-c';
-import 'prismjs/components/prism-csharp';
-import 'prismjs/components/prism-cpp';
-import 'prismjs/components/prism-diff';
-import 'prismjs/components/prism-ini';
-import 'prismjs/components/prism-json';
-import 'prismjs/components/prism-java';
-import 'prismjs/components/prism-kotlin';
-import 'prismjs/components/prism-lua';
-import 'prismjs/components/prism-markdown';
-import 'prismjs/components/prism-matlab';
-import 'prismjs/components/prism-nsis';
-import 'prismjs/components/prism-python';
-import 'prismjs/components/prism-ruby';
-import 'prismjs/components/prism-rust';
-import 'prismjs/components/prism-sql';
-import 'prismjs/components/prism-powershell';
-import 'prismjs/components/prism-vhdl';
-import 'prismjs/components/prism-bash';
-
-const hightlightWithLineNumbers = (input: string, language: string) =>
-  highlight(input, language)
-    .split('\n')
-    .map((line: string, i: number) => `<span class='editorLineNumber'>${i + 1}</span>${line}`)
-    .join('\n');
 
 type Props = {
   onSave: Function;
   onAbort: Function;
+  highlight: (code: string, language: string) => string;
   content: {
     code: string;
     title: string;
@@ -88,7 +56,7 @@ interface CodeContentState {
   format: string;
 }
 
-const CodeBlockEditor = ({ onSave, onAbort, content = null }: Props) => {
+const CodeBlockEditor = ({ onSave, onAbort, highlight, content = null }: Props) => {
   const { t } = useTranslation();
   const [defaultLang] = languageOptions;
   const [codeContent, setCodeContent] = useState<CodeContentState>({
@@ -96,6 +64,15 @@ const CodeBlockEditor = ({ onSave, onAbort, content = null }: Props) => {
     title: content ? content.title : defaultLang.title,
     format: content ? content.format : defaultLang.format,
   });
+
+  const highlightWithLineNumbers = useCallback(
+    (input: string, language: string) =>
+      highlight(input, language)
+        .split('\n')
+        .map((line: string, i: number) => `<span class='editorLineNumber'>${i + 1}</span>${line}`)
+        .join('\n'),
+    [highlight],
+  );
 
   const titleRef = createRef<HTMLInputElement>();
 
@@ -170,9 +147,7 @@ const CodeBlockEditor = ({ onSave, onAbort, content = null }: Props) => {
         onValueChange={(code) => {
           setCodeContent({ ...codeContent, code });
         }}
-        highlight={(code) =>
-          hightlightWithLineNumbers(code, languages[codeContent.format] ? languages[codeContent.format] : '')
-        }
+        highlight={(code) => highlightWithLineNumbers(code, codeContent.format)}
         padding={10}
         textareaId="codeArea"
         style={{

--- a/yarn.lock
+++ b/yarn.lock
@@ -11685,7 +11685,7 @@ pretty-ms@7.0.1:
   dependencies:
     parse-ms "^2.1.0"
 
-prismjs@^1.22.0, prismjs@^1.27.0:
+prismjs@^1.27.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
   integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==


### PR DESCRIPTION
several times caused weird behavior. Instead, the component accepts a `highlight` function expected to return a formatted string

Gidder ikke legge inn en altfor god beskrivelse på hvordan man skal loade Prism-grammars, da det er så mange forskjellige måter å gjøre det på.