### PR TITLE
Fix spacing for lists and related content

### DIFF
--- a/packages/ndla-ui/src/FramedContent/FramedContent.tsx
+++ b/packages/ndla-ui/src/FramedContent/FramedContent.tsx
@@ -33,14 +33,6 @@ const StyledFramedContent = styled.div`
       margin-left: 0;
     }
   }
-
-  &:first-child {
-    margin-top: 0;
-  }
-
-  &:last-child {
-    margin-bottom: 0;
-  }
 `;
 
 const FramedContent = forwardRef<HTMLDivElement, ComponentPropsWithRef<"div">>(({ children, ...rest }, ref) => (

--- a/packages/ndla-ui/src/List/UnOrderedList.tsx
+++ b/packages/ndla-ui/src/List/UnOrderedList.tsx
@@ -12,8 +12,8 @@ import { colors, fonts, spacing } from "@ndla/core";
 
 const StyledUl = styled.ul`
   padding-left: ${spacing.nsmall};
-  margin-left: ${spacing.normal};
-  ${fonts.sizes("18px", "29px")};
+  margin: ${spacing.normal} 0 ${spacing.normal} ${spacing.normal};
+  ${fonts.size.text.content};
 
   ul {
     margin-left: 0;

--- a/packages/ndla-ui/src/List/UnOrderedList.tsx
+++ b/packages/ndla-ui/src/List/UnOrderedList.tsx
@@ -16,7 +16,7 @@ const StyledUl = styled.ul`
   ${fonts.size.text.content};
 
   ul {
-    margin-left: 0;
+    margin: 0;
   }
 
   > li {


### PR DESCRIPTION
Fikser: [Trello](https://trello.com/c/Iuj7CA7M/310-manglende-padding-etter-lister)

Kan testes på: [Kampanje mot kredittkjøp](http://localhost:3000/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7/topic:3cdf9349-4593-498c-a899-9310133a4788/topic:1d740ae3-18da-4d49-bdfc-0aa7387e5c58/topic:ca80b078-842d-475a-8cca-9b47affe9614/resource:b29ec816-f825-4073-a348-a797a26e00e7) [Fjellvettreglene](http://localhost:3000/nb/article/10244)