### PR TITLE
Visible focus arena modal

### DIFF
--- a/packages/button/src/ButtonV2.tsx
+++ b/packages/button/src/ButtonV2.tsx
@@ -88,16 +88,11 @@ export const buttonStyle = ({
     box-shadow: none;
     text-align: center;
 
-    &:hover {
-      color: ${theme.hoverForeground};
-      background-color: ${theme.hoverBackground};
-      border-color: ${theme.hoverBackground};
-    }
-
+    &:hover,
     &:focus-visible {
       color: ${theme.hoverForeground};
       background-color: ${theme.hoverBackground};
-      border-color: ${colors.black};
+      border-color: ${theme.hoverBackground};
     }
 
     &[disabled] {

--- a/packages/button/src/ButtonV2.tsx
+++ b/packages/button/src/ButtonV2.tsx
@@ -95,6 +95,8 @@ export const buttonStyle = ({
     }
 
     &:focus-visible {
+      color: ${theme.hoverForeground};
+      background-color: ${theme.hoverBackground};
       border-color: ${colors.black};
     }
 


### PR DESCRIPTION
Endringer i https://github.com/NDLANO/frontend-packages/pull/2058 gjorde at fokus i modaler ble nærmest usynlig. Det ser dessuten ut til at det er en SafeLinkButton, ikke en ButtonV2, som er i bruk der (så endringa virka ikke). Så har reversert endringene, og legger en ekstra fokus-firkant (som uansett ikke virket) sammen med resten av PRen min her: https://github.com/NDLANO/ndla-frontend/pull/1690