### PR TITLE
add margin at the bottom of the grid

### DIFF
--- a/packages/ndla-ui/src/Grid/Grid.tsx
+++ b/packages/ndla-ui/src/Grid/Grid.tsx
@@ -25,6 +25,7 @@ const GridContainer = styled.div`
   grid-template-columns: 1fr;
   grid-gap: ${spacing.normal};
   padding: ${spacing.normal};
+  margin-bottom: ${spacing.normal};
 
   ${mq.range({ until: breakpoints.tabletWide })} {
     &[data-columns="2x2"],


### PR DESCRIPTION
Det er en bug der grids inn i artikler mangler padding mellom grid og p elementer, så da ville de ha en generell margin-bottom på grid