### PR TITLE
Exports license-link to be used in ed

### DIFF
--- a/packages/ndla-ui/src/LicenseByline/index.tsx
+++ b/packages/ndla-ui/src/LicenseByline/index.tsx
@@ -7,3 +7,4 @@
  */
 
 export { default as EmbedByline } from "./EmbedByline";
+export { default as LicenseLink } from "./LicenseLink";

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -29,6 +29,8 @@ export {
   BlockConcept,
 } from "./Embed";
 
+export { LicenseLink } from "./LicenseByline";
+
 export {
   ArticleByline,
   ArticleFootNotes,


### PR DESCRIPTION
Tenkte denne kan brukes i søkeresultat i ed i stedet for LincenseByline som berre viser ikoner.