### PR TITLE
Select updates: package bump + fix console warning

### DIFF
--- a/packages/ndla-ui/package.json
+++ b/packages/ndla-ui/package.json
@@ -57,7 +57,7 @@
     "i18next-browser-languagedetector": "^6.1.1",
     "react-bem-helper": "1.4.1",
     "react-device-detect": "^2.2.3",
-    "react-select": "^5.7.0",
+    "react-select": "^5.7.5",
     "react-swipeable": "^7.0.0",
     "remarkable": "^2.0.1",
     "shave": "^2.5.10"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@ndla/core": "^4.1.7",
     "@ndla/icons": "^4.0.6",
-    "react-select": "^5.7.0"
+    "react-select": "^5.7.5"
   },
   "peerDependencies": {
     "@emotion/react": "^11.10.4",

--- a/packages/select/src/Select/BaseControl.tsx
+++ b/packages/select/src/Select/BaseControl.tsx
@@ -95,7 +95,6 @@ const BaseControl = <T extends boolean>({
     data-has-value={hasValue}
     ref={innerRef}
     {...innerProps}
-    {...rest}
   >
     {children}
   </StyledBaseControl>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12076,10 +12076,10 @@ react-router@6.3.0:
   dependencies:
     history "^5.2.0"
 
-react-select@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.7.0.tgz#82921b38f1fcf1471a0b62304da01f2896cd8ce6"
-  integrity sha512-lJGiMxCa3cqnUr2Jjtg9YHsaytiZqeNOKeibv6WF5zbK/fPegZ1hg3y/9P1RZVLhqBTs0PfqQLKuAACednYGhQ==
+react-select@^5.7.5:
+  version "5.7.5"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.7.5.tgz#d2d0f29994e0f06000147bfb2adf58324926c2fd"
+  integrity sha512-jgYZa2xgKP0DVn5GZk7tZwbRx7kaVz1VqU41S8z1KWmshRDhlrpKS0w80aS1RaK5bVIXpttgSou7XCjWw1ncKA==
   dependencies:
     "@babel/runtime" "^7.12.0"
     "@emotion/cache" "^11.4.0"


### PR DESCRIPTION
- Bumper react-select (ingen breaking endringer)
- Sender ikke lenger videre alle props fra parent i BaseControl, sjekket litt opp i dette og gir ikke mening å passe ned react-select spesifikke props når vi har bygget vår egen div-wrapper(StyledBaseControl), dette fjerner også advarselen som tidligere ble vist i konsoll:
![Skjermbilde 2023-09-29 kl  12 51 23](https://github.com/NDLANO/frontend-packages/assets/26788204/755e1128-7a11-4530-a0a6-24d0d721251f)

Testet opp mot selects i ed, og de ser ut til å fungere sånn de skal med denne oppdateringen!