### PR TITLE
Allow undefined copyright in embed byline

### DIFF
--- a/packages/ndla-ui/src/LicenseByline/EmbedByline.tsx
+++ b/packages/ndla-ui/src/LicenseByline/EmbedByline.tsx
@@ -39,27 +39,27 @@ export interface EmbedBylineErrorProps extends BaseProps {
 
 interface ImageProps extends BaseProps {
   type: 'image';
-  copyright: ImageCopyright;
+  copyright: ImageCopyright | undefined;
 }
 
 interface BrightcoveProps extends BaseProps {
   type: 'video';
-  copyright: BrightcoveCopyright;
+  copyright: BrightcoveCopyright | undefined;
 }
 
 interface AudioProps extends BaseProps {
   type: 'audio';
-  copyright: AudioCopyright;
+  copyright: AudioCopyright | undefined;
 }
 
 interface PodcastProps extends BaseProps {
   type: 'podcast';
-  copyright: AudioCopyright;
+  copyright: AudioCopyright | undefined;
 }
 
 interface ConceptProps extends BaseProps {
   type: 'concept';
-  copyright: ConceptCopyright;
+  copyright: ConceptCopyright | undefined;
 }
 
 export type EmbedBylineTypeProps = ImageProps | BrightcoveProps | AudioProps | PodcastProps | ConceptProps;
@@ -158,7 +158,7 @@ const EmbedByline = ({
 
   const { copyright } = props;
 
-  const license = getLicenseByAbbreviation(copyright.license?.license ?? '', i18n.language);
+  const license = copyright ? getLicenseByAbbreviation(copyright.license?.license ?? '', i18n.language) : undefined;
   const authors = getLicenseCredits(copyright);
   const captionAuthors = Object.values(authors).find((i) => i.length > 0) ?? [];
 
@@ -167,7 +167,7 @@ const EmbedByline = ({
       {!!strippedDescription?.length && description && <LicenseDescription description={description} />}
       {visibleAlt ? <StyledSpan>{`Alt: ${visibleAlt}`}</StyledSpan> : null}
       <RightsWrapper data-grid={inGrid}>
-        <LicenseLink license={license} asLink={!!license.url.length} />
+        {license ? <LicenseLink license={license} asLink={!!license.url.length} /> : null}
         <LicenseInformationWrapper>
           <span>
             <b>{t(`embed.type.${type}`)}: </b>


### PR DESCRIPTION
Alle brightcoves har ikke copyright. Det må vi nesten tillate.
Gjerne kom med designtilbakemeldinger.
![bilde](https://github.com/NDLANO/frontend-packages/assets/9728475/e563348d-8cfd-46eb-957b-971fbca9f685)
