### PR TITLE
Do not render block concepts on error

### DIFF
--- a/packages/article-converter/src/plugins/embed/conceptEmbedPlugin.tsx
+++ b/packages/article-converter/src/plugins/embed/conceptEmbedPlugin.tsx
@@ -14,5 +14,13 @@ import { PluginType } from '../types';
 export const conceptEmbedPlugin: PluginType = (element, _, opts) => {
   const props = attributesToProps(element.attribs);
   const data = JSON.parse(props['data-json']) as ConceptMetaData;
-  return <ConceptEmbed embed={data} fullWidth heartButton={opts.components?.heartButton} lang={opts.articleLanguage} />;
+  return (
+    <ConceptEmbed
+      embed={data}
+      fullWidth
+      heartButton={opts.components?.heartButton}
+      lang={opts.articleLanguage}
+      renderContext={opts.renderContext}
+    />
+  );
 };

--- a/packages/ndla-ui/src/Embed/ConceptEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/ConceptEmbed.tsx
@@ -24,7 +24,7 @@ import { NotionImage } from '../Notion/NotionImage';
 import { ConceptNotionV2, ConceptNotionData, ConceptType } from './conceptComponents';
 import { EmbedByline } from '../LicenseByline';
 import EmbedErrorPlaceholder from './EmbedErrorPlaceholder';
-import { HeartButtonType } from './types';
+import { HeartButtonType, RenderContext } from './types';
 import { Gloss } from '../Gloss';
 
 interface PopoverPosition {
@@ -72,6 +72,7 @@ interface Props {
   fullWidth?: boolean;
   heartButton?: HeartButtonType;
   lang?: string;
+  renderContext?: RenderContext;
 }
 
 const StyledButton = styled.button`
@@ -93,7 +94,13 @@ const StyledButton = styled.button`
   }
 `;
 
-export const ConceptEmbed = ({ embed, fullWidth, heartButton: HeartButton, lang }: Props) => {
+export const ConceptEmbed = ({
+  embed,
+  fullWidth,
+  heartButton: HeartButton,
+  lang,
+  renderContext = 'article',
+}: Props) => {
   const parsedContent = useMemo(() => {
     if (embed.status === 'error' || !embed.data.concept.content) return undefined;
     return parse(embed.data.concept.content.content);
@@ -101,6 +108,7 @@ export const ConceptEmbed = ({ embed, fullWidth, heartButton: HeartButton, lang 
   if (embed.status === 'error' && embed.embedData.type === 'inline') {
     return <span>{embed.embedData.linkText}</span>;
   } else if (embed.status === 'error') {
+    if (renderContext === 'article') return undefined;
     return <EmbedErrorPlaceholder type="concept" />;
   }
 

--- a/packages/ndla-ui/src/Embed/types.ts
+++ b/packages/ndla-ui/src/Embed/types.ts
@@ -11,4 +11,4 @@ import { EmbedMetaData } from '@ndla/types-embed';
 
 export type HeartButtonType = ElementType<{ embed: Extract<EmbedMetaData, { status: 'success' }> }>;
 
-export type RenderContext = 'article' | 'embed';
+export type RenderContext = 'article' | 'embed' | 'editor';


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3811

Innfører også en rendering-context for ED så vi kan vise forklaringer som feiler.

Uheldig løsning, egentlig. Er hverken fan av å skjule feil eller å introdusere en rendering-context for ED. Er det en bedre måte å gjøre det på? 