### PR TITLE
add alttext to h5p type

### DIFF
--- a/packages/types-embed/src/h5pTypes.ts
+++ b/packages/types-embed/src/h5pTypes.ts
@@ -14,6 +14,7 @@ export interface H5pEmbedData {
   url: string;
   title?: string;
   pageUrl?: string;
+  alt?: string;
 }
 
 export interface H5pLicenseInformation {


### PR DESCRIPTION
Relates to https://github.com/NDLANO/Issues/issues/3758

Legger til støtte for `data-alt` på `h5p` `ndlaembed`'s
