### PR TITLE
Changed default element for modalTitle to be h2

### DIFF
--- a/packages/ndla-modal/src/ModalTitle.tsx
+++ b/packages/ndla-modal/src/ModalTitle.tsx
@@ -13,7 +13,7 @@ interface Props {
   as?: ElementType;
 }
 
-const ModalTitle = ({ as: Element = 'h1', ...rest }: DialogTitleProps & Props) => {
+const ModalTitle = ({ as: Element = 'h2', ...rest }: DialogTitleProps & Props) => {
   return (
     <Title asChild>
       <Element {...rest} />


### PR DESCRIPTION
Pratet med Hedvig, H2 virker mer logisk å ha på modal titelen framfor H1. Denne forandrer alle titler på modaler utenom hvor vi har vært eksplisitte!

løser https://trello.com/c/QuZbIokl/618-h1-i-modal 