### PR TITLE
Hide decorative badge for screen readers

### DIFF
--- a/packages/ndla-ui/src/SearchTypeResult/SearchTypeHeader.tsx
+++ b/packages/ndla-ui/src/SearchTypeResult/SearchTypeHeader.tsx
@@ -96,14 +96,26 @@ const SearchTypeHeader = ({ filters = [], onFilterClick, totalCount, type }: Pro
         <TypeWrapper>
           {type && (
             <BadgeWrapper>
-              <ContentTypeBadge type={type} title={t(`contentTypes.${type}`)} background border={false} size="large" />
+              <ContentTypeBadge
+                aria-hidden
+                type={type}
+                title={t(`contentTypes.${type}`)}
+                background
+                border={false}
+                size="large"
+              />
             </BadgeWrapper>
           )}
           <SubjectName>
-            <h2 id={`searchitem-header-${type}`}>
+            <h2
+              id={`searchitem-header-${type}`}
+              aria-label={`${type ? t(`contentTypes.${type}`) : t(`searchPage.resultType.allContentTypes`)} ${
+                totalCount ? t(`searchPage.resultType.hits`, { count: totalCount }) : null
+              }`}
+            >
               {type ? t(`contentTypes.${type}`) : t(`searchPage.resultType.allContentTypes`)}
             </h2>
-            {totalCount && <Count>{t(`searchPage.resultType.hits`, { count: totalCount })}</Count>}
+            {totalCount && <Count aria-hidden>{t(`searchPage.resultType.hits`, { count: totalCount })}</Count>}
           </SubjectName>
         </TypeWrapper>
       </HeaderWrapper>

--- a/packages/ndla-ui/src/SearchTypeResult/SearchTypeHeader.tsx
+++ b/packages/ndla-ui/src/SearchTypeResult/SearchTypeHeader.tsx
@@ -107,15 +107,10 @@ const SearchTypeHeader = ({ filters = [], onFilterClick, totalCount, type }: Pro
             </BadgeWrapper>
           )}
           <SubjectName>
-            <h2
-              id={`searchitem-header-${type}`}
-              aria-label={`${type ? t(`contentTypes.${type}`) : t(`searchPage.resultType.allContentTypes`)} ${
-                totalCount ? t(`searchPage.resultType.hits`, { count: totalCount }) : null
-              }`}
-            >
+            <h2 id={`searchitem-header-${type}`}>
               {type ? t(`contentTypes.${type}`) : t(`searchPage.resultType.allContentTypes`)}
             </h2>
-            {totalCount && <Count aria-hidden>{t(`searchPage.resultType.hits`, { count: totalCount })}</Count>}
+            {totalCount && <Count>{t(`searchPage.resultType.hits`, { count: totalCount })}</Count>}
           </SubjectName>
         </TypeWrapper>
       </HeaderWrapper>


### PR DESCRIPTION
Gjemmer badges i søkeresultat headers for skjermlesere. Visning av denne fører til at skjermleser leser opp "dobbel tittel", og den er i mine øyne kun dekorativ.