### PR TITLE
react-select updates: package bump + fix console warning

### DIFF
--- a/packages/ndla-ui/package.json
+++ b/packages/ndla-ui/package.json
@@ -57,7 +57,7 @@
     "i18next-browser-languagedetector": "^7.1.0",
     "react-bem-helper": "1.4.1",
     "react-device-detect": "^2.2.3",
-    "react-select": "^5.7.5",
+    "react-select": "^5.8.0",
     "react-swipeable": "^7.0.0"
   },
   "peerDependencies": {

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@ndla/core": "^4.2.7",
     "@ndla/icons": "^4.2.0",
-    "react-select": "^5.7.5"
+    "react-select": "^5.8.0"
   },
   "peerDependencies": {
     "@emotion/react": "^11.10.4",

--- a/packages/select/src/Select/BaseControl.tsx
+++ b/packages/select/src/Select/BaseControl.tsx
@@ -82,7 +82,7 @@ const BaseControl = <T extends boolean>({
   innerRef,
   innerProps,
   children,
-  ...rest
+  isDisabled,
 }: ControlProps<Option, T>) => (
   <StyledBaseControl
     data-small={small}
@@ -90,7 +90,7 @@ const BaseControl = <T extends boolean>({
     data-color-theme={colorTheme}
     data-outline={outline}
     data-required={required}
-    data-disabled={rest.isDisabled}
+    data-disabled={isDisabled}
     data-menu-open={menuIsOpen}
     data-has-value={hasValue}
     ref={innerRef}

--- a/packages/select/src/Select/BaseGroupHeading.tsx
+++ b/packages/select/src/Select/BaseGroupHeading.tsx
@@ -27,10 +27,9 @@ const StyledGroupHeader = styled.div`
 const BaseGroupHeading = <T extends boolean>({
   children,
   selectProps: { small, bold },
-  ...rest
 }: GroupHeadingProps<Option, T>) => {
   return (
-    <StyledGroupHeader data-small={small} data-bold={bold} {...rest}>
+    <StyledGroupHeader data-small={small} data-bold={bold}>
       {children}
     </StyledGroupHeader>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -12041,10 +12041,10 @@ react-router@6.3.0:
   dependencies:
     history "^5.2.0"
 
-react-select@^5.7.5:
-  version "5.7.5"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.7.5.tgz#d2d0f29994e0f06000147bfb2adf58324926c2fd"
-  integrity sha512-jgYZa2xgKP0DVn5GZk7tZwbRx7kaVz1VqU41S8z1KWmshRDhlrpKS0w80aS1RaK5bVIXpttgSou7XCjWw1ncKA==
+react-select@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.8.0.tgz#bd5c467a4df223f079dd720be9498076a3f085b5"
+  integrity sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==
   dependencies:
     "@babel/runtime" "^7.12.0"
     "@emotion/cache" "^11.4.0"


### PR DESCRIPTION
- Bumper react-select 
- Fjerner advarsel som ble vist i konsoll når man brukte Grouped-variant av Select