### PR TITLE
Make linking work with native source code

### DIFF
--- a/packages/article-converter/package.json
+++ b/packages/article-converter/package.json
@@ -3,9 +3,10 @@
   "version": "6.2.1",
   "description": "Transforms NDLA articles into extended html versions",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "sideEffects": false,
   "scripts": {
     "build": "node ../../scripts/build.js package",
@@ -46,7 +47,11 @@
     "react-router-dom": ">= 6.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "ebeb8a1d86cba369e1156719ebaecb58a6e2cdfc"
 }

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -3,9 +3,10 @@
   "version": "12.0.38",
   "description": "Button component for NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "scripts": {
     "build": "node ../../scripts/build.js package",
     "build:types": "tsc -p tsconfig.build.json",
@@ -39,7 +40,11 @@
     "react-i18next": "^13.3.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -4,9 +4,10 @@
   "description": "Carousel for NDLA",
   "license": "GPL-3.0",
   "sideEffects": false,
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "scripts": {
     "build": "node ../../scripts/build.js package",
     "build:types": "tsc -p tsconfig.build.json",
@@ -35,7 +36,11 @@
     "react": ">= 16.8.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,10 +3,11 @@
   "version": "4.5.0",
   "description": "UI component library for NDLA.",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "sideEffects": false,
-  "types": "lib/index.d.ts",
   "scripts": {
     "build": "node ../../scripts/build.js package",
     "build:types": "tsc -p tsconfig.build.json",
@@ -35,7 +36,11 @@
     "@emotion/react": "^11.10.4"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/dropdown-menu/package.json
+++ b/packages/dropdown-menu/package.json
@@ -3,9 +3,10 @@
   "version": "1.0.31",
   "description": "Dropdown menu component for NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "scripts": {
     "build": "node ../../scripts/build.js package",
     "build:types": "tsc -p tsconfig.build.json",
@@ -36,6 +37,10 @@
     "react-dom": ">= 16.8.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -3,9 +3,10 @@
   "version": "2.1.5",
   "description": "Collection of React hooks used by NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "scripts": {
     "build": "node ../../scripts/build.js package",
     "build:types": "tsc -p tsconfig.build.json",
@@ -35,6 +36,10 @@
     "@ndla/util": "^4.0.4"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   }
 }

--- a/packages/ndla-accordion/package.json
+++ b/packages/ndla-accordion/package.json
@@ -3,9 +3,10 @@
   "version": "3.0.35",
   "description": "A simple accordion from NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "sideEffects": false,
   "scripts": {
     "build": "node ../../scripts/build.js package",
@@ -38,7 +39,11 @@
     "react-i18next": "^13.3.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/ndla-audio-search/package.json
+++ b/packages/ndla-audio-search/package.json
@@ -3,9 +3,10 @@
   "version": "5.0.1",
   "description": "A simple library for searching for audio files from NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "scripts": {
     "build": "node ../../scripts/build.js package",
     "build:types": "tsc -p tsconfig.build.json",
@@ -39,7 +40,11 @@
     "react": ">= 16.8.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/ndla-code/package.json
+++ b/packages/ndla-code/package.json
@@ -3,9 +3,10 @@
   "version": "5.0.49",
   "description": "Code components for NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "scripts": {
     "build": "node ../../scripts/build.js package",
     "build:types": "tsc -p tsconfig.build.json",
@@ -45,7 +46,11 @@
     "@ndla/types-embed": "^4.1.1"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/ndla-editor/package.json
+++ b/packages/ndla-editor/package.json
@@ -3,9 +3,10 @@
   "version": "5.0.50",
   "description": "Editor components for NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/NDLANO/frontend-packages.git/ndla-editor/"
@@ -39,7 +40,11 @@
     "react-i18next": "^13.3.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/ndla-error-reporter/package.json
+++ b/packages/ndla-error-reporter/package.json
@@ -3,8 +3,9 @@
   "version": "2.0.0",
   "description": "Error reporter for NDLA. Listens to window.onerror and sends client errors to Loggly.",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
+  "type": "module",
+  "main": "src/index.js",
+  "module": "src/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/NDLANO/frontend-packages.git/ndla-error-reporter/"
@@ -29,6 +30,9 @@
     "raven-js": "^3.22.3"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js"
   }
 }

