### PR TITLE
#3715: Allow descriptionless `MediaList` items

### DIFF
--- a/packages/ndla-licenses/src/CCRel.ts
+++ b/packages/ndla-licenses/src/CCRel.ts
@@ -35,10 +35,11 @@ export const getResourceTypeNamespace = (type: ResourceTypes | undefined | null)
   }
 };
 
-export const metaTypes = {
-  author: 'author',
-  copyrightHolder: 'copyrightHolder',
-  contributor: 'contributor',
-  title: 'title',
-  other: 'other',
-};
+export enum metaTypes {
+  author = 'author',
+  copyrightHolder = 'copyrightHolder',
+  contributor = 'contributor',
+  title = 'title',
+  other = 'other',
+  otherWithoutDescription = 'otherWithoutDescription',
+}

--- a/packages/ndla-licenses/src/CCRel.ts
+++ b/packages/ndla-licenses/src/CCRel.ts
@@ -35,11 +35,13 @@ export const getResourceTypeNamespace = (type: ResourceTypes | undefined | null)
   }
 };
 
-export enum metaTypes {
-  author = 'author',
-  copyrightHolder = 'copyrightHolder',
-  contributor = 'contributor',
-  title = 'title',
-  other = 'other',
-  otherWithoutDescription = 'otherWithoutDescription',
-}
+export const metaTypes = {
+  author: 'author',
+  copyrightHolder: 'copyrightHolder',
+  contributor: 'contributor',
+  title: 'title',
+  other: 'other',
+  otherWithoutDescription: 'otherWithoutDescription',
+} as const;
+
+export type MetaType = keyof typeof metaTypes;

--- a/packages/ndla-licenses/src/index.ts
+++ b/packages/ndla-licenses/src/index.ts
@@ -14,6 +14,7 @@ export {
 } from './contributorTypes';
 
 export { resourceTypes, getResourceTypeNamespace, metaTypes } from './CCRel';
+export type { MetaType } from './CCRel';
 
 export { BY, SA, NA, NC, ND, PD, CC0, CC, COPYRIGHTED, getLicenseRightByAbbreviation } from './licenseRights';
 

--- a/packages/ndla-ui/src/MediaList/MediaList.tsx
+++ b/packages/ndla-ui/src/MediaList/MediaList.tsx
@@ -13,6 +13,7 @@ import {
   isCreativeCommonsLicense,
   metaTypes,
 } from '@ndla/licenses';
+import type { MetaType } from '@ndla/licenses';
 import { LicenseDescription } from '@ndla/notion';
 import BEMHelper from 'react-bem-helper';
 import { uuid } from '@ndla/util';
@@ -187,12 +188,12 @@ export type ItemType = ItemTypeWithDescription | DescriptionLessItemType;
 interface ItemTypeWithDescription {
   label: string;
   description: string;
-  metaType: Omit<metaTypes, 'otherWithoutDescription'>;
+  metaType: Omit<MetaType, 'otherWithoutDescription'>;
 }
 
 interface DescriptionLessItemType {
   label: string;
-  metaType: metaTypes.otherWithoutDescription;
+  metaType: 'otherWithoutDescription';
 }
 
 function isOtherWithoutDescription(item: ItemType): item is DescriptionLessItemType {

--- a/packages/ndla-ui/src/MediaList/index.ts
+++ b/packages/ndla-ui/src/MediaList/index.ts
@@ -13,3 +13,5 @@ export {
   MediaListItemImage,
   MediaListItemMeta,
 } from './MediaList';
+
+export type { ItemType } from './MediaList';

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -207,6 +207,8 @@ export {
   MediaListItemMeta,
 } from './MediaList';
 
+export type { ItemType } from './MediaList';
+
 export {
   default as ContentTypeBadge,
   SubjectMaterialBadge,

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -631,6 +631,7 @@ const messages = {
     title: 'Title',
     originator: 'Originator',
     rightsholder: 'Rightsholder',
+    processed: 'The content has been processed',
     source: 'Source',
     published: 'Published',
     info: 'License information',

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -630,6 +630,7 @@ const messages = {
     title: 'Tittel',
     originator: 'Opphaver',
     published: 'Publiseringsdato',
+    processed: 'Innholdet har blitt bearbeidet',
     rightsholder: 'Rettighetshaver',
     source: 'Kilde',
     info: 'Lisensinformasjon',

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -629,6 +629,7 @@ const messages = {
     },
     title: 'Tittel',
     originator: 'Opphavar',
+    processed: 'Innhaldet har vorte omarbeidd',
     rightsholder: 'Rettshavar',
     source: 'Kjelde',
     published: 'Publiseringsdato',

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -631,6 +631,7 @@ const messages = {
     title: 'Tihttel',
     originator: 'Ásaheaddji',
     published: 'Almmuhanbeaivi',
+    processed: 'Innhaldet har vorte omarbeidd',
     rightsholder: 'Vuoigatvuođaguoddi',
     source: 'Gáldu',
     info: 'Lisensinformasjon',

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -631,7 +631,7 @@ const messages = {
     title: 'Tihttel',
     originator: 'Ásaheaddji',
     published: 'Almmuhanbeaivi',
-    processed: 'Innhaldet har vorte omarbeidd',
+    processed: 'Sisdoallu lea rievdaduvvon.',
     rightsholder: 'Vuoigatvuođaguoddi',
     source: 'Gáldu',
     info: 'Lisensinformasjon',

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -634,6 +634,7 @@ const messages = {
     title: 'Tihtele',
     originator: 'Opphaver',
     published: 'Publiseringsdato',
+    processed: 'Innhaldet har vorte omarbeidd',
     rightsholder: 'Rettighetshaver',
     source: 'Gaaltije',
     info: 'Lisensinformasjon',


### PR DESCRIPTION
Nyttig for å kunne legge til elementer uten to deler. Feks "Innholdet har blitt bearbeidet" i copyright teksten :smile: