### PR TITLE
Update tabs pseuo class for box shadow styling

### DIFF
--- a/packages/ndla-tabs/src/Tabs.tsx
+++ b/packages/ndla-tabs/src/Tabs.tsx
@@ -70,8 +70,8 @@ const TabsRoot = styled(Root)`
       padding: ${spacing.nsmall};
       position: relative;
     }
-    [data-tab-panel]:focus-within,
-    [data-tab-trigger]:focus-within {
+    [data-tab-panel]:focus-visible,
+    [data-tab-trigger]:focus-visible {
       z-index: 3;
       box-shadow: 0 0 0 2px ${colors.brand.primary};
     }


### PR DESCRIPTION
Tenker det gir mening å kun vise box-shadow når man navigerer til elementet med tastatur og ikke når man klikker med mus, enige?

Dette vil kun påvirke tabs som brukes med runde kanter, altså feks på dashboard i ed