### PR TITLE
Increase article width from 66% to 70%

### DIFF
--- a/packages/core/scss/core.scss
+++ b/packages/core/scss/core.scss
@@ -13,8 +13,6 @@
 @import '~inuitcss/tools/tools.clearfix';
 @import 'global/utilities/mixin_icons';
 
-$inuit-fractions: 1 2 3 4 5 6 10 12;
-
 @import 'global/settings/settings.breakpoints';
 
 @import 'global/tools/tools.aliases';

--- a/packages/core/scss/global/utilities/utilities.widths.scss
+++ b/packages/core/scss/global/utilities/utilities.widths.scss
@@ -42,7 +42,7 @@
 //   .u-3/4
 //   .u-2/3
 
-$inuit-fractions: 1 2 3 4 5 6 7 8 9 10 11 12 !default;
+$inuit-fractions: 1 2 3 4 5 6 7 8 9 10 11 12 20 !default;
 
 
 

--- a/packages/ndla-ui/src/Layout/LayoutItem.tsx
+++ b/packages/ndla-ui/src/Layout/LayoutItem.tsx
@@ -6,36 +6,28 @@
  *
  */
 
-import { HTMLAttributes, ReactNode } from "react";
+import { HTMLAttributes, ReactNode, useMemo } from "react";
 
 interface Props extends HTMLAttributes<HTMLElement> {
   children?: ReactNode;
-  layout?: string;
+  layout?: "extend" | "center";
 }
 
 export const LayoutItem = ({ children, layout, ...rest }: Props) => {
-  switch (layout) {
-    case "extend": {
-      return (
-        <section className="u-10/12@desktop u-push-1/12@desktop u-10/12@tablet u-push-1/12@tablet">{children}</section>
-      );
+  const className = useMemo(() => {
+    if (layout === "extend") {
+      return "u-10/12@desktop u-push-1/12@desktop u-10/12@tablet u-push-1/12@tablet";
+    } else if (layout === "center") {
+      return "u-7/10@desktop u-push-3/20@desktop u-10/12@tablet u-push-1/12@tablet";
     }
-    case "center": {
-      return (
-        <section className="u-4/6@desktop u-push-1/6@desktop u-10/12@tablet u-push-1/12@tablet">{children}</section>
-      );
-    }
-    case "full": {
-      return <section className="u-1/1@desktop">{children}</section>;
-    }
-    default: {
-      return (
-        <section className="o-layout__item" {...rest}>
-          {children}
-        </section>
-      );
-    }
-  }
+    return undefined;
+  }, [layout]);
+
+  return (
+    <section className={className} {...rest}>
+      {children}
+    </section>
+  );
 };
 
 export default LayoutItem;

--- a/stories/basicStyles/banners.stories.tsx
+++ b/stories/basicStyles/banners.stories.tsx
@@ -41,7 +41,7 @@ const BannerList = () => {
   return (
     <PageContainer>
       <OneColumn>
-        <LayoutItem layout="full">
+        <LayoutItem>
           <article className="c-article c-article--clean">
             <FormControl id="search">
               <Label visuallyHidden>Søk etter bannere</Label>


### PR DESCRIPTION
Fixes https://trello.com/c/QGpwQyPt/733-unng%C3%A5-h5p-mobilvisning-endre-ved-%C3%A5-sette-hovedkolonne-til-over-620

Dette vil også påvirke læringssti-navigasjon.