### PR TITLE
Adding wrapper to disclaimer embed

### DIFF
--- a/packages/ndla-ui/src/Embed/UuDisclaimerEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/UuDisclaimerEmbed.tsx
@@ -9,6 +9,7 @@
 import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "@emotion/styled";
+import { spacing } from "@ndla/core";
 import { InformationOutline } from "@ndla/icons/common";
 import SafeLink from "@ndla/safelink";
 import { UuDisclaimerMetaData } from "@ndla/types-embed";
@@ -31,6 +32,12 @@ const Disclaimer = styled.div`
   -ms-user-select: none;
 `;
 
+const DisclaimerWrapper = styled.div`
+  > :nth-child(2) {
+    margin-top: ${spacing.xsmall};
+  }
+`;
+
 const UuDisclaimerEmbed = ({ embed, children }: Props) => {
   const { t } = useTranslation();
 
@@ -50,7 +57,7 @@ const UuDisclaimerEmbed = ({ embed, children }: Props) => {
   ) : null;
 
   return (
-    <>
+    <DisclaimerWrapper>
       <StyledMessageBox type="info">
         <InformationOutline />
         <Disclaimer>
@@ -59,7 +66,7 @@ const UuDisclaimerEmbed = ({ embed, children }: Props) => {
         </Disclaimer>
       </StyledMessageBox>
       {children}
-    </>
+    </DisclaimerWrapper>
   );
 };
 


### PR DESCRIPTION
Discussion in https://github.com/NDLANO/Issues/issues/3919 + https://trello.com/c/cXgSKdZK/352-uu-disclaimer#comment-65ca0aaabe4171cb7c75b967

Første element får overstyrt margin-top slik at disclaimeren blir flytende rett over, heller enn med den store margin som noen av komponentene våre har.