### PR TITLE
Refactor RadioButtonGroup to be more accessible and malliable

### DIFF
--- a/packages/ndla-ui/package.json
+++ b/packages/ndla-ui/package.json
@@ -49,6 +49,7 @@
     "@ndla/tooltip": "^4.1.20",
     "@ndla/typography": "^0.2.0",
     "@ndla/util": "^3.2.0",
+    "@radix-ui/react-radio-group": "^1.1.3",
     "@radix-ui/react-popover": "^1.0.6",
     "@radix-ui/react-slider": "^1.1.2",
     "date-fns": "^2.30.0",

--- a/packages/ndla-ui/src/RadioButtonGroup/RadioButtonGroup.stories.tsx
+++ b/packages/ndla-ui/src/RadioButtonGroup/RadioButtonGroup.stories.tsx
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Meta, StoryFn, StoryObj } from '@storybook/react';
+import { css } from '@emotion/react';
+import { colors, misc, spacing, utils } from '@ndla/core';
+import RadioButtonGroup, { RadioButtonGroupRoot, RadioGroupItem } from './RadioButtonGroup';
+import { defaultParameters } from '../../../../stories/defaults';
+
+export default {
+  title: 'Components/RadioButtonGroup',
+  component: RadioButtonGroup,
+  tags: ['autodocs'],
+  parameters: {
+    ...defaultParameters,
+  },
+  args: {
+    uniqeIds: true,
+    label: 'Velg fag',
+    options: [
+      {
+        title: 'T1',
+        value: 't1',
+      },
+      {
+        title: 'R1',
+        value: 'r1',
+      },
+      {
+        title: 'R2',
+        value: 'r2',
+      },
+      {
+        title: 'S1',
+        value: 's1',
+        disabled: true,
+      },
+    ],
+  },
+} as Meta<typeof RadioButtonGroup>;
+
+export const RadioButtonGroupStory: StoryFn<typeof RadioButtonGroup> = ({ ...args }) => {
+  return <RadioButtonGroup {...args} />;
+};
+
+RadioButtonGroupStory.storyName = 'RadioButtonGroup';
+
+export const WithStandaloneComponents: StoryObj<typeof RadioButtonGroup> = {
+  args: {
+    onChange: () => {},
+    direction: 'vertical',
+    options: [
+      {
+        title: 'Vis navnet mitt når jeg deler en mappe',
+        value: 'showName',
+      },
+      {
+        title: 'Ikke vis navnet mitt når jeg deler en mappe',
+        value: 'dontShowName',
+      },
+      {
+        title: 'Kanskje vis navnet mitt når jeg deler en mappe',
+        value: 'maybeShowName',
+      },
+    ],
+  },
+  render: ({ options, ...args }) => {
+    return (
+      <RadioButtonGroupRoot
+        value={args.selected}
+        direction={args.direction}
+        defaultValue={args.selected ?? options[0].value}
+        onValueChange={args.onChange}
+        css={css`
+          gap: 0px;
+        `}
+        aria-labelledby="desc"
+      >
+        <span id="desc" css={css(utils.visuallyHidden)}>
+          {args.label}
+        </span>
+        {options.map((option) => (
+          <RadioGroupItem
+            key={option.value}
+            id={option.value}
+            css={css`
+              box-sizing: content-box;
+              border-radius: ${misc.borderRadius};
+              border: 1px solid ${colors.brand.greyLight};
+              border-radius: 0px;
+              padding: ${spacing.small};
+              border-color: ${colors.brand.light};
+
+              &:focus-within,
+              &[data-state='checked'] {
+                outline: 0px;
+                border-color: ${colors.brand.primary};
+                border-radius: 0px;
+                z-index: 1;
+              }
+              &:first-of-type {
+                border-top-left-radius: ${misc.borderRadius};
+                border-top-right-radius: ${misc.borderRadius};
+              }
+              &:not(:first-of-type) {
+                margin-top: -1px;
+              }
+              &:last-of-type {
+                border-bottom-left-radius: ${misc.borderRadius};
+                border-bottom-right-radius: ${misc.borderRadius};
+              }
+            `}
+            value={option.value}
+            title={option.title}
+            disabled={option.disabled}
+          />
+        ))}
+      </RadioButtonGroupRoot>
+    );
+  },
+};

