### PR TITLE
Set 'no' when article langage is 'nb' for improved accessibility

### DIFF
--- a/packages/ndla-ui/src/Article/Article.tsx
+++ b/packages/ndla-ui/src/Article/Article.tsx
@@ -183,6 +183,7 @@ export const Article = ({
 
   const authors =
     copyright?.creators.length || copyright?.rightsholders.length ? copyright.creators : copyright?.processors;
+  const updatedLang = lang === 'nb' ? 'no' : lang;
 
   return (
     <div ref={wrapperRef}>
@@ -197,10 +198,10 @@ export const Article = ({
           )}
           <ArticleHeaderWrapper competenceGoals={competenceGoals}>
             {heartButton ? <ArticleFavoritesButtonWrapper>{heartButton}</ArticleFavoritesButtonWrapper> : null}
-            <ArticleTitle id={id} icon={icon} label={messages.label} lang={lang}>
+            <ArticleTitle id={id} icon={icon} label={messages.label} lang={updatedLang}>
               {title}
             </ArticleTitle>
-            <ArticleIntroduction lang={lang}>{introduction}</ArticleIntroduction>
+            <ArticleIntroduction lang={updatedLang}>{introduction}</ArticleIntroduction>
           </ArticleHeaderWrapper>
         </LayoutItem>
         <LayoutItem layout="center">


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/3856

Oppdaterer lang attributt: 'nb' --> 'no' (oppdaterer ikke 'nn' fordi det var spesifisert i trello-kortet at skulle forbli sånn det var!)

**NB**: Jeg regner med at vi ønsker å gjøre dette for alle steder lang-attributt settes og ikke bare på ingress!