### PR TITLE
Removing margin from framedcontent. Add section around uu-disclaimer

### DIFF
--- a/packages/core/scss/global/elements/_elements.details.scss
+++ b/packages/core/scss/global/elements/_elements.details.scss
@@ -1,7 +1,7 @@
 details {
   transition-duration: 150ms;
   transition-property: left, right, width;
-  margin: $spacing--large 0;
+  margin-bottom: $spacing--large;
   width: 100%;
   box-sizing: border-box;
   position: relative;

--- a/packages/ndla-ui/src/Embed/UuDisclaimerEmbed.stories.tsx
+++ b/packages/ndla-ui/src/Embed/UuDisclaimerEmbed.stories.tsx
@@ -12,6 +12,7 @@ import H5pEmbed from "./H5pEmbed";
 import IframeEmbed from "./IframeEmbed";
 import UuDisclaimerEmbed from "./UuDisclaimerEmbed";
 import { defaultParameters } from "../../../../stories/defaults";
+import FramedContent from "../FramedContent";
 
 const embedData: UuDisclaimerEmbedData = {
   resource: "uu-disclaimer",
@@ -145,6 +146,22 @@ export const WithHtml: StoryObj<typeof UuDisclaimerEmbed> = {
           <p>innhold</p>
         </details>
       </>
+    ),
+  },
+};
+
+export const WithFramedContent: StoryObj<typeof UuDisclaimerEmbed> = {
+  args: {
+    embed: {
+      resource: "uu-disclaimer",
+      status: "success",
+      embedData: embedData,
+      data: {},
+    },
+    children: (
+      <FramedContent>
+        <p>Dette er tekst i ramme</p>
+      </FramedContent>
     ),
   },
 };

--- a/packages/ndla-ui/src/Embed/UuDisclaimerEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/UuDisclaimerEmbed.tsx
@@ -21,6 +21,7 @@ interface Props {
 
 const MessageBoxWrapper = styled.div`
   margin-bottom: ${spacing.xsmall};
+  margin-top: ${spacing.normal};
 `;
 
 const StyledMessageBox = styled(MessageBox)`

--- a/packages/ndla-ui/src/Embed/UuDisclaimerEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/UuDisclaimerEmbed.tsx
@@ -9,6 +9,7 @@
 import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "@emotion/styled";
+import { spacing } from "@ndla/core";
 import { InformationOutline } from "@ndla/icons/common";
 import SafeLink from "@ndla/safelink";
 import { UuDisclaimerMetaData } from "@ndla/types-embed";
@@ -21,6 +22,7 @@ interface Props {
 const StyledMessageBox = styled(MessageBox)`
   display: flex;
   flex-align: center;
+  margin-bottom: ${spacing.xsmall};
 `;
 
 const Disclaimer = styled.div`
@@ -50,7 +52,7 @@ const UuDisclaimerEmbed = ({ embed, children }: Props) => {
   ) : null;
 
   return (
-    <>
+    <section>
       <StyledMessageBox type="info">
         <InformationOutline />
         <Disclaimer>
@@ -59,7 +61,7 @@ const UuDisclaimerEmbed = ({ embed, children }: Props) => {
         </Disclaimer>
       </StyledMessageBox>
       {children}
-    </>
+    </section>
   );
 };
 

--- a/packages/ndla-ui/src/Embed/UuDisclaimerEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/UuDisclaimerEmbed.tsx
@@ -55,7 +55,7 @@ const UuDisclaimerEmbed = ({ embed, children }: Props) => {
   ) : null;
 
   return (
-    <section>
+    <div role="region">
       <MessageBoxWrapper>
         <StyledMessageBox type="info">
           <InformationOutline />
@@ -66,7 +66,7 @@ const UuDisclaimerEmbed = ({ embed, children }: Props) => {
         </StyledMessageBox>
       </MessageBoxWrapper>
       {children}
-    </section>
+    </div>
   );
 };
 

--- a/packages/ndla-ui/src/Embed/UuDisclaimerEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/UuDisclaimerEmbed.tsx
@@ -19,10 +19,13 @@ interface Props {
   children?: ReactNode;
 }
 
+const MessageBoxWrapper = styled.div`
+  margin-bottom: ${spacing.xsmall};
+`;
+
 const StyledMessageBox = styled(MessageBox)`
   display: flex;
   flex-align: center;
-  margin-bottom: ${spacing.xsmall};
 `;
 
 const Disclaimer = styled.div`
@@ -53,13 +56,15 @@ const UuDisclaimerEmbed = ({ embed, children }: Props) => {
 
   return (
     <section>
-      <StyledMessageBox type="info">
-        <InformationOutline />
-        <Disclaimer>
-          {embedData.disclaimer}
-          {disclaimerLink}
-        </Disclaimer>
-      </StyledMessageBox>
+      <MessageBoxWrapper>
+        <StyledMessageBox type="info">
+          <InformationOutline />
+          <Disclaimer>
+            {embedData.disclaimer}
+            {disclaimerLink}
+          </Disclaimer>
+        </StyledMessageBox>
+      </MessageBoxWrapper>
       {children}
     </section>
   );

--- a/packages/ndla-ui/src/FactBox/FactBox.tsx
+++ b/packages/ndla-ui/src/FactBox/FactBox.tsx
@@ -27,7 +27,7 @@ const StyledAside = styled.aside`
   align-items: center;
   position: relative;
   z-index: ${stackOrder.offsetSingle};
-  margin: ${spacing.large} 0 calc(${spacing.large} - ${spacing.nsmall}) 0;
+  margin-bottom: ${spacing.large};
   overflow: hidden;
   padding-bottom: ${spacing.nsmall};
 

--- a/packages/ndla-ui/src/FramedContent/FramedContent.tsx
+++ b/packages/ndla-ui/src/FramedContent/FramedContent.tsx
@@ -13,6 +13,7 @@ import { colors, spacing } from "@ndla/core";
 const StyledFramedContent = styled.div`
   padding: ${spacing.mediumlarge};
   border: 1px solid ${colors.brand.tertiary};
+  margin-bottom: ${spacing.large};
   overflow: hidden;
 
   .c-figure {

--- a/packages/ndla-ui/src/FramedContent/FramedContent.tsx
+++ b/packages/ndla-ui/src/FramedContent/FramedContent.tsx
@@ -12,7 +12,6 @@ import { colors, spacing } from "@ndla/core";
 
 const StyledFramedContent = styled.div`
   padding: ${spacing.mediumlarge};
-  margin: ${spacing.large} 0;
   border: 1px solid ${colors.brand.tertiary};
   overflow: hidden;
 


### PR DESCRIPTION
Tekst i ramme har så masse avstand rundt seg. Tester å redusere dette.
Dette ser bedre ut i det minste
![image](https://github.com/NDLANO/frontend-packages/assets/8956884/1f88ea6a-ef46-46fa-a0ac-d5f3da86ed4d)
