### PR TITLE
Do not show a colon after embed type if there are no caption authors

### DIFF
--- a/packages/ndla-ui/src/LicenseByline/EmbedByline.tsx
+++ b/packages/ndla-ui/src/LicenseByline/EmbedByline.tsx
@@ -163,7 +163,7 @@ const EmbedByline = ({
         {license ? <LicenseLink license={license} asLink={!!license.url.length} /> : null}
         <LicenseInformationWrapper>
           <span>
-            <b>{t(`embed.type.${type}`)}: </b>
+            <b>{`${t(`embed.type.${type}`)}${captionAuthors.length ? ':' : ''}`} </b>
             {captionAuthors.map((author) => author.name).join(', ')}
           </span>
         </LicenseInformationWrapper>


### PR DESCRIPTION
Fixes https://trello.com/c/nId4jCuA/624-forklaring-uten-lisens-m%C3%A5-ikke-ha-kolon