### PR TITLE
add margin to competence goals

### DIFF
--- a/packages/ndla-ui/src/Article/ArticleHeaderWrapper.tsx
+++ b/packages/ndla-ui/src/Article/ArticleHeaderWrapper.tsx
@@ -34,7 +34,7 @@ const ArticleHeaderWrapper = ({ children, competenceGoals }: Props) => {
   return (
     <div {...classes("header")}>
       {children}
-      {competenceGoals}
+      <div {...classes("competence")}>{competenceGoals}</div>
     </div>
   );
 };

--- a/packages/ndla-ui/src/Article/component.article.scss
+++ b/packages/ndla-ui/src/Article/component.article.scss
@@ -111,7 +111,7 @@
 }
 
 .c-article__competence {
-  margin-top: 24px;
+  margin-top: $spacing;
 }
 
 .c-article__title {

--- a/packages/ndla-ui/src/Article/component.article.scss
+++ b/packages/ndla-ui/src/Article/component.article.scss
@@ -60,7 +60,7 @@
   }
 
   &:after {
-    content: '';
+    content: "";
     display: table;
     clear: both;
   }
@@ -108,6 +108,10 @@
   @include mq(desktop) {
     margin-bottom: $spacing--large;
   }
+}
+
+.c-article__competence {
+  margin-top: 24px;
 }
 
 .c-article__title {


### PR DESCRIPTION
Fikser: [Trello](https://trello.com/c/qhYst6yg/670-kompetansem%C3%A5lknappen-svever-helt-oppi-ingressen)
[#3902](https://github.com/NDLANO/Issues/issues/3902)


Nå har jeg bare endret scss, men burde kanskje vurdere å skrive komponenten over til emotion i en annen PR?