### PR TITLE
Changing buildsOn nn translation

### DIFF
--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -516,7 +516,7 @@ const messages = {
     associatedTopics: 'Tilhøyrande emne',
   },
   subjectFrontPage: {
-    buildsOn: 'Byggjer på',
+    buildsOn: 'Bygger på',
     connectedTo: 'Felles programfag saman med',
     leadsTo: 'Leier til',
   },


### PR DESCRIPTION
Ref https://trello.com/c/zEX5dXKW/436-progresjonsvisning-fag skulle det være 'Bygger', ikke 'Byggjer'.