### PR TITLE
Show rightsholders comma separated

### DIFF
--- a/packages/ndla-ui/src/ContactBlock/ContactBlock.tsx
+++ b/packages/ndla-ui/src/ContactBlock/ContactBlock.tsx
@@ -180,7 +180,7 @@ const ContactBlock = ({
               />
             </LinkWrapper>
             <span>
-              {`${t('photo')}: ${authors.reduce((acc, name) => (acc = `${acc} ${name?.name}`), '')} `}
+              {`${t('embed.type.image')}: ${authors.map((author) => `${author?.name}`).join(', ')} `}
               {!!license && <LicenseLink license={license} asLink={!!license.url.length} />}
             </span>
           </>

--- a/packages/ndla-ui/src/ContactBlock/Contactblock.stories.tsx
+++ b/packages/ndla-ui/src/ContactBlock/Contactblock.stories.tsx
@@ -40,7 +40,12 @@ export default {
           },
         ],
         processors: [],
-        rightsholders: [],
+        rightsholders: [
+          {
+            type: 'rightsholder',
+            name: 'NTB',
+          },
+        ],
         processed: false,
       },
       tags: {


### PR DESCRIPTION
Fikser at rettighetshavere vises kommaseparert. Henta koden fra EmbedByline. Kan sjekkes på storybook.