### PR TITLE
Ny xsmall--spacing som speiler xsmall fra spacing.

### DIFF
--- a/packages/core/scss/global/tools/tools.aliases.scss
+++ b/packages/core/scss/global/tools/tools.aliases.scss
@@ -1,13 +1,15 @@
 $spacing: $inuit-global-spacing-unit;
-$spacing--nsmall: $inuit-global-spacing-unit/1.5;
+$spacing--xsmall: $inuit-global-spacing-unit/4;
 $spacing--small: $inuit-global-spacing-unit/2;
+$spacing--nsmall: $inuit-global-spacing-unit/1.5;
 $spacing--medium: $inuit-global-spacing-unit * 1.25;
 $spacing--large: $inuit-global-spacing-unit * 2;
 
 :root {
   --spacing: #{$spacing};
-  --spacing--nsmall: #{$spacing--nsmall};
+  --spacing--xsmall: #{$spacing--xsmall};
   --spacing--small: #{$spacing--small};
+  --spacing--nsmall: #{$spacing--nsmall};
   --spacing--medium: #{$spacing--medium};
   --spacing--large: #{$spacing--large};
 }

--- a/packages/core/scss/global/utilities/utilities.helpers.scss
+++ b/packages/core/scss/global/utilities/utilities.helpers.scss
@@ -15,34 +15,58 @@
 /* Float article objects */
 .u-float-left {
   @include float(13, 20, 'left', 10);
+  @include mq(tablet) {
+    margin: $spacing--xsmall 0 $spacing;
+  }
+  @include mq(desktop) {
+    margin: $spacing--xsmall 0 $spacing;
+  }
 }
 .u-float-right {
   @include float(13, 20, 'right', 10);
+  @include mq(tablet) {
+    margin: $spacing--xsmall 0 $spacing;
+  }
+  @include mq(desktop) {
+    margin: $spacing--xsmall 0 $spacing;
+  }
 }
 .u-float-small-left {
   @include float(2, 4, 'left');
+  @include mq(tablet) {
+    margin: $spacing--xsmall 0 $spacing;
+  }
+  @include mq(desktop) {
+    margin: $spacing--xsmall 0 $spacing;
+  }
 }
 .u-float-small-right {
   @include float(2, 4, 'right');
+  @include mq(tablet) {
+    margin: $spacing--xsmall 0 $spacing;
+  }
+  @include mq(desktop) {
+    margin: $spacing--xsmall 0 $spacing;
+  }
 }
 .u-float-xsmall-left {
   @include float(2, 4, 'left');
   @include mq(tablet) {
     @include float(1, 4, 'left');
-    margin: $spacing--small $spacing $spacing--medium 0;
+    margin: $spacing--xsmall 0 $spacing--medium;
   }
   @include mq(desktop) {
-    margin: $spacing--small $spacing $spacing--medium 0;
+    margin: $spacing--xsmall 0 $spacing--medium;
   }
 }
 .u-float-xsmall-right {
   @include float(2, 4, 'right');
   @include mq(tablet) {
     @include float(1, 4, 'right');
-    margin: $spacing--small 0 $spacing--medium $spacing;
+    margin: $spacing--xsmall 0 $spacing $spacing--xsmall;
   }
   @include mq(desktop) {
-    margin: $spacing--small 0 $spacing--medium $spacing;
+    margin: $spacing--xsmall 0 $spacing $spacing--xsmall;
   }
 }
 


### PR DESCRIPTION
Bruker spacing for å aligne bilder til tekst.
![image](https://github.com/NDLANO/frontend-packages/assets/8956884/db2333e5-c383-448f-8f86-a38ace0dcc88)

Har forsøkt å gjøre det så likt som tidligere, men med mindre luft over. Har lagt meg på 6px og ikkje 0 fordi ingen marg såg nesten ut til å være for lite.

Synes sjølv det ser ganske bra ut men ekspandering kunne vore bedre.