### PR TITLE
Always show embed byline on small images when on small screens

### DIFF
--- a/packages/ndla-ui/src/Embed/ImageEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/ImageEmbed.tsx
@@ -177,10 +177,11 @@ const ImageEmbed = ({
           lang={lang}
         />
       </ImageWrapper>
-      {isBylineHidden || (isSmall(embedData.size) && !imageSizes) ? null : (
+      {isBylineHidden ? null : (
         <EmbedByline
           type="image"
           copyright={data.copyright}
+          hideOnLargeScreens={isSmall(embedData.size) && !imageSizes}
           description={parsedDescription}
           bottomRounded
           visibleAlt={previewAlt ? embed.embedData.alt : ""}

--- a/packages/ndla-ui/src/LicenseByline/EmbedByline.tsx
+++ b/packages/ndla-ui/src/LicenseByline/EmbedByline.tsx
@@ -96,7 +96,7 @@ const BylineWrapper = styled.div`
   &[data-first="true"] {
     border-top: 1px solid ${colors.brand.light};
   }
-  &[data-hide-on-large-screen="true"] {
+  &[data-hide-on-large-screens="true"] {
     ${mq.range({ from: breakpoints.tablet })} {
       display: none;
     }

--- a/packages/ndla-ui/src/LicenseByline/EmbedByline.tsx
+++ b/packages/ndla-ui/src/LicenseByline/EmbedByline.tsx
@@ -27,6 +27,7 @@ interface BaseProps {
   children?: ReactNode;
   visibleAlt?: string;
   error?: true | false;
+  hideOnLargeScreens?: boolean;
   first?: boolean;
   inGrid?: boolean;
 }
@@ -95,6 +96,11 @@ const BylineWrapper = styled.div`
   &[data-first="true"] {
     border-top: 1px solid ${colors.brand.light};
   }
+  &[data-hide-on-large-screen="true"] {
+    ${mq.range({ from: breakpoints.tablet })} {
+      display: none;
+    }
+  }
 `;
 
 const mobileStyling = css`
@@ -135,6 +141,7 @@ const EmbedByline = ({
   description,
   children,
   visibleAlt,
+  hideOnLargeScreens,
   first = true,
   inGrid = false,
   ...props
@@ -157,7 +164,12 @@ const EmbedByline = ({
   const captionAuthors = Object.values(authors).find((i) => i.length > 0) ?? [];
 
   return (
-    <BylineWrapper data-top-rounded={topRounded} data-bottom-rounded={bottomRounded} data-first={first}>
+    <BylineWrapper
+      data-top-rounded={topRounded}
+      data-hide-on-large-screens={hideOnLargeScreens}
+      data-bottom-rounded={bottomRounded}
+      data-first={first}
+    >
       {description && <LicenseDescription description={description} />}
       {visibleAlt ? <StyledSpan>{`Alt: ${visibleAlt}`}</StyledSpan> : null}
       <RightsWrapper data-grid={inGrid}>


### PR DESCRIPTION
Fixes https://trello.com/c/fpaGOogD/743-sm%C3%A5-bilder-i-mobilvisning-fullbredde-mangler-hjerte-og-byline

Litt tricky greie, det her. Jeg _tror_ dette skal fikse originalproblemet uten å innføre noen nye, men tør ikke si meg helt sikker. Gjerne test litt ekstra.