### PR TITLE
Removed styled component in ExpandableBox. Added summary css in details

### DIFF
--- a/packages/core/scss/global/elements/_elements.details.scss
+++ b/packages/core/scss/global/elements/_elements.details.scss
@@ -56,5 +56,10 @@ summary {
   color: $brand-color;
   cursor: pointer;
   padding: $spacing;
-}
 
+  & > * {
+    display: inline;
+    font-weight: $font-weight-normal;
+    @include font-size(18px, 24px);
+  }
+}

--- a/packages/ndla-ui/src/ExpandableBox/ExpandableBox.tsx
+++ b/packages/ndla-ui/src/ExpandableBox/ExpandableBox.tsx
@@ -18,14 +18,6 @@ export const ExpandableBox = ({ children, ...rest }: Props) => {
 
 interface SummaryProps extends HTMLAttributes<HTMLElement> {}
 
-const StyledSummary = styled.summary`
-  & > * {
-    display: inline;
-    font-size: ${fonts.size.text.metaText.medium};
-    font-weight: ${fonts.weight.normal};
-  }
-`;
-
 export const ExpandableBoxSummary = ({ children, ...rest }: SummaryProps) => {
-  return <StyledSummary {...rest}>{children}</StyledSummary>;
+  return <summary {...rest}>{children}</summary>;
 };


### PR DESCRIPTION
Vi har ikke article-converter plugin for summary/details men vi har css sheet så da legger vi inn CSS'en der istedenfor!