### PR TITLE
Updated inputv3 borders for wcag compliance

### DIFF
--- a/packages/ndla-forms/src/InputV3.tsx
+++ b/packages/ndla-forms/src/InputV3.tsx
@@ -27,15 +27,15 @@ interface InputContextType {}
 const InputContext = createContext<InputContextType | undefined>(undefined);
 
 const inputCss = css`
-  border: 1px solid ${colors.brand.greyLighter};
+  border: 1px solid ${colors.brand.grey};
   background: ${colors.brand.greyLightest};
-  transition-duration: border-color 100ms ease;
+  transition-duration: border-width 100ms ease;
   border-radius: ${misc.borderRadius};
   min-height: ${spacing.large};
   padding: 0px ${spacing.small};
 
   &:focus-within {
-    border-color: ${colors.brand.primary};
+    border-width: 2px;
   }
 `;
 


### PR DESCRIPTION
For å gjøre InputV3 compliant med wcag 1.4.11 (se også [Trello](https://trello.com/c/sJVPpD3h/571-uu-feil-inni-skriv-et-svar-og-skriv-innlegg)) er border-color satt til colors.brand.grey. Se nærmere info om ratio og fargevalg, beskrevet i https://github.com/NDLANO/ndla-frontend/pull/1690 som gjelder texteditoren. 
Har da lagt fokus-effekten på border-width, tilsvarende outline-effekten som uansett er der på teksteditoren, fordi kontrasten ikke er så tydelig mellom colors.primary og colors.grey.