### PR TITLE
More css fixes to new embeds

### DIFF
--- a/packages/ndla-ui/src/BlogPost/BlogPost.tsx
+++ b/packages/ndla-ui/src/BlogPost/BlogPost.tsx
@@ -44,7 +44,6 @@ const Container = styled(SafeLink)`
   height: 100%;
   ${mq.range({ from: breakpoints.tabletWide })} {
     max-width: 350px;
-    max-height: fit-content;
     &[data-size='large'] {
       max-width: 532px;
     }

--- a/packages/ndla-ui/src/CampaignBlock/CampaignBlock.tsx
+++ b/packages/ndla-ui/src/CampaignBlock/CampaignBlock.tsx
@@ -69,8 +69,8 @@ const StyledDescription = styled.p`
 `;
 
 const StyledImg = styled.img`
-  max-height: 200px;
   align-self: center;
+  object-fit: contain;
 `;
 
 const StyledLink = styled(SafeLink)`


### PR DESCRIPTION
Max-content på blog post fungerer ikke ordentlig i safari. 
<img width="1140" alt="bilde" src="https://github.com/NDLANO/frontend-packages/assets/9728475/172119db-686d-48a2-bf53-dbf8c9389a7d">

Gjør også en endring i måten vi viser bilder på i kampanjeblokken. Vi letterboxer nå bildet til en viss grad når aspect-ratioen er helt på tur

Kan testes på http://localhost:3000/article/38311 med linking.