### PR TITLE
Add expandable box component

### DIFF
--- a/packages/ndla-ui/src/ExpandableBox/ExpandableBox.stories.tsx
+++ b/packages/ndla-ui/src/ExpandableBox/ExpandableBox.stories.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Meta, StoryObj } from '@storybook/react';
+import { ExpandableBox, ExpandableBoxSummary } from './ExpandableBox';
+import { defaultParameters } from '../../../../stories/defaults';
+
+/**
+ * This is just a thin wrapper around the native HTML details element.
+ * `ExpandableBoxSummary` is a thin wrapper around the native HTML summary element.
+ * The components will eventually add style and functionality to the native elements, as opposed to the components being styled by global css.
+ */
+export default {
+  title: 'Components/ExpandableBox',
+  tags: ['autodocs'],
+  parameters: {
+    inlineStories: true,
+    ...defaultParameters,
+  },
+  component: ExpandableBox,
+  render: (args) => (
+    <ExpandableBox {...args}>
+      <ExpandableBoxSummary>Open me</ExpandableBoxSummary>
+      Everything here is only visible when the box is open
+    </ExpandableBox>
+  ),
+} as Meta<typeof ExpandableBox>;
+
+export const Default: StoryObj<typeof ExpandableBox> = {};

--- a/packages/ndla-ui/src/ExpandableBox/ExpandableBox.tsx
+++ b/packages/ndla-ui/src/ExpandableBox/ExpandableBox.tsx
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { HTMLAttributes } from 'react';
+
+interface Props extends HTMLAttributes<HTMLDetailsElement> {}
+
+export const ExpandableBox = ({ children, ...rest }: Props) => {
+  return <details {...rest}>{children}</details>;
+};
+
+interface SummaryProps extends HTMLAttributes<HTMLElement> {}
+
+export const ExpandableBoxSummary = ({ children, ...rest }: SummaryProps) => {
+  return <summary {...rest}>{children}</summary>;
+};

--- a/packages/ndla-ui/src/ExpandableBox/index.ts
+++ b/packages/ndla-ui/src/ExpandableBox/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export { ExpandableBox, ExpandableBoxSummary } from './ExpandableBox';

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -9,6 +9,7 @@
 // Ignore typescript implicit any warning and export all javascript components
 // Move components to this file when they are migrated to typescript
 
+export { ExpandableBox, ExpandableBoxSummary } from './ExpandableBox';
 export { default as FramedContent } from './FramedContent';
 export { default as SectionHeading } from './SectionHeading';
 export {

--- a/stories/simple-components.jsx
+++ b/stories/simple-components.jsx
@@ -5,24 +5,6 @@ import FootnotesExample from './article/FootnotesExample';
 import TreeStructureExample from './molecules/TreeStructureExample';
 
 storiesOf('Components', module)
-  .add('Expandable box', () => (
-    <div>
-      <StoryIntro title="Ekspanderbar boks" />
-      <StoryBody>
-        <details>
-          <summary>Oppsummering av innhold</summary>
-          <p>
-            Pitching er også en god måte å bevisstgjøre seg selv på. Når du pitcher, blir idéen og historien i den
-            filmen du planlegger å lage, tydeligere for både deg selv og dem du eventuelt jobber sammen med i klassen.
-          </p>
-          <p>
-            Pitching er også en god måte å bevisstgjøre seg selv på. Når du pitcher, blir idéen og historien i den
-            filmen du planlegger å lage, tydeligere for både deg selv og dem du eventuelt jobber sammen med i klassen.
-          </p>
-        </details>
-      </StoryBody>
-    </div>
-  ))
   .add('References', () => (
     <div>
       <StoryIntro title="Kildehenvisninger">


### PR DESCRIPTION
Bare en tynn wrapper rundt `details` og `summary`. Kan brukes til å fjerne global css på sikt.