### PR TITLE
Proper interop between radio buttons and form control

### DIFF
--- a/packages/ndla-forms/src/FormControl.tsx
+++ b/packages/ndla-forms/src/FormControl.tsx
@@ -72,8 +72,8 @@ const useFormControlProvider = ({ id: idProp, isRequired, isDisabled, isInvalid 
       return {
         ...props,
         ref: forwardedRef,
-        "data-disabled": isDisabled,
-        "data-invalid": isInvalid,
+        "data-disabled": props?.["data-disabled"] ? props["data-disabled"] : isDisabled,
+        "data-invalid": props?.["data-invalid"] ? props["data-invalid"] : isInvalid,
         id: props.id !== undefined ? props.id : labelId,
         htmlFor: props.htmlFor !== undefined ? props.htmlFor : id,
       };

--- a/packages/ndla-forms/src/Label.tsx
+++ b/packages/ndla-forms/src/Label.tsx
@@ -44,3 +44,36 @@ export const Label = forwardRef<HTMLLabelElement, Props>(
     );
   },
 );
+
+const StyledLegend = styled(Text)`
+  float: none;
+  width: inherit;
+  &[data-disabled="true"] {
+    color: ${colors.brand.greyMedium};
+  }
+`;
+
+export const Legend = forwardRef<HTMLLabelElement, Props>(
+  ({ textStyle = "label-large", visuallyHidden, margin = "small", ...rest }, ref) => {
+    const control = useFormControlContext();
+    // Legend does not use htmlFor (for), so we remove it.
+    const { id: _, htmlFor: __, ...fieldProps } = control?.getLabelProps(rest, ref) ?? { ref, ...rest };
+
+    return (
+      <StyledLegend
+        element="legend"
+        css={visuallyHidden ? visuallyHiddenStyle : undefined}
+        {...rest}
+        {...fieldProps}
+        textStyle={textStyle}
+        margin={margin}
+      />
+    );
+  },
+);
+
+export const Fieldset = styled.fieldset`
+  border: none;
+  padding: 0;
+  margin: 0;
+`;

--- a/packages/ndla-forms/src/RadioButtonGroup/RadioButtonGroup.stories.tsx
+++ b/packages/ndla-forms/src/RadioButtonGroup/RadioButtonGroup.stories.tsx
@@ -6,14 +6,16 @@
  *
  */
 
+import { useState } from "react";
 import { css } from "@emotion/react";
 import { Meta, StoryFn } from "@storybook/react";
 import { spacing, colors } from "@ndla/core";
 import { RadioButtonGroup } from "./RadioButtonGroup";
 import { RadioButtonItem } from "./RadioButtonItem";
+import { FieldErrorMessage } from "..";
 import { defaultParameters } from "../../../../stories/defaults";
 import { FormControl } from "../FormControl";
