### PR TITLE
Handle markdown-urls as is

### DIFF
--- a/packages/ndla-ui/src/utils/__tests__/relativeUrl-test.tsx
+++ b/packages/ndla-ui/src/utils/__tests__/relativeUrl-test.tsx
@@ -69,4 +69,10 @@ describe("getPossibleRelativeUrl", () => {
 
     expect(getPossiblyRelativeUrl(url, pathname)).toEqual("/");
   });
+  it("handles mailto from markdown", () => {
+    const url = "mailto:test@ndla.no";
+    const pathname = "https://ndla.no/about/hvem-er-vi";
+
+    expect(getPossiblyRelativeUrl(url, pathname)).toEqual("mailto:test@ndla.no");
+  });
 });

--- a/packages/ndla-ui/src/utils/relativeUrl.ts
+++ b/packages/ndla-ui/src/utils/relativeUrl.ts
@@ -16,6 +16,8 @@ const REPLACE_WWW = /^www\./;
 
 export const getPossiblyRelativeUrl = (url: string, path?: string) => {
   if (!path) return url;
+  // If url is a mailto link, return url as is.
+  if (url.startsWith("mailto:")) return url;
   // If not on NDLA, or if url is not a NDLA url, return url as is
   if (!NDLA_URL.test(url) || !NDLA_URL.test(path)) return url;
   //Remove environment info


### PR DESCRIPTION
Epost-adresser som parses av markdown returnerer automatisk en mailto-lenke. Dette gjør at disse slipper gjennom article-converter uten å få lagt på path til sida lenka vises på.