### PR TITLE
Differentiate between article and embed rendering

### DIFF
--- a/packages/article-converter/src/plugins/embed/brightcoveEmbedPlugin.tsx
+++ b/packages/article-converter/src/plugins/embed/brightcoveEmbedPlugin.tsx
@@ -14,5 +14,5 @@ import { PluginType } from '../types';
 export const brightcoveEmbedPlugin: PluginType = (element, _, opts) => {
   const props = attributesToProps(element.attribs);
   const data = JSON.parse(props['data-json']) as BrightcoveMetaData;
-  return <BrightcoveEmbed embed={data} heartButton={opts.components?.heartButton} />;
+  return <BrightcoveEmbed embed={data} heartButton={opts.components?.heartButton} renderContext={opts.renderContext} />;
 };

--- a/packages/article-converter/src/plugins/embed/imageEmbedPlugin.tsx
+++ b/packages/article-converter/src/plugins/embed/imageEmbedPlugin.tsx
@@ -24,6 +24,7 @@ export const imageEmbedPlugin: PluginType = (element, _, opts) => {
       previewAlt={opts.previewAlt}
       heartButton={opts.components?.heartButton}
       lang={opts.articleLanguage}
+      renderContext={opts.renderContext}
     />
   );
 };

--- a/packages/article-converter/src/plugins/types.ts
+++ b/packages/article-converter/src/plugins/types.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import { HeartButtonType } from '@ndla/ui';
+import { HeartButtonType, RenderContext } from '@ndla/ui';
 import { Element, HTMLReactParserOptions } from 'html-react-parser';
 
 export interface DynamicComponents {
@@ -21,6 +21,7 @@ export interface TransformOptions {
   frontendDomain?: string;
   components?: DynamicComponents;
   articleLanguage?: string;
+  renderContext?: RenderContext;
 }
 
 export type PluginType = (

--- a/packages/ndla-ui/src/Embed/BrightcoveEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/BrightcoveEmbed.tsx
@@ -18,12 +18,13 @@ import { ButtonV2 } from '@ndla/button';
 import { Figure } from '../Figure';
 import { EmbedByline } from '../LicenseByline';
 import EmbedErrorPlaceholder from './EmbedErrorPlaceholder';
-import { HeartButtonType } from './types';
+import { HeartButtonType, RenderContext } from './types';
 
 interface Props {
   embed: BrightcoveMetaData;
   isConcept?: boolean;
   heartButton?: HeartButtonType;
+  renderContext?: RenderContext;
 }
 
 const LinkedVideoButton = styled(ButtonV2)`
@@ -57,19 +58,19 @@ const getIframeProps = (data: BrightcoveEmbedData, sources: BrightcoveVideoSourc
     width: source?.width ?? '640',
   };
 };
-const BrightcoveEmbed = ({ embed, isConcept, heartButton: HeartButton }: Props) => {
+const BrightcoveEmbed = ({ embed, isConcept, heartButton: HeartButton, renderContext = 'article' }: Props) => {
   const [showOriginalVideo, setShowOriginalVideo] = useState(true);
   const { t } = useTranslation();
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const { embedData } = embed;
   const fallbackTitle = `${t('embed.type.video')}: ${embedData.videoid}`;
   const parsedDescription = useMemo(() => {
-    if (embed.embedData.caption) {
-      return parse(embed.embedData.caption);
+    if (embed.embedData.caption || renderContext === 'article') {
+      return embed.embedData.caption ? parse(embed.embedData.caption) : undefined;
     } else if (embed.status === 'success' && embed.data.description) {
       return parse(embed.data.description);
     }
-  }, [embed]);
+  }, [embed, renderContext]);
 
   useEffect(() => {
     const iframe = iframeRef.current;

--- a/packages/ndla-ui/src/Embed/ImageEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/ImageEmbed.tsx
@@ -19,7 +19,7 @@ import { Figure, FigureType } from '../Figure';
 import Image, { ImageLink } from '../Image';
 import { EmbedByline } from '../LicenseByline';
 import EmbedErrorPlaceholder from './EmbedErrorPlaceholder';
-import { HeartButtonType } from './types';
+import { HeartButtonType, RenderContext } from './types';
 
 interface Props {
   embed: ImageMetaData;
@@ -28,6 +28,7 @@ interface Props {
   heartButton?: HeartButtonType;
   inGrid?: boolean;
   lang?: string;
+  renderContext?: RenderContext;
 }
 
 export interface Author {
@@ -105,17 +106,25 @@ export const getCrop = (data: ImageEmbedData) => {
 
 const expandedSizes = '(min-width: 1024px) 1024px, 100vw';
 
-const ImageEmbed = ({ embed, previewAlt, heartButton: HeartButton, inGrid, path, lang }: Props) => {
+const ImageEmbed = ({
+  embed,
+  previewAlt,
+  heartButton: HeartButton,
+  inGrid,
+  path,
+  lang,
+  renderContext = 'article',
+}: Props) => {
   const [isBylineHidden, setIsBylineHidden] = useState(hideByline(embed.embedData.size));
   const [imageSizes, setImageSizes] = useState<string | undefined>(undefined);
 
   const parsedDescription = useMemo(() => {
-    if (embed.embedData.caption) {
-      return parse(embed.embedData.caption);
+    if (embed.embedData.caption || renderContext === 'article') {
+      return embed.embedData.caption ? parse(embed.embedData.caption) : undefined;
     } else if (embed.status === 'success' && embed.data.caption.caption) {
       return parse(embed.data.caption.caption);
     }
-  }, [embed]);
+  }, [embed, renderContext]);
 
   if (embed.status === 'error') {
     const { align, size } = embed.embedData;

--- a/packages/ndla-ui/src/Embed/index.ts
+++ b/packages/ndla-ui/src/Embed/index.ts
@@ -20,4 +20,4 @@ export { ConceptNotionV2 } from './conceptComponents';
 export { default as ConceptListEmbed } from './ConceptListEmbed';
 export { default as UnknownEmbed } from './UnknownEmbed';
 export { InlineConcept, BlockConcept } from './ConceptEmbed';
-export type { HeartButtonType } from './types';
+export type { HeartButtonType, RenderContext } from './types';

--- a/packages/ndla-ui/src/Embed/types.ts
+++ b/packages/ndla-ui/src/Embed/types.ts
@@ -10,3 +10,5 @@ import { ElementType } from 'react';
 import { EmbedMetaData } from '@ndla/types-embed';
 
 export type HeartButtonType = ElementType<{ embed: Extract<EmbedMetaData, { status: 'success' }> }>;
+
+export type RenderContext = 'article' | 'embed';

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -213,7 +213,7 @@ export { BlogPostV2 } from './BlogPost';
 export { ProgrammeCard } from './ProgrammeCard';
 export { KeyFigure } from './KeyFigure';
 export { default as ContactBlock } from './ContactBlock';
-export type { HeartButtonType } from './Embed';
+export type { HeartButtonType, RenderContext } from './Embed';
 export { CampaignBlock } from './CampaignBlock';
 export { Grid, GridParallaxItem } from './Grid';
 export type { GridType } from './Grid';


### PR DESCRIPTION
https://github.com/NDLANO/Issues/issues/3813

Implementerer en option som lar konsumenten spesifisere en render-kontekst. I denne omgangen sørger den for at artikkel-rendering alltid tar i bruk caption som satt på embed-data, mens embed-rendering foretrekker "kilde"-data. 

Skal vi se på dette som en breaking for article-converter? Må oppdatere embed-siden i ndla-frontend.