-import { Label } from "../Label";
+import { Fieldset, Label, Legend } from "../Label";
 
 const radioButtonWrapperStyles = css`
   display: flex;
@@ -40,57 +42,156 @@ export const Default: StoryFn<typeof RadioButtonGroup> = ({ ...args }) => (
 
 export const WithLabelAndForm: StoryFn<typeof RadioButtonGroup> = () => (
   <form>
-    <RadioButtonGroup defaultValue="radio1">
-      <div css={radioButtonWrapperStyles}>
-        <RadioButtonItem value="radio1" id="r1" />
-        <Label margin="none" textStyle="label-small" htmlFor="r1">
-          Radio 1
-        </Label>
-      </div>
-      <div css={radioButtonWrapperStyles}>
-        <RadioButtonItem value="radio2" id="r2" />
-        <Label margin="none" textStyle="label-small" htmlFor="r2">
-          Radio 2
-        </Label>
-      </div>
+    <RadioButtonGroup defaultValue="radio1" asChild>
+      <Fieldset>
+        <Legend margin="none" textStyle="label-small">
+          Choose an option
+        </Legend>
+        <div css={radioButtonWrapperStyles}>
+          <RadioButtonItem value="radio1" id="r1" />
+          <Label margin="none" textStyle="label-small" htmlFor="r1">
+            Radio 1
+          </Label>
+        </div>
+        <div css={radioButtonWrapperStyles}>
+          <RadioButtonItem value="radio2" id="r2" />
+          <Label margin="none" textStyle="label-small" htmlFor="r2">
+            Radio 2
+          </Label>
+        </div>
+      </Fieldset>
     </RadioButtonGroup>
   </form>
 );
 
 export const Horizontal: StoryFn<typeof RadioButtonGroup> = () => (
   <form>
-    <RadioButtonGroup orientation="horizontal" defaultValue="radio1" style={{ display: "flex", gap: spacing.small }}>
-      <div css={radioButtonWrapperStyles}>
-        <RadioButtonItem value="radio1" id="r3" />
-        <Label margin="none" textStyle="label-small" htmlFor="r3">
-          Radio 1
-        </Label>
-      </div>
-      <div css={radioButtonWrapperStyles}>
-        <RadioButtonItem value="radio2" id="r4" />
-        <Label margin="none" textStyle="label-small" htmlFor="r4">
-          Radio 2
-        </Label>
-      </div>
+    <RadioButtonGroup
+      orientation="horizontal"
+      defaultValue="radio1"
+      style={{ display: "flex", gap: spacing.small }}
+      asChild
+    >
+      <Fieldset>
+        <Legend margin="none" textStyle="label-small">
+          Choose an option
+        </Legend>
+        <div css={radioButtonWrapperStyles}>
+          <RadioButtonItem value="radio1" id="r3" />
+          <Label margin="none" textStyle="label-small" htmlFor="r3">
+            Radio 1
+          </Label>
+        </div>
+        <div css={radioButtonWrapperStyles}>
+          <RadioButtonItem value="radio2" id="r4" />
+          <Label margin="none" textStyle="label-small" htmlFor="r4">
+            Radio 2
+          </Label>
+        </div>
+      </Fieldset>
     </RadioButtonGroup>
   </form>
 );
 
 export const InFormControlWithDisabled: StoryFn<any> = () => (
   <form>
-    <RadioButtonGroup defaultValue="radio1">
-      <FormControl id="r5" css={radioButtonWrapperStyles}>
-        <RadioButtonItem value="radio1" />
-        <Label margin="none" textStyle="label-small">
-          Radio 1
-        </Label>
-      </FormControl>
-      <FormControl id="r6" css={radioButtonWrapperStyles} isDisabled>
-        <RadioButtonItem value="radio2" />
-        <Label margin="none" textStyle="label-small">
-          Radio 2
-        </Label>
-      </FormControl>
-    </RadioButtonGroup>
+    <FormControl id={"radio-with-form-control"}>
+      <RadioButtonGroup defaultValue="radio1" asChild>
+        <Fieldset>
+          <Legend margin="none" textStyle="label-small">
+            Choose an option
+          </Legend>
+          <div css={radioButtonWrapperStyles}>
+            <RadioButtonItem id="radio1" value="radio1" />
+            <Label margin="none" htmlFor="radio1" textStyle="label-small">
+              Radio 1
+            </Label>
+          </div>
+          <div css={radioButtonWrapperStyles}>
+            <RadioButtonItem id="radio2" value="radio2" />
+            <Label margin="none" htmlFor="radio2" textStyle="label-small">
+              Radio 2
+            </Label>
+          </div>
+          <div css={radioButtonWrapperStyles}>
+            <RadioButtonItem id="radio3" value="radio3" disabled />
+            <Label margin="none" htmlFor="radio3" data-disabled="true" textStyle="label-small">
+              Radio 3
+            </Label>
+          </div>
+        </Fieldset>
+      </RadioButtonGroup>
+    </FormControl>
   </form>
 );
+
+export const InFormControlWithAllDisabled: StoryFn<any> = () => (
+  <form>
+    <FormControl id={"radio-with-form-control"} isDisabled>
+      <RadioButtonGroup defaultValue="radio4" asChild>
+        <Fieldset>
+          <Legend margin="none" textStyle="label-small">
+            Choose an option
+          </Legend>
+          <div css={radioButtonWrapperStyles}>
+            <RadioButtonItem id="radio4" value="radio1" />
+            <Label margin="none" htmlFor="radio4" textStyle="label-small">
+              Radio 4
+            </Label>
+          </div>
+          <div css={radioButtonWrapperStyles}>
+            <RadioButtonItem id="radio5" value="radio5" />
+            <Label margin="none" htmlFor="radio2" textStyle="label-small">
+              Radio 5
+            </Label>
+          </div>
+          <div css={radioButtonWrapperStyles}>
+            <RadioButtonItem id="radio6" value="radio6" />
+            <Label margin="none" htmlFor="radio6" data-disabled="true" textStyle="label-small">
+              Radio 6
+            </Label>
+          </div>
+        </Fieldset>
+      </RadioButtonGroup>
+    </FormControl>
+  </form>
+);
+
+export const InFormControlWithErrorMessageAndHelper: StoryFn<any> = () => {
+  const [value, setValue] = useState("parrot");
+
+  const error = value === "parrot" ? "This is an error. You probably clicked the wrong thing." : undefined;
+
+  return (
+    <form>
+      <FormControl id={"radio-with-form-control"} isInvalid={!!error} isRequired>
+        <RadioButtonGroup value={value} onValueChange={setValue} asChild>
+          <Fieldset>
+            <Legend margin="none" textStyle="label-small">
+              Choose your favourite pet
+            </Legend>
+            <div css={radioButtonWrapperStyles}>
+              <RadioButtonItem id="dog" value="dog" />
+              <Label margin="none" htmlFor="dog" textStyle="label-small">
+                Dog
+              </Label>
+            </div>
+            <div css={radioButtonWrapperStyles}>
+              <RadioButtonItem id="cat" value="cat" />
+              <Label margin="none" htmlFor="cat" textStyle="label-small">
+                Cat
+              </Label>
+            </div>
+            <div css={radioButtonWrapperStyles}>
+              <RadioButtonItem id="parrot" value="parrot" />
+              <Label margin="none" htmlFor="parrot" textStyle="label-small">
+                Parrot
+              </Label>
+            </div>
+            <FieldErrorMessage>{error}</FieldErrorMessage>
+          </Fieldset>
+        </RadioButtonGroup>
+      </FormControl>
+    </form>
+  );
+};

--- a/packages/ndla-forms/src/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/ndla-forms/src/RadioButtonGroup/RadioButtonGroup.tsx
@@ -8,10 +8,13 @@
 
 import { forwardRef } from "react";
 import { RadioGroupProps, Root } from "@radix-ui/react-radio-group";
+import { useFormControl } from "../FormControl";
 
 export const RadioButtonGroup = forwardRef<HTMLDivElement, RadioGroupProps>(({ children, ...rest }, ref) => {
+  // This is usually rendered as a fieldset, so we can ignore the ID.
+  const { id: _, ...props } = useFormControl(rest);
   return (
-    <Root {...rest} ref={ref}>
+    <Root {...props} ref={ref}>
       {children}
     </Root>
   );

--- a/packages/ndla-forms/src/RadioButtonGroup/RadioButtonItem.tsx
+++ b/packages/ndla-forms/src/RadioButtonGroup/RadioButtonItem.tsx
@@ -10,7 +10,6 @@ import { forwardRef } from "react";
 import styled from "@emotion/styled";
 import { RadioGroupItemProps, Item, Indicator } from "@radix-ui/react-radio-group";
 import { spacing, colors } from "@ndla/core";
-import { useFormControl } from "../FormControl";
 
 export const StyledRadioGroupItem = styled(Item)`
   all: unset;