--- a/packages/ndla-ui/src/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/ndla-ui/src/RadioButtonGroup/RadioButtonGroup.tsx
@@ -6,147 +6,177 @@
  *
  */
 
-import { Fragment, Component, ChangeEvent } from 'react';
+import { useMemo } from 'react';
 import styled from '@emotion/styled';
-import { uuid } from '@ndla/util';
-import { spacing, fonts, colors } from '@ndla/core';
+import { uuid as uuidFunc } from '@ndla/util';
+import { Text } from '@ndla/typography';
+import { spacing, fonts, colors, misc } from '@ndla/core';
+import { Indicator, Item, RadioGroupItemProps, RadioGroupProps, Root } from '@radix-ui/react-radio-group';
 
 interface Props {
   selected?: string;
+  className?: string;
   options: {
     title: string;
     value: string;
     disabled?: boolean;
   }[];
+  direction?: 'horizontal' | 'vertical';
   label?: string;
   uniqeIds?: boolean;
   onChange: (value: string) => void;
 }
 
-interface State {
-  selected: string;
-}
-
-const RadioButtonGroupWrapper = styled.div`
-  padding: ${spacing.small} 0;
+const GroupLabel = styled(Text)`
   font-family: ${fonts.sans};
+  font-weight: ${fonts.weight.semibold};
+`;
+
+const RadioButtonGroupLabel = styled(Text)`
+  color: ${colors.brand.primary};
+  font-family: ${fonts.sans};
+`;
+
+const RadioButtonWrapper = styled.div`
   display: flex;
   align-items: center;
-`;
-
-const RadioButtonGroupLabelHeading = styled.h1`
-  ${fonts.sizes('16px', '20px')};
-  margin: 0 ${spacing.normal} 0 0;
-  font-weight: 600;
-`;
-
-const RadioButtonGroupLabel = styled.label`
-  ${fonts.sizes('16px', '28px')};
-  color: ${colors.brand.primary};
-  align-items: center;
-  display: inline-flex;
-  &:before {
-    content: '';
-    margin-right: ${spacing.small};
-    width: 20px;
-    height: 20px;
-    border-radius: 100%;
-    border: 2px solid ${colors.brand.tertiary};
-    transition: 200ms border-color ease;
+  padding: 0px ${spacing.small};
+  gap: ${spacing.small};
+  &:focus-within {
+    outline: 2px solid ${colors.brand.primary};
+    border-radius: ${misc.borderRadius};
   }
-  &:after {
+`;
+
+export const StyledRadioGroupItem = styled(Item)`
+  all: unset;
+  transition: 200ms all ease;
+  box-shadow: 0 0 0 2px ${colors.brand.light};
+  min-width: ${spacing.nsmall};
+  min-height: ${spacing.nsmall};
+  width: ${spacing.nsmall};
+  height: ${spacing.nsmall};
+  border-radius: 100%;
+  &[data-state='checked'] {
+    box-shadow: 0 0 0 2px ${colors.brand.primary};
+  }
+`;
+
+const RadioButtonIndicator = styled(Indicator)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+
+  &::after {
     content: '';
-    background: transparent;
-    width: 10px;
-    height: 10px;
-    border-radius: 100%;
-    position: absolute;
-    transform: translateX(5px) scale(0, 0);
+    display: block;
+    width: 0px;
+    height: 0px;
+    border-radius: 50%;
+    background-color: ${colors.brand.light};
     transition: 200ms all ease;
   }
-  &:not(:last-child) {
-    margin-right: ${spacing.medium};
+  &:hover,
+  &:focus-visible,
+  &[data-state='checked'] {
+    &::after {
+      width: ${spacing.small};
+      height: ${spacing.small};
+    }
   }
-`;
+  &[data-disabled] {
+    &::after {
+      width: 0px;
+      height: 0px;
+    }
+  }
 
-const RadioButtonGroupInput = styled.input`
-  opacity: 0;
-  position: absolute;
-  width: auto;
-  &:hover + ${RadioButtonGroupLabel} {
-    outline: 1px dotted #212121;
-    outline: -webkit-focus-ring-color auto 5px;
-    &:after {
-      transform: translateX(5px) scale(1, 1);
-      background: ${colors.brand.tertiary};
-    }
-  }
-  // emotion does not seem to support several selectors combined with targeting another emotion component
-  // so we duplicate the css for :hover and :focus.
-  &:focus + ${RadioButtonGroupLabel} {
-    outline: 1px dotted #212121;
-    outline: -webkit-focus-ring-color auto 5px;
-    &:after {
-      transform: translateX(5px) scale(1, 1);
-      background: ${colors.brand.tertiary};
-    }
-  }
-  &:checked + ${RadioButtonGroupLabel} {
-    &:before {
-      border-color: ${colors.brand.primary};
-    }
-    &:after {
-      transform: translateX(5px) scale(1, 1);
-      background: ${colors.brand.primary};
+  &[data-state='checked'] {
+    &::after {
+      background-color: ${colors.brand.primary};
     }
   }
 `;
 
-class RadioButtonGroup extends Component<Props, State> {
-  private readonly uuid?: string;
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      selected: props.selected || props.options[0].value,
-    };
-    this.handleOnChange = this.handleOnChange.bind(this);
-    this.uuid = this.props.uniqeIds ? uuid() : undefined;
+export const StyledRadioButtonGroupRoot = styled(Root)`
+  padding: ${spacing.small} 0;
+  gap: ${spacing.small};
+  display: flex;
+  font-family: ${fonts.sans};
+  align-items: center;
+  &[data-direction='vertical'] {
+    flex-direction: column;
+    align-items: unset;
   }
+`;
 
-  handleOnChange(e: ChangeEvent<HTMLInputElement>) {
-    this.setState({
-      selected: e.target.value,
-    });
-    this.props.onChange(e.target.value);
-  }
+interface ItemProps extends RadioGroupItemProps {}
 
-  render() {
-    return (
-      <section>
-        <RadioButtonGroupWrapper role="radiogroup">
-          {this.props.label && <RadioButtonGroupLabelHeading>{this.props.label}</RadioButtonGroupLabelHeading>}
-          {this.props.options.map((option) => {
-            const id = this.uuid ? `${this.uuid}_${option.value}` : option.value;
-            return (
-              <Fragment key={option.value}>
-                <RadioButtonGroupInput
-                  disabled={option.disabled}
-                  aria-checked={this.state.selected === option.value}
-                  checked={this.state.selected === option.value}
-                  type="radio"
-                  value={option.value}
-                  id={id}
-                  name={id}
-                  onChange={this.handleOnChange}
-                />
-                <RadioButtonGroupLabel htmlFor={id}>{option.title}</RadioButtonGroupLabel>
-              </Fragment>
-            );
-          })}
-        </RadioButtonGroupWrapper>
-      </section>
-    );
-  }
+export const RadioGroupItem = ({ value, disabled, id, title, className }: ItemProps) => {
+  return (
+    <RadioButtonWrapper key={value} className={className}>
+      <StyledRadioGroupItem disabled={disabled} value={value} id={id}>
+        <RadioButtonIndicator forceMount />
+      </StyledRadioGroupItem>
+      <RadioButtonGroupLabel element="label" textStyle="content" margin="none" htmlFor={id}>
+        {title}
+      </RadioButtonGroupLabel>
+    </RadioButtonWrapper>
+  );
+};
+
+interface RootProps extends RadioGroupProps {
+  direction?: 'horizontal' | 'vertical';
 }
+
+export const RadioButtonGroupRoot = ({ children, direction, ...rest }: RootProps) => {
+  return (
+    <StyledRadioButtonGroupRoot data-direction={direction} {...rest}>
+      {children}
+    </StyledRadioButtonGroupRoot>
+  );
+};
+
+const RadioButtonGroup = ({
+  selected,
+  options,
+  label,
+  uniqeIds,
+  onChange,
+  direction = 'horizontal',
+  className,
+}: Props) => {
+  const uuid = useMemo(() => (uniqeIds ? uuidFunc() : undefined), [uniqeIds]);
+
+  return (
+    <RadioButtonGroupRoot
+      data-direction={direction}
+      value={selected}
+      defaultValue={selected ?? options[0].value}
+      className={className}
+      onValueChange={onChange}
+    >
+      {label && (
+        <GroupLabel element="span" textStyle="content">
+          {label}
+        </GroupLabel>
+      )}
+      {options.map((option) => {
+        const id = uuid ? `${uuid}_${option.value}` : option.value;
+        return (
+          <RadioGroupItem
+            key={option.value}
+            disabled={option.disabled}
+            value={option.value}
+            id={id}
+            title={option.title}
+          />
+        );
+      })}
+    </RadioButtonGroupRoot>
+  );
+};
 
 export default RadioButtonGroup;

--- a/stories/collated-components.jsx
+++ b/stories/collated-components.jsx
@@ -12,7 +12,6 @@ import {
   Translation,
   TranslationLine,
   ArticleByline,
-  RadioButtonGroup,
   EditorName,
   FooterText,
   LanguageSelector,
@@ -38,7 +37,6 @@ import FileListExample from './molecules/FileListExample';
 
 import Oops from '../images/oops.gif';
 import cecilie from '../images/cecilie.png';
-import ComponentInfo from './ComponentInfo';
 
 import FooterExample from './molecules/footers';
 import MessageBox from './molecules/MessageBoxExample';
@@ -456,85 +454,6 @@ storiesOf('Patterns', module)
       </StoryBody>
     </div>
   ))
-
-  .add('Radio buttons', () => (
-    <div>
-      <StoryIntro title="Filter">
-        <p>Radiobutton group komponent som håndterer states og gir callback ved endring</p>
-      </StoryIntro>
-      <StoryBody>
-        <ComponentInfo
-          reactCode={`
-  <RadioButtonGroup
-    options={[
-      { title: '1T', value: '1T' },
-      { title: 'R1', value: 'R1' },
-      { title: 'R2', value: 'R2' },
-      { title: 'S1', value: 'S1' }
-    ]}
-    onChange={(value) => {
-      console.log('changed to', value);
-    }}
-  />
-          `}
-          usesPropTypes={[
-            {
-              name: 'options',
-              type: 'ArrayOf(Shape)',
-              default: 'Required',
-              description: `[{ title: '1T', value '1T' }, { title: 'R1', value: 'R1' }]`,
-            },
-            {
-              name: 'onChange',
-              type: 'Function',
-              default: 'Required',
-              description: '(val) => {}',
-            },
-            {
-              name: 'uniqeIds',
-              type: 'Bool',
-              default: 'null',
-              description:
-                'Lager unike id på input og label. Sørger for at ikke htmlFor og input name/id ikke krasjer med andre komponenter på siden',
-            },
-          ]}
-          status={2}
-        >
-          <h2 className="u-heading">Radiobuttons (group) uten label</h2>
-          <div className="c-filter u-margin-top">
-            <RadioButtonGroup
-              options={[
-                { title: '1T', value: '1T' },
-                { title: 'R1', value: 'R1' },
-                { title: 'R2', value: 'R2' },
-                { title: 'S1', value: 'S1' },
-              ]}
-              onChange={(value) => {
-                console.log('changed to', value); // eslint-disable-line no-console
-              }}
-            />
-          </div>
-          <h2 className="u-heading">Radiobuttons (group) med label</h2>
-          <div className="c-filter u-margin-top">
-            <RadioButtonGroup
-              options={[
-                { title: '1T', value: '1T' },
-                { title: 'R1', value: 'R1' },
-                { title: 'R2', value: 'R2' },
-                { title: 'S1', value: 'S1' },
-              ]}
-              uniqeIds
-              label="Velg fag"
-              onChange={(value) => {
-                console.log('changed to', value); // eslint-disable-line no-console
-              }}
-            />
-          </div>
-        </ComponentInfo>
-      </StoryBody>
-    </div>
-  ))
-
   .add('Related content', () => (
     <I18nTranslate>
       {(t) => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2555,6 +2555,23 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-slot" "1.0.2"
 
+"@radix-ui/react-radio-group@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-radio-group/-/react-radio-group-1.1.3.tgz#3197f5dcce143bcbf961471bf89320735c0212d3"
+  integrity sha512-x+yELayyefNeKeTx4fjK6j99Fs6c4qKm3aY38G3swQVTN6xMpsrbigC0uHs2L//g8q4qR7qOcww8430jJmi2ag==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-roving-focus" "1.0.4"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-previous" "1.0.1"
+    "@radix-ui/react-use-size" "1.0.1"
+
 "@radix-ui/react-roving-focus@1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz#e90c4a6a5f6ac09d3b8c1f5b5e81aab2f0db1974"


### PR DESCRIPTION
Denne skal strengt tatt ikke være noe særlig breaking, annet enn at stylingen har blitt litt annerledes. Label har ikke lenger en hover-state. Det går heller ikke an å tabbe mellom radio-buttons lenger, man må bruke piltaster.