### PR TITLE
Fix UI overflow bug on nested display elements

### DIFF
--- a/packages/core/scss/global/elements/_elements.details.scss
+++ b/packages/core/scss/global/elements/_elements.details.scss
@@ -2,7 +2,8 @@ details {
   transition-duration: 150ms;
   transition-property: left, right, width;
   margin: $spacing--large 0;
-  display: block;
+  width: 100%;
+  box-sizing: border-box;
   position: relative;
   left: 0;
   clear: left;

--- a/packages/core/scss/global/elements/_elements.details.scss
+++ b/packages/core/scss/global/elements/_elements.details.scss
@@ -2,7 +2,7 @@ details {
   transition-duration: 150ms;
   transition-property: left, right, width;
   margin: $spacing--large 0;
-  width: 100%;
+  display: block;
   position: relative;
   left: 0;
   clear: left;


### PR DESCRIPTION
https://github.com/NDLANO/Issues/issues/3879

Forårsakes av at width og margin ikke klarer bli enige med hverandre. Tenkte først `display: block;`, men sida det kan hende det er en grunn te at det opprinnelig ble valgt å sette width til 100%, så har jeg istedet løst det med box-sizing.

Problemet kan, som nevnt i issuet, f.eks. sees under "Språkutvikling i barnehagealderen" her https://test.ndla.no/article/14955