### PR TITLE
remove overwrite of heading level

### DIFF
--- a/packages/article-converter/src/plugins/divPlugin.tsx
+++ b/packages/article-converter/src/plugins/divPlugin.tsx
@@ -19,7 +19,7 @@ export const divPlugin: PluginType = (node, opts) => {
     const props = attributesToProps(node.attribs);
 
     return (
-      <RelatedArticleList {...props} headingLevel="h3">
+      <RelatedArticleList {...props}>
         {/* @ts-ignore */}
         {domToReact(node.children, opts)}
       </RelatedArticleList>


### PR DESCRIPTION
Det var et sted vi overskrev heading nivå til _RelatedContent_. Den skal være H2

[Trello](https://trello.com/c/r3U3QB3U/696-overskriftsniv%C3%A5-i-komponenter)