### PR TITLE
Use props from react-select in Select

### DIFF
--- a/packages/ndla-ui/src/Navigation/NavigationBox.tsx
+++ b/packages/ndla-ui/src/Navigation/NavigationBox.tsx
@@ -227,7 +227,9 @@ export const NavigationBox = ({
                     data-color-mode={colorMode}
                   >
                     <StyledMarksWrapper>
-                      {item.isAdditionalResource && <StyledAdditional aria-label={t("resource.additionalTooltip")} ariaHidden={false} />}
+                      {item.isAdditionalResource && (
+                        <StyledAdditional aria-label={t("resource.additionalTooltip")} ariaHidden={false} />
+                      )}
                       {item.isRestrictedResource && (
                         <StyledHumanBoardIconWrapper>
                           <HumanMaleBoard />

--- a/packages/ndla-ui/src/SearchTypeResult/components/ItemContexts.tsx
+++ b/packages/ndla-ui/src/SearchTypeResult/components/ItemContexts.tsx
@@ -107,7 +107,12 @@ const ItemContexts = ({ contexts, id, title }: ItemContextsType) => {
                           ariaHidden={false}
                         />
                       ) : (
-                        <Core size="normal" color={colors.brand.primary} aria-label={t("resource.tooltipCoreTopic")} ariaHidden={false}/>
+                        <Core
+                          size="normal"
+                          color={colors.brand.primary}
+                          aria-label={t("resource.tooltipCoreTopic")}
+                          ariaHidden={false}
+                        />
                       )}
                     </Breadcrumb>
                   </ContextListItem>

--- a/packages/select/src/Select/Select.tsx
+++ b/packages/select/src/Select/Select.tsx
@@ -6,31 +6,23 @@
  *
  */
 
-import { ReactNode, useMemo } from "react";
-import ReactSelect, { PropsValue, createFilter, OptionsOrGroups, StylesConfig } from "react-select";
-import BaseContainer from "./BaseContainer";
-import BaseControl from "./BaseControl";
-import BaseDropdownIndicator from "./BaseDropdownIndicator";
-import BaseGroupHeading from "./BaseGroupHeading";
-import BaseMenu from "./BaseMenu";
-import BaseMultiValue from "./BaseMultiValue";
-import BaseOption from "./BaseOption";
-import BasePlaceholder from "./BasePlaceholder";
-import BaseSingleValue from "./BaseSingleValue";
-import { Option, Color, MultiValue, SingleValue, GroupBase } from "./types";
-import ValueContainer from "./ValueContainer";
+import { useMemo } from 'react';
+import ReactSelect, { createFilter, StylesConfig, Props } from 'react-select';
+import BaseContainer from './BaseContainer';
+import BaseControl from './BaseControl';
+import BaseDropdownIndicator from './BaseDropdownIndicator';
+import BaseGroupHeading from './BaseGroupHeading';
+import BaseMenu from './BaseMenu';
+import BaseMultiValue from './BaseMultiValue';
+import BaseOption from './BaseOption';
+import BasePlaceholder from './BasePlaceholder';
+import BaseSingleValue from './BaseSingleValue';
+import { Option, Color, MultiValue, SingleValue, GroupBase } from './types';
+import ValueContainer from './ValueContainer';
 
-interface Props<T extends boolean> {
-  /** Options to populate the select menu. Grouped view if options are of type GroupBase. */
-  options: OptionsOrGroups<Option, GroupBase<Option>>;
-  label?: string;
-  onChange?: (value: T extends true ? MultiValue : SingleValue) => void;
-  value?: PropsValue<Option>;
-  placeholder?: string;
-  menuPlacement?: "bottom" | "top" | "auto";
+interface SelectProps<T extends boolean> extends Props<Option, T, GroupBase<Option>> {
   isMulti?: T;
   hideArrow?: boolean;
-  isLoading?: boolean;
   small?: boolean;
   bold?: boolean;
   /** Only has effect when isMulti is false. */
@@ -38,32 +30,23 @@ interface Props<T extends boolean> {
   postfix?: string;
   outline?: boolean;
   colorTheme?: Color;
-  isSearchable?: boolean;
-  noOptionsMessage?: (obj: { inputValue: string }) => ReactNode;
-  isClearable?: boolean;
-  closeMenuOnSelect?: boolean;
   /** Indicate if search hits should be matched from start of word or at any position. Only has effect when isSearchable is true. */
-  matchFrom?: "any" | "start";
-  required?: boolean;
-  isDisabled?: boolean;
-  id?: string;
-  defaultValue?: PropsValue<Option>;
+  matchFrom?: 'any' | 'start';
   inModal?: boolean;
 }
 
 const Select = <T extends boolean>({
   options,
   hideArrow,
-  label,
-  menuPlacement = "bottom",
-  colorTheme = "blue",
+  menuPlacement = 'bottom',
+  colorTheme = 'blue',
   isSearchable = false,
-  matchFrom = "start",
+  matchFrom = 'start',
   inModal,
   isMulti,
   ...rest
-}: Props<T>) => {
-  const portalTarget = useMemo(() => (typeof document !== "undefined" ? document.body : null), []);
+}: SelectProps<T>) => {
+  const portalTarget = useMemo(() => (typeof document !== 'undefined' ? document.body : null), []);
 
   const components = useMemo(
     () => ({
@@ -84,7 +67,7 @@ const Select = <T extends boolean>({
 
   const styles: StylesConfig<Option, T> = useMemo(() => ({ menuPortal: (base) => ({ ...base, zIndex: 99999 }) }), []);
   const filterOption = useMemo(
-    () => (matchFrom === "start" ? createFilter({ matchFrom: "start" }) : undefined),
+    () => (matchFrom === 'start' ? createFilter({ matchFrom: 'start' }) : undefined),
     [matchFrom],
   );
 
@@ -94,7 +77,6 @@ const Select = <T extends boolean>({
       isMulti={isMulti}
       options={options}
       colorTheme={colorTheme}
-      aria-label={label}
       isSearchable={isSearchable}
       menuPlacement={menuPlacement}
       hideSelectedOptions={false}

--- a/packages/select/src/Select/Select.tsx
+++ b/packages/select/src/Select/Select.tsx
@@ -6,19 +6,19 @@
  *
  */
 
-import { useMemo } from 'react';
-import ReactSelect, { createFilter, StylesConfig, Props } from 'react-select';
-import BaseContainer from './BaseContainer';
-import BaseControl from './BaseControl';
-import BaseDropdownIndicator from './BaseDropdownIndicator';
-import BaseGroupHeading from './BaseGroupHeading';
-import BaseMenu from './BaseMenu';
-import BaseMultiValue from './BaseMultiValue';
-import BaseOption from './BaseOption';
-import BasePlaceholder from './BasePlaceholder';
-import BaseSingleValue from './BaseSingleValue';
-import { Option, Color, MultiValue, SingleValue, GroupBase } from './types';
-import ValueContainer from './ValueContainer';
+import { useMemo } from "react";
+import ReactSelect, { createFilter, StylesConfig, Props } from "react-select";
+import BaseContainer from "./BaseContainer";
+import BaseControl from "./BaseControl";
+import BaseDropdownIndicator from "./BaseDropdownIndicator";
+import BaseGroupHeading from "./BaseGroupHeading";
+import BaseMenu from "./BaseMenu";
+import BaseMultiValue from "./BaseMultiValue";
+import BaseOption from "./BaseOption";
+import BasePlaceholder from "./BasePlaceholder";
+import BaseSingleValue from "./BaseSingleValue";
+import { Option, Color, GroupBase } from "./types";
+import ValueContainer from "./ValueContainer";
 
 interface SelectProps<T extends boolean> extends Props<Option, T, GroupBase<Option>> {
   isMulti?: T;
@@ -31,22 +31,22 @@ interface SelectProps<T extends boolean> extends Props<Option, T, GroupBase<Opti
   outline?: boolean;
   colorTheme?: Color;
   /** Indicate if search hits should be matched from start of word or at any position. Only has effect when isSearchable is true. */
-  matchFrom?: 'any' | 'start';
+  matchFrom?: "any" | "start";
   inModal?: boolean;
 }
 
 const Select = <T extends boolean>({
   options,
   hideArrow,
-  menuPlacement = 'bottom',
-  colorTheme = 'blue',
+  menuPlacement = "bottom",
+  colorTheme = "blue",
   isSearchable = false,
-  matchFrom = 'start',
+  matchFrom = "start",
   inModal,
   isMulti,
   ...rest
 }: SelectProps<T>) => {
-  const portalTarget = useMemo(() => (typeof document !== 'undefined' ? document.body : null), []);
+  const portalTarget = useMemo(() => (typeof document !== "undefined" ? document.body : null), []);
 
   const components = useMemo(
     () => ({
@@ -67,7 +67,7 @@ const Select = <T extends boolean>({
 
   const styles: StylesConfig<Option, T> = useMemo(() => ({ menuPortal: (base) => ({ ...base, zIndex: 99999 }) }), []);
   const filterOption = useMemo(
-    () => (matchFrom === 'start' ? createFilter({ matchFrom: 'start' }) : undefined),
+    () => (matchFrom === "start" ? createFilter({ matchFrom: "start" }) : undefined),
     [matchFrom],
   );
 


### PR DESCRIPTION
Liten omskrivning av Select-komponent til å ta i bruk props fra react-select, så slipper de å defineres dobbelt opp! 

Denne er breaking, så kommer tilhørende PR i ed