### PR TITLE
move moderator email to be on its own

### DIFF
--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -1062,7 +1062,8 @@ const messages = {
         maxLength: "The maximum length for the text field is reached",
         error: "The field is required",
       },
-      bottomText: "Are you missing a category? Let our moderator know at moderator@ndla.no",
+      bottomText: "Are you missing a category? Let our moderator know at ",
+      moderatorEmail: "moderator@ndla.no",
       notification: {
         title: "Notifications",
         showAll: "View all notifications",

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -1062,7 +1062,8 @@ const messages = {
         maxLength: "Maksimal lengde for tekstfeltet er nådd",
         error: "Feltet er påkrevd",
       },
-      bottomText: "Savner du en kategori? Gi vår moderator beskjed på moderator@ndla.no",
+      bottomText: "Savner du en kategori? Gi vår moderator beskjed på ",
+      moderatorEmail: "moderator@ndla.no",
       notification: {
         title: "Varslinger",
         showAll: "Se alle varslinger",

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -1062,7 +1062,8 @@ const messages = {
         maxLength: "Maksimal lengd for tekstfeltet er nådd",
         error: "Feltet er påkravd",
       },
-      bottomText: "Saknar du ein kategori? Gi moderatoren vår beskjed på moderator@ndla.no",
+      bottomText: "Saknar du ein kategori? Gi moderatoren vår beskjed på ",
+      moderatorEmail: "moderator@ndla.no",
       notification: {
         title: "Varslingar",
         showAll: "Sjå alle varslingar",

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -1064,7 +1064,8 @@ const messages = {
         maxLength: "Maksimal lengde for tekstfeltet er nådd",
         error: "Feltet er påkrevd",
       },
-      bottomText: "Savner du en kategori? Gi vår moderator beskjed på moderator@ndla.no",
+      bottomText: "Savner du en kategori? Gi vår moderator beskjed på ",
+      moderatorEmail: "moderator@ndla.no",
       notification: {
         title: "Varslinger",
         showAll: "Se alle varslinger",

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -1066,7 +1066,8 @@ const messages = {
         maxLength: "Maksimal lengde for tekstfeltet er nådd",
         error: "Feltet er påkrevd",
       },
-      bottomText: "Savner du en kategori? Gi vår moderator beskjed på moderator@ndla.no",
+      bottomText: "Savner du en kategori? Gi vår moderator beskjed på ",
+      moderatorEmail: "moderator@ndla.no",
       notification: {
         title: "Varslinger",
         showAll: "Se alle varslinger",


### PR DESCRIPTION
hjelper å løse [trello](https://trello.com/c/YrUA9zoB/755-gjere-moderator-epost-p%C3%A5-arena-klikkbar)