### PR TITLE
Wrap embed description in a spawn, allowing for items to display as inline instead of using parent flex

### DIFF
--- a/packages/ndla-ui/src/Embed/ImageEmbed.stories.tsx
+++ b/packages/ndla-ui/src/Embed/ImageEmbed.stories.tsx
@@ -20,7 +20,8 @@ const embedData: ImageEmbedData = {
   size: 'full',
   align: '',
   alt: 'Tenåringsjente med lyse fletter slenger på håret. Foto. ',
-  caption: 'Modellklarert.',
+  caption:
+    'Den østerrikske tronfølgeren Franz Ferdinand og hans hustru Sophie var på besøk i Sarajevo i 1914. Begge ble skutt og drept av nasjonalisten Gavrilo Princip i det som er kjent som <em>skuddene i Sarajevo</em>. Denne hendelsen var den utløsende årsaken til første verdenskrig.',
   url: 'https://api.test.ndla.no/image-api/v2/images/61181',
 };
 

--- a/packages/ndla-ui/src/LicenseByline/LicenseDescription.tsx
+++ b/packages/ndla-ui/src/LicenseByline/LicenseDescription.tsx
@@ -34,7 +34,7 @@ const LicenseDescription = ({ description, icon }: Props) => {
   return (
     <StyledFigCaption>
       {icon}
-      {description}
+      <span>{description}</span>
     </StyledFigCaption>
   );
 };


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3832