--- a/packages/ndla-forms/package.json
+++ b/packages/ndla-forms/package.json
@@ -3,9 +3,10 @@
   "version": "7.0.7",
   "description": "Forms components for NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "sideEffects": false,
   "scripts": {
     "build": "node ../../scripts/build.js package",
@@ -45,7 +46,11 @@
     "react-i18next": "^13.3.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/ndla-howto/package.json
+++ b/packages/ndla-howto/package.json
@@ -3,9 +3,10 @@
   "version": "4.1.89",
   "description": "Temporary how-to texts for production system",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "sideEffects": false,
   "scripts": {
     "build": "node ../../scripts/build.js package",
@@ -46,7 +47,11 @@
     "react-router-dom": ">= 6.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "ebeb8a1d86cba369e1156719ebaecb58a6e2cdfc"
 }

--- a/packages/ndla-icons/action/package.json
+++ b/packages/ndla-icons/action/package.json
@@ -1,9 +1,13 @@
-
 {
   "name": "@ndla/icons/action",
   "private": true,
-  "main": "../lib/action/index.js",
-  "module": "../es/action/index.js",
-  "jsnext:main": "../es/action/index.js"
+  "main": "../src/action/index.ts",
+  "module": "../src/action/index.ts",
+  "types": "../src/action/index.ts",
+  "publishConfig": {
+    "main": "../lib/action/index.js",
+    "module": "../es/action/index.js",
+    "types": "../lib/action/index.d.ts"
+  }
 }
-    
+

--- a/packages/ndla-icons/common/package.json
+++ b/packages/ndla-icons/common/package.json
@@ -1,9 +1,13 @@
-
 {
   "name": "@ndla/icons/common",
   "private": true,
-  "main": "../lib/common/index.js",
-  "module": "../es/common/index.js",
-  "jsnext:main": "../es/common/index.js"
+  "main": "../src/common/index.ts",
+  "module": "../src/common/index.ts",
+  "types": "../src/common/index.ts",
+  "publishConfig": {
+    "main": "../lib/common/index.js",
+    "module": "../es/common/index.js",
+    "types": "../lib/common/index.d.ts"
+  }
 }
-    
+

--- a/packages/ndla-icons/contentType/package.json
+++ b/packages/ndla-icons/contentType/package.json
@@ -1,9 +1,13 @@
-
 {
   "name": "@ndla/icons/contentType",
   "private": true,
-  "main": "../lib/contentType/index.js",
-  "module": "../es/contentType/index.js",
-  "jsnext:main": "../es/contentType/index.js"
+  "main": "../src/contentType/index.ts",
+  "module": "../src/contentType/index.ts",
+  "types": "../src/contentType/index.ts",
+  "publishConfig": {
+    "main": "../lib/contentType/index.js",
+    "module": "../es/contentType/index.js",
+    "types": "../lib/contentType/index.d.ts"
+  }
 }
-    
+

--- a/packages/ndla-icons/editor/package.json
+++ b/packages/ndla-icons/editor/package.json
@@ -1,9 +1,13 @@
-
 {
   "name": "@ndla/icons/editor",
   "private": true,
-  "main": "../lib/editor/index.js",
-  "module": "../es/editor/index.js",
-  "jsnext:main": "../es/editor/index.js"
+  "main": "../src/editor/index.ts",
+  "module": "../src/editor/index.ts",
+  "types": "../src/editor/index.ts",
+  "publishConfig": {
+    "main": "../lib/editor/index.js",
+    "module": "../es/editor/index.js",
+    "types": "../lib/editor/index.d.ts"
+  }
 }
-    
+

--- a/packages/ndla-icons/licenses/package.json
+++ b/packages/ndla-icons/licenses/package.json
@@ -1,9 +1,13 @@
-
 {
   "name": "@ndla/icons/licenses",
   "private": true,
-  "main": "../lib/licenses/index.js",
-  "module": "../es/licenses/index.js",
-  "jsnext:main": "../es/licenses/index.js"
+  "main": "../src/licenses/index.ts",
+  "module": "../src/licenses/index.ts",
+  "types": "../src/licenses/index.ts",
+  "publishConfig": {
+    "main": "../lib/licenses/index.js",
+    "module": "../es/licenses/index.js",
+    "types": "../lib/licenses/index.d.ts"
+  }
 }
-    
+

--- a/packages/ndla-icons/package.json
+++ b/packages/ndla-icons/package.json
@@ -3,10 +3,11 @@
   "version": "6.0.0",
   "description": "A package containing icons used in NDLA frontends",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "sideEffects": false,
-  "types": "lib/index.d.ts",
   "scripts": {
     "build": "node ../../scripts/build.js package",
     "build:types": "tsc -p tsconfig.build.json",
@@ -39,7 +40,11 @@
     "react": ">= 16.8.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/ndla-image-search/package.json
+++ b/packages/ndla-image-search/package.json
@@ -3,9 +3,10 @@
   "version": "7.0.2",
   "description": "A simple library for searching images from NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "scripts": {
     "build": "node ../../scripts/build.js package",
     "build:types": "tsc -p tsconfig.build.json",
@@ -49,7 +50,11 @@
     "react-router-dom": ">= 6.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "ebeb8a1d86cba369e1156719ebaecb58a6e2cdfc"
 }

--- a/packages/ndla-licenses/package.json
+++ b/packages/ndla-licenses/package.json
@@ -3,9 +3,10 @@
   "version": "7.2.5",
   "description": "A simple library for retrieving license information for NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "scripts": {
     "build": "node ../../scripts/build.js package",
     "build:types": "tsc -p tsconfig.build.json",
@@ -25,7 +26,11 @@
     "es"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/ndla-modal/package.json
+++ b/packages/ndla-modal/package.json
@@ -3,9 +3,10 @@
   "version": "5.0.35",
   "description": "A smart Modal NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "sideEffects": false,
   "scripts": {
     "build": "node ../../scripts/build.js package",
@@ -37,7 +38,11 @@
     "react-i18next": "^13.3.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/ndla-notion/package.json
+++ b/packages/ndla-notion/package.json
@@ -3,9 +3,10 @@
   "version": "6.0.36",
   "description": "Notions and dictionary-notions for NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "Types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "sideEffects": false,
   "scripts": {
     "build": "node ../../scripts/build.js package",
@@ -37,7 +38,11 @@
     "react-i18next": "^13.3.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/ndla-pager/package.json
+++ b/packages/ndla-pager/package.json
@@ -3,9 +3,10 @@
   "version": "3.0.0",
   "description": "Pager component for NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "sideEffects": false,
   "scripts": {
     "build": "node ../../scripts/build.js package",
@@ -35,7 +36,11 @@
     "react": ">= 16.8.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "module",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/ndla-tabs/package.json
+++ b/packages/ndla-tabs/package.json
@@ -3,9 +3,10 @@
   "version": "4.0.0",
   "description": "React Tabs component for NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "sideEffects": false,
   "scripts": {
     "build": "node ../../scripts/build.js package",
@@ -36,7 +37,11 @@
     "@radix-ui/react-tabs": "^1.0.4"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/ndla-tracker/package.json
+++ b/packages/ndla-tracker/package.json
@@ -3,9 +3,10 @@
   "version": "5.0.6",
   "description": "A simple library for tracking NDLA applications",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "sideEffects": false,
   "scripts": {
     "build": "node ../../scripts/build.js package",
@@ -33,7 +34,11 @@
     "react-router-dom": ">= 5.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "dependencies": {
     "@ndla/util": "^4.0.4",

--- a/packages/ndla-ui/package.json
+++ b/packages/ndla-ui/package.json
@@ -3,9 +3,10 @@
   "version": "50.12.1",
   "description": "UI component library for NDLA.",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "sideEffects": false,
   "scripts": {
     "build": "node ../../scripts/build.js package",
@@ -79,7 +80,11 @@
     "webpack-cli": "^5.0.1"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "ebeb8a1d86cba369e1156719ebaecb58a6e2cdfc"
 }

--- a/packages/ndla-video-search/package.json
+++ b/packages/ndla-video-search/package.json
@@ -3,9 +3,10 @@
   "version": "6.0.1",
   "description": "A simple library for searching NDLA videos",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "scripts": {
     "build": "node ../../scripts/build.js package",
     "build:types": "tsc -p tsconfig.build.json",
@@ -43,7 +44,11 @@
     "@ndla/util": "^4.0.4"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/safelink/package.json
+++ b/packages/safelink/package.json
@@ -3,8 +3,10 @@
   "version": "5.0.0",
   "description": "SafeLink component for NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
+  "type": "module",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "sideEffects": false,
   "scripts": {
     "build": "node ../../scripts/build.js package",
@@ -36,7 +38,11 @@
     "react-router-dom": "^6.3.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -3,9 +3,10 @@
   "version": "3.3.10",
   "description": "Select component library for NDLA.",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "types": "src/index.ts",
+  "type": "module",
   "sideEffects": false,
   "scripts": {
     "build": "node ../../scripts/build.js package",
@@ -37,7 +38,11 @@
     "react-i18next": "^13.3.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "f767a48efedffff1904be8bfb39097d6bc6eba6f"
 }

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -4,9 +4,10 @@
   "description": "Switch button for NDLA",
   "license": "GPL-3.0",
   "sideEffects": false,
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "type": "module",
   "scripts": {
     "build": "node ../../scripts/build.js package",
     "build:types": "tsc -p tsconfig.build.json",
@@ -36,7 +37,11 @@
     "react-dom": ">= 16.8.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -3,9 +3,10 @@
   "version": "7.0.0",
   "description": "Tooltip component from NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "types": "src/index.ts",
+  "type": "module",
   "sideEffects": false,
   "scripts": {
     "build": "node ../../scripts/build.js package",
@@ -37,7 +38,11 @@
     "react-i18next": "^13.3.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   },
   "gitHead": "c2e2628a2dddfcca03f25548474243ffcd13595e"
 }

--- a/packages/types-embed/package.json
+++ b/packages/types-embed/package.json
@@ -3,7 +3,8 @@
   "version": "4.1.1",
   "description": "Types used for NDLA embeds",
   "license": "GPL-3.0",
-  "types": "lib/index.d.ts",
+  "types": "src/index.ts",
+  "type": "module",
   "scripts": {
     "build:types": "tsc -p tsconfig.build.json",
     "prepublish": "tsc -p tsconfig.build.json"
@@ -27,6 +28,8 @@
     "@ndla/types-taxonomy": "^1.0.22"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "types": "lib/index.d.ts"
   }
 }

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -3,9 +3,10 @@
   "version": "0.4.14",
   "description": "Typography components library for NDLA.",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "types": "src/index.ts",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "type": "module",
   "sideEffects": false,
   "scripts": {
     "build": "node ../../scripts/build.js package",
@@ -34,6 +35,10 @@
     "react": ">= 16.8.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "type": "commonjs",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   }
 }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -3,9 +3,16 @@
   "version": "4.0.4",
   "description": "Collection of util functions used by NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "types": "src/index.ts",
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "require": "./src/index.ts"
+    }
+  },
   "sideEffects": false,
   "scripts": {
     "build": "node ../../scripts/build.js package",
@@ -22,6 +29,7 @@
   ],
   "author": "ndla@knowit.no",
   "files": [
+    "src",
     "lib",
     "es",
     "types"
@@ -30,6 +38,10 @@
     "react": ">= 16.8.0"
   },
   "publishConfig": {
-    "access": "public"
+    "type": "commonjs",
+    "access": "public",
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "types": "lib/index.d.ts"
   }
 }


### PR DESCRIPTION
God aften.

Fikk en litt kul idé om å få til linking uten å trenge å måtte kjøre opp frontend-packages. Den er kanskje litt sinnsyk, og forblir derfor draft inntil videre. Testene feiler fordi jeg ikke har lagt inn noe innsats for å få ting til å kjøre som ESM.

Man må ha litt kunnskap om hvordan package resolution og `package.json` funker, så det kommer nå. Hvis dere kan noe om det fra før av er det bare å hoppe over dette:

I `package.json` er det tre (egentlig fire/fem) felter som avgjør hvor man faktisk importerer kode fra. 
* "main": Brukes tradisjonelt sett av node for å hente ut kode på `CommonJS`-format (tenk module.exports)
* "module": Brukes av nettlesere, og til en viss grad node (tenk export {something}). 
* "types": TypeScript-greier. 

Når vi linker inn pakker vanligvis vil dette si at vi tar i bruk kode som ligger i `main` og `module`, som peker til `/lib/index.js` og `es/index.js`. Hva om vi bare pekte til `src/index.ts` istedenfor? Det funker som et skudd... ish.

`package.json` har også feltet `publishConfig`, som lar en gjøre endringer til en `package.json`-fil i øyeblikket den publiseres. Det vil si at vi kan endre på verdiene til `main`, `module` og `types` når vi publiserer en pakke. Da kan vi peke på kompilert kode når vi ikke linker.

Det finnes dessverre noen ulemper med denne fremgangsmåten:
* Vi må transpilere mer data. Man merker at sidelasting er tregere når man har lenket inn pakker i større grad enn man gjorde før. Vil tro dette er mest merkbart i ED.
* Vi må ha en `css`-fil for "linked" og "unlinked" i hver frontend.
* Det er en viss fare for at `publishConfig` ikke støtter alle feltene vi definerer der. Det avhenger litt av hvilket verktøy man bruker. Jeg vet ikke helt om yarn støtter alle våre.

Jeg tror egentlig ikke at dette er noe vi har veldig lyst til å gå for. Men kanskje noen mener noe annet? Dette er blant annet en grei indikator på monorepo-ytelse.