### PR TITLE
Add eventlistener on click to handle correct textarea element resizing

### DIFF
--- a/packages/ndla-forms/src/InputV3.tsx
+++ b/packages/ndla-forms/src/InputV3.tsx
@@ -102,10 +102,13 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, r
   useEffect(() => {
     window.addEventListener("input", resize);
     window.addEventListener("resize", resize);
+    const textareaRef = localRef.current;
+    if (textareaRef) textareaRef.addEventListener("click", resize);
     resize();
     return () => {
       window.removeEventListener("input", resize);
       window.removeEventListener("resize", resize);
+      if (textareaRef) textareaRef.removeEventListener("click", resize);
     };
   }, [resize]);
 


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/3920

Denne skal fikse at høyden til kommentarer tilpasses riktig når man klikker på elementet