### PR TITLE
Updated text and fonts to match new typography

### DIFF
--- a/packages/core/src/fonts.ts
+++ b/packages/core/src/fonts.ts
@@ -29,8 +29,11 @@ const fonts = {
       ingress: sizes('20px', '31px'),
       button: sizes('16px', '24px'),
       content: sizes('18px', '29px'),
+      metaTextxxsmall: sizes('10px', '12px'),
+      metaTextxsmall: sizes('10px', '20px'),
       metaTextSmall: sizes('16px', '24px'),
-      metaTextLarge: sizes('18px', '24px'),
+      metaTextMedium: sizes('18px', '24px'),
+      metaTextLarge: sizes('22px', '30px'),
     },
   },
 };

--- a/packages/core/src/fonts.ts
+++ b/packages/core/src/fonts.ts
@@ -29,11 +29,13 @@ const fonts = {
       ingress: sizes('20px', '31px'),
       button: sizes('16px', '24px'),
       content: sizes('18px', '29px'),
-      metaTextxxsmall: sizes('10px', '12px'),
-      metaTextxsmall: sizes('10px', '20px'),
-      metaTextSmall: sizes('16px', '24px'),
-      metaTextMedium: sizes('18px', '24px'),
-      metaTextLarge: sizes('22px', '30px'),
+      metaText: {
+        xxsmall: sizes('10px', '12px'),
+        xsmall: sizes('12px', '20px'),
+        small: sizes('16px', '24px'),
+        medium: sizes('18px', '24px'),
+        large: sizes('22px', '30px'),
+      },
     },
   },
 };

--- a/packages/typography/src/Text.stories.tsx
+++ b/packages/typography/src/Text.stories.tsx
@@ -61,9 +61,30 @@ export const MetaTextLarge: StoryObj<typeof Text> = {
   },
 };
 
+export const MetaTextMedium: StoryObj<typeof Text> = {
+  args: {
+    textStyle: 'meta-text-small',
+    children: exampleText,
+  },
+};
+
 export const MetaTextSmall: StoryObj<typeof Text> = {
   args: {
     textStyle: 'meta-text-small',
+    children: exampleText,
+  },
+};
+
+export const MetaTextXSmall: StoryObj<typeof Text> = {
+  args: {
+    textStyle: 'meta-text-xsmall',
+    children: exampleText,
+  },
+};
+
+export const MetaTextXXSmall: StoryObj<typeof Text> = {
+  args: {
+    textStyle: 'meta-text-xxsmall',
     children: exampleText,
   },
 };
@@ -80,7 +101,10 @@ export const Chinese: StoryObj<typeof Text> = {
       <Text {...args} textStyle="content" />
       <Text {...args} textStyle="content-alt" />
       <Text {...args} textStyle="meta-text-large" />
+      <Text {...args} textStyle="meta-text-medium" />
       <Text {...args} textStyle="meta-text-small" />
+      <Text {...args} textStyle="meta-text-xsmall" />
+      <Text {...args} textStyle="meta-text-xxsmall" />
       <Text {...args} data-pinyin="">
         Pinyin does not get larger if marked with data-pinyin
       </Text>

--- a/packages/typography/src/Text.stories.tsx
+++ b/packages/typography/src/Text.stories.tsx
@@ -63,7 +63,7 @@ export const MetaTextLarge: StoryObj<typeof Text> = {
 
 export const MetaTextMedium: StoryObj<typeof Text> = {
   args: {
-    textStyle: 'meta-text-small',
+    textStyle: 'meta-text-medium',
     children: exampleText,
   },
 };

--- a/packages/typography/src/Text.tsx
+++ b/packages/typography/src/Text.tsx
@@ -6,9 +6,9 @@
  *
  */
 
-import { ComponentProps, ElementType, ReactNode, ComponentPropsWithoutRef } from 'react';
+import { ComponentProps, ElementType, ReactNode } from 'react';
 import { css, SerializedStyles } from '@emotion/react';
-import { breakpoints, colors, fonts, mq, spacing } from '@ndla/core';
+import { breakpoints, fonts, mq, spacing } from '@ndla/core';
 import { MarginVariant } from './types';
 
 const baseStyle = css`
@@ -34,10 +34,22 @@ const elementStyle: { [key in TextVariant]: SerializedStyles } = {
   'content-alt': css`
     ${fonts.size.text.metaTextLarge};
   `,
+  'meta-text-xxsmall': css`
+    font-weight: ${fonts.weight.semibold};
+    ${fonts.size.text.metaTextxxsmall};
+  `,
+  'meta-text-xsmall': css`
+    font-weight: ${fonts.weight.semibold};
+    ${fonts.size.text.metaTextxsmall};
+  `,
   'meta-text-small': css`
     ${fonts.size.text.metaTextSmall};
   `,
+  'meta-text-medium': css`
+    ${fonts.size.text.metaTextMedium};
+  `,
   'meta-text-large': css`
+    font-weight: ${fonts.weight.bold};
     ${fonts.size.text.metaTextLarge};
   `,
 };
@@ -63,7 +75,16 @@ const elementMarginStyle: { [key in MarginVariant]: SerializedStyles } = {
   normal: css``,
 };
 
-type TextVariant = 'ingress' | 'button' | 'content' | 'content-alt' | 'meta-text-small' | 'meta-text-large';
+type TextVariant =
+  | 'ingress'
+  | 'button'
+  | 'content'
+  | 'content-alt'
+  | 'meta-text-xxsmall'
+  | 'meta-text-xsmall'
+  | 'meta-text-small'
+  | 'meta-text-medium'
+  | 'meta-text-large';
 
 interface Props<T extends ElementType> {
   element?: T;

--- a/packages/typography/src/Text.tsx
+++ b/packages/typography/src/Text.tsx
@@ -32,25 +32,25 @@ const elementStyle: { [key in TextVariant]: SerializedStyles } = {
     ${fonts.size.text.content};
   `,
   'content-alt': css`
-    ${fonts.size.text.metaTextLarge};
+    ${fonts.size.text.metaText.large};
   `,
   'meta-text-xxsmall': css`
     font-weight: ${fonts.weight.semibold};
-    ${fonts.size.text.metaTextxxsmall};
+    ${fonts.size.text.metaText.xxsmall};
   `,
   'meta-text-xsmall': css`
     font-weight: ${fonts.weight.semibold};
-    ${fonts.size.text.metaTextxsmall};
+    ${fonts.size.text.metaText.xsmall};
   `,
   'meta-text-small': css`
-    ${fonts.size.text.metaTextSmall};
+    ${fonts.size.text.metaText.small};
   `,
   'meta-text-medium': css`
-    ${fonts.size.text.metaTextMedium};
+    ${fonts.size.text.metaText.medium};
   `,
   'meta-text-large': css`
     font-weight: ${fonts.weight.bold};
-    ${fonts.size.text.metaTextLarge};
+    ${fonts.size.text.metaText.large};
   `,
 };
 


### PR DESCRIPTION
Vil kreve at når vi bumper pakker at vi må bytte fra `large` til `medium` hvor `Text`-komponenten er brukt og `fonts.size.text.metaTextLarge`.

Fra det jeg har sett er det 2 steder i ndla-frontend.