@@ -71,9 +70,8 @@ const RadioButtonIndicator = styled(Indicator)`
 `;
 
 export const RadioButtonItem = forwardRef<HTMLButtonElement, RadioGroupItemProps>(({ ...rest }, ref) => {
-  const props = useFormControl(rest);
   return (
-    <StyledRadioGroupItem {...props} ref={ref}>
+    <StyledRadioGroupItem {...rest} ref={ref}>
       <RadioButtonIndicator forceMount />
     </StyledRadioGroupItem>
   );

--- a/packages/ndla-forms/src/index.ts
+++ b/packages/ndla-forms/src/index.ts
@@ -21,7 +21,7 @@ export { StyledButtonWrapper, FieldHeaderIconStyle } from "./Styles";
 export { FormPill, FormPills } from "./FormPill";
 export { CheckboxItem } from "./CheckboxItem";
 export { default as UploadDropZone } from "./UploadDropZone";
-export { Label } from "./Label";
+export { Label, Legend, Fieldset } from "./Label";
 export { FormControl, useFormControl } from "./FormControl";
 export type { FormControlProps } from "./FormControl";
 export { Input as InputV3, InputContainer, TextArea as TextAreaV3 } from "./InputV3";


### PR DESCRIPTION
Makan til rotete opplegg. Tror dette skal være akkurat nok til å tilby universelt utformede radio buttons uten at vi må gi helt slipp på `FormControl`. En `FormControl` skal wrappe en `RadioButtonGroup`, og ikke individuelle `RadioButtonItem`. 