### PR TITLE
Do not nest paragraphs in ArticleIntroduction

### DIFF
--- a/packages/ndla-ui/src/Article/Article.tsx
+++ b/packages/ndla-ui/src/Article/Article.tsx
@@ -77,7 +77,7 @@ type ArticleIntroductionProps = {
 export const ArticleIntroduction = ({ children, lang }: ArticleIntroductionProps) => {
   if (children) {
     return (
-      <Text textStyle="ingress" lang={lang}>
+      <Text textStyle="ingress" element="div" lang={lang}>
         {children}
       </Text>
     );


### PR DESCRIPTION
`Text`-komponenten førte til at vi endte opp med `<p><p>Innhold</p></p>`, i og med at introduksjonen ikke er inline-markdown.