### PR TITLE
Remove unused deps from ndla/notion

### DIFF
--- a/packages/ndla-notion/package.json
+++ b/packages/ndla-notion/package.json
@@ -28,10 +28,7 @@
     "@ndla/core": "^4.1.8",
     "@ndla/icons": "^4.0.8",
     "@ndla/licenses": "^7.1.4",
-    "@ndla/modal": "^4.0.9",
-    "@ndla/safelink": "^4.1.23",
-    "@ndla/tooltip": "^4.1.20",
-    "@ndla/util": "^3.2.0"
+    "@ndla/tooltip": "^4.1.20"
   },
   "peerDependencies": {
     "@emotion/react": "^11.10.4",


### PR DESCRIPTION
Var tidligere snakk om å gjøre `ndla/notion` til sin egen pakke, men jeg er litt var på det. Både `ndla/video-search` og `ndla/audio-search`avhenger av den, og jeg har ikke veldig lyst til at de skal være avhengige av `ndla/ui`. Vi kan dog redusere avtrykket til Notion så godt vi kan, og eventuelt fjerne det helt når vi går vekk fra den gamle bylinen.