### PR TITLE
Added spacing value

### DIFF
--- a/packages/core/src/spacing.ts
+++ b/packages/core/src/spacing.ts
@@ -1,12 +1,22 @@
 export const spacingUnit = 24;
 
-export type SpacingNames = 'xxsmall' | 'xsmall' | 'small' | 'nsmall' | 'normal' | 'medium' | 'mediumlarge' | 'large';
+export type SpacingNames =
+  | 'xxsmall'
+  | 'xsmall'
+  | 'small'
+  | 'nsmall'
+  | 'snormal'
+  | 'normal'
+  | 'medium'
+  | 'mediumlarge'
+  | 'large';
 
 const spacing: Record<SpacingNames, string> = {
   xxsmall: `${spacingUnit / 6}px`,
   xsmall: `${spacingUnit / 4}px`,
   small: `${spacingUnit / 2}px`,
   nsmall: `${spacingUnit / 1.5}px`,
+  snormal: `${spacingUnit / 1.2}px`,
   normal: `${spacingUnit}px`,
   medium: `${spacingUnit * 1.25}px`,
   mediumlarge: `${spacingUnit * 1.5}px`,


### PR DESCRIPTION
Utvidet med en ekstra spacing unit. Hoppet mellom 16px (nsmall) og 24px (normal) var litt voldsomt (spesielt mtp tilpasninger mot UU-krav som [sukesskriterie 2.5.8](https://tetralogical.com/blog/2023/10/05/whats-new-wcag-2.2/#2.5.8-target-size-(minimum)-(aa)) i versjon 2.2 av WCAG. Kravet sier 24px, men pga spacing mellom ikoner vil 20px jevnt over være nok for å oppfylle kravet. 16px (nsmall) gjerne litt i minste laget.