### PR TITLE
Support unavailable resources

### DIFF
--- a/packages/ndla-ui/src/ContentTypeBadge/ContentTypeBadge.tsx
+++ b/packages/ndla-ui/src/ContentTypeBadge/ContentTypeBadge.tsx
@@ -35,7 +35,7 @@ interface Props extends ComponentProps<"div"> {
   background?: boolean;
   border?: boolean;
   className?: string;
-  isAvailable: boolean;
+  isAvailable?: boolean;
 }
 
 const sizes = {
@@ -169,7 +169,7 @@ export const ContentTypeBadge = ({
   size = "small",
   border = true,
   className,
-  isAvailable,
+  isAvailable = true,
   ...rest
 }: Props) => {
   const { Icon, style } = useMemo(() => {

--- a/packages/ndla-ui/src/ContentTypeBadge/ContentTypeBadge.tsx
+++ b/packages/ndla-ui/src/ContentTypeBadge/ContentTypeBadge.tsx
@@ -35,7 +35,6 @@ interface Props extends ComponentProps<"div"> {
   background?: boolean;
   border?: boolean;
   className?: string;
-  isAvailable?: boolean;
 }
 
 const sizes = {
@@ -160,6 +159,11 @@ const iconMap = {
     iconColor: colors.brand.grey,
     backgroundColor: colors.brand.greyLight,
   },
+  [contentTypes.MISSING]: {
+    icon: Minus,
+    iconColor: colors.brand.grey,
+    backgroundColor: colors.brand.greyLight,
+  },
 } as const;
 
 export const ContentTypeBadge = ({
@@ -169,19 +173,16 @@ export const ContentTypeBadge = ({
   size = "small",
   border = true,
   className,
-  isAvailable = true,
   ...rest
 }: Props) => {
   const { Icon, style } = useMemo(() => {
     const fromMap = iconMap[type];
-    const style = isAvailable
-      ? {
-          "--icon-color": fromMap.iconColor,
-          "--background-color": fromMap.backgroundColor,
-        }
-      : { "--icon-color": colors.brand.grey, "--background-color": colors.brand.greyLight };
-    return { Icon: isAvailable ? fromMap.icon : Minus, style: style as CSSProperties };
-  }, [isAvailable, type]);
+    const style = {
+      "--icon-color": fromMap.iconColor,
+      "--background-color": fromMap.backgroundColor,
+    } as CSSProperties;
+    return { Icon: fromMap.icon, style };
+  }, [type]);
 
   const cssStyles = useMemo(() => {
     const styles = [sizes[size]];

--- a/packages/ndla-ui/src/ContentTypeBadge/ContentTypeBadge.tsx
+++ b/packages/ndla-ui/src/ContentTypeBadge/ContentTypeBadge.tsx
@@ -11,7 +11,7 @@ import { CSSProperties, ComponentProps, useMemo } from "react";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { breakpoints, colors, mq } from "@ndla/core";
-import { MenuBook } from "@ndla/icons/action";
+import { Minus, MenuBook } from "@ndla/icons/action";
 import { Audio } from "@ndla/icons/common";
 import {
   AssessmentResource,
@@ -35,6 +35,7 @@ interface Props extends ComponentProps<"div"> {
   background?: boolean;
   border?: boolean;
   className?: string;
+  isAvailable: boolean;
 }
 
 const sizes = {
@@ -168,16 +169,19 @@ export const ContentTypeBadge = ({
   size = "small",
   border = true,
   className,
+  isAvailable,
   ...rest
 }: Props) => {
   const { Icon, style } = useMemo(() => {
     const fromMap = iconMap[type];
-    const style = {
-      "--icon-color": fromMap.iconColor,
-      "--background-color": fromMap.backgroundColor,
-    } as CSSProperties;
-    return { Icon: fromMap.icon, style };
-  }, [type]);
+    const style = isAvailable
+      ? {
+          "--icon-color": fromMap.iconColor,
+          "--background-color": fromMap.backgroundColor,
+        }
+      : { "--icon-color": colors.brand.grey, "--background-color": colors.brand.greyLight };
+    return { Icon: isAvailable ? fromMap.icon : Minus, style: style as CSSProperties };
+  }, [isAvailable, type]);
 
   const cssStyles = useMemo(() => {
     const styles = [sizes[size]];

--- a/packages/ndla-ui/src/Resource/BlockResource.stories.tsx
+++ b/packages/ndla-ui/src/Resource/BlockResource.stories.tsx
@@ -73,7 +73,6 @@ export const WithMenu: StoryObj<typeof BlockResource> = {
 export const WithUnavailableResource: StoryObj<typeof BlockResource> = {
   args: {
     title: "Ressurs ikke tilgjengelig",
-    isAvailable: false,
     resourceTypes: [],
     resourceImage: { src: "", alt: "" },
   },

--- a/packages/ndla-ui/src/Resource/BlockResource.stories.tsx
+++ b/packages/ndla-ui/src/Resource/BlockResource.stories.tsx
@@ -70,6 +70,15 @@ export const WithMenu: StoryObj<typeof BlockResource> = {
   },
 };
 
+export const WithUnavailableResource: StoryObj<typeof BlockResource> = {
+  args: {
+    title: "Ressurs ikke tilgjengelig",
+    isAvailable: false,
+    resourceTypes: [],
+    resourceImage: { src: "", alt: "" },
+  },
+};
+
 export const Loading: StoryObj<typeof BlockResource> = {
   args: {
     isLoading: true,

--- a/packages/ndla-ui/src/Resource/BlockResource.tsx
+++ b/packages/ndla-ui/src/Resource/BlockResource.tsx
@@ -101,11 +101,12 @@ const ImageWrapper = styled.div`
 
 interface BlockImageProps {
   image: ResourceImageProps;
+  isAvailable: boolean;
   loading?: boolean;
   contentType: string;
 }
 
-const BlockImage = ({ image, loading, contentType }: BlockImageProps) => {
+const BlockImage = ({ image, isAvailable, loading, contentType }: BlockImageProps) => {
   if (loading) {
     return (
       <ContentLoader height={"100%"} width={"100%"} viewBox={null} preserveAspectRatio="none">
@@ -115,8 +116,8 @@ const BlockImage = ({ image, loading, contentType }: BlockImageProps) => {
   }
   if (image.src === "") {
     return (
-      <ContentIconWrapper contentType={contentType}>
-        <ContentTypeBadge type={contentType} size="large" />
+      <ContentIconWrapper contentType={contentType} isAvailable={isAvailable}>
+        <ContentTypeBadge type={contentType} size="large" isAvailable={isAvailable} />
       </ContentIconWrapper>
     );
   } else {
@@ -172,6 +173,7 @@ const BlockResource = ({
     <BlockElementWrapper id={id}>
       <ImageWrapper>
         <BlockImage
+          isAvailable={isAvailable}
           image={resourceImage}
           loading={isLoading}
           contentType={

--- a/packages/ndla-ui/src/Resource/BlockResource.tsx
+++ b/packages/ndla-ui/src/Resource/BlockResource.tsx
@@ -142,6 +142,7 @@ interface Props {
   link: string;
   tagLinkPrefix?: string;
   title: string;
+  titleWarning?: boolean;
   resourceImage: ResourceImageProps;
   tags?: string[];
   description?: string;
@@ -156,6 +157,7 @@ const BlockResource = ({
   link,
   tagLinkPrefix,
   title,
+  titleWarning,
   tags,
   resourceImage,
   description,
@@ -182,7 +184,13 @@ const BlockResource = ({
       <BlockInfoWrapper>
         <ContentWrapper>
           <ResourceTypeAndTitleLoader loading={isLoading}>
-            <ResourceTitleLink data-link="" title={title} target={targetBlank ? "_blank" : undefined} to={link}>
+            <ResourceTitleLink
+              data-warning={titleWarning}
+              data-link=""
+              title={title}
+              target={targetBlank ? "_blank" : undefined}
+              to={link}
+            >
               <Text element="span" textStyle="label-small" css={resourceHeadingStyle}>
                 {title}
               </Text>

--- a/packages/ndla-ui/src/Resource/BlockResource.tsx
+++ b/packages/ndla-ui/src/Resource/BlockResource.tsx
@@ -142,7 +142,6 @@ interface Props {
   link: string;
   tagLinkPrefix?: string;
   title: string;
-  titleWarning?: boolean;
   resourceImage: ResourceImageProps;
   tags?: string[];
   description?: string;
@@ -150,6 +149,7 @@ interface Props {
   isLoading?: boolean;
   targetBlank?: boolean;
   resourceTypes?: { id: string; name: string }[];
+  isAvailable?: boolean;
 }
 
 const BlockResource = ({
@@ -157,7 +157,6 @@ const BlockResource = ({
   link,
   tagLinkPrefix,
   title,
-  titleWarning,
   tags,
   resourceImage,
   description,
@@ -165,6 +164,7 @@ const BlockResource = ({
   isLoading,
   targetBlank,
   resourceTypes,
+  isAvailable = true,
 }: Props) => {
   const firstResourceType = resourceTypes?.[0]?.id ?? "";
 
@@ -185,7 +185,7 @@ const BlockResource = ({
         <ContentWrapper>
           <ResourceTypeAndTitleLoader loading={isLoading}>
             <ResourceTitleLink
-              data-warning={titleWarning}
+              data-resource-available={isAvailable}
               data-link=""
               title={title}
               target={targetBlank ? "_blank" : undefined}

--- a/packages/ndla-ui/src/Resource/ListResource.stories.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.stories.tsx
@@ -71,6 +71,15 @@ export const WithMenu: StoryObj<typeof ListResource> = {
   },
 };
 
+export const WithUnavailableResource: StoryObj<typeof ListResource> = {
+  args: {
+    title: "Ressurs ikke tilgjengelig",
+    isAvailable: false,
+    resourceTypes: [],
+    resourceImage: { src: "", alt: "" },
+  },
+};
+
 export const Loading: StoryObj<typeof ListResource> = {
   args: {
     isLoading: true,

--- a/packages/ndla-ui/src/Resource/ListResource.stories.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.stories.tsx
@@ -74,7 +74,6 @@ export const WithMenu: StoryObj<typeof ListResource> = {
 export const WithUnavailableResource: StoryObj<typeof ListResource> = {
   args: {
     title: "Ressurs ikke tilgjengelig",
-    isAvailable: false,
     resourceTypes: [],
     resourceImage: { src: "", alt: "" },
   },

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -201,7 +201,6 @@ export interface ListResourceProps {
   link: string;
   tagLinkPrefix?: string;
   title: string;
-  titleWarning?: boolean;
   resourceImage: ResourceImageProps;
   resourceTypes: { id: string; name: string }[];
   tags?: string[];
@@ -209,6 +208,7 @@ export interface ListResourceProps {
   menu?: ReactNode;
   isLoading?: boolean;
   targetBlank?: boolean;
+  isAvailable?: boolean;
 }
 
 const ListResource = ({
@@ -216,7 +216,6 @@ const ListResource = ({
   link,
   tagLinkPrefix,
   title,
-  titleWarning,
   tags,
   resourceImage,
   resourceTypes,
@@ -224,6 +223,7 @@ const ListResource = ({
   menu,
   isLoading = false,
   targetBlank,
+  isAvailable = true,
 }: ListResourceProps) => {
   const showDescription = description !== undefined;
   const imageType = showDescription ? "normal" : "compact";
@@ -243,7 +243,12 @@ const ListResource = ({
       </ImageWrapper>
       <TopicAndTitleWrapper>
         <TypeAndTitleLoader loading={isLoading}>
-          <StyledLink to={link} data-warning={titleWarning} data-link="" target={targetBlank ? "_blank" : undefined}>
+          <StyledLink
+            to={link}
+            data-resource-available={isAvailable}
+            data-link=""
+            target={targetBlank ? "_blank" : undefined}
+          >
             <Text element="span" textStyle="label-small" css={resourceHeadingStyle} title={title}>
               {title}
             </Text>

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -201,6 +201,7 @@ export interface ListResourceProps {
   link: string;
   tagLinkPrefix?: string;
   title: string;
+  titleWarning?: boolean;
   resourceImage: ResourceImageProps;
   resourceTypes: { id: string; name: string }[];
   tags?: string[];
@@ -215,6 +216,7 @@ const ListResource = ({
   link,
   tagLinkPrefix,
   title,
+  titleWarning,
   tags,
   resourceImage,
   resourceTypes,
@@ -241,7 +243,7 @@ const ListResource = ({
       </ImageWrapper>
       <TopicAndTitleWrapper>
         <TypeAndTitleLoader loading={isLoading}>
-          <StyledLink to={link} data-link="" target={targetBlank ? "_blank" : undefined}>
+          <StyledLink to={link} data-warning={titleWarning} data-link="" target={targetBlank ? "_blank" : undefined}>
             <Text element="span" textStyle="label-small" css={resourceHeadingStyle} title={title}>
               {title}
             </Text>

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -128,18 +128,26 @@ const TopicAndTitleWrapper = styled.div`
 
 interface ListResourceImageProps {
   resourceImage: ResourceImageProps;
+  isAvailable: boolean;
   loading?: boolean;
   type: "normal" | "compact";
   contentType: string;
   background?: boolean;
 }
 
-const ListResourceImage = ({ resourceImage, loading, type, contentType, background }: ListResourceImageProps) => {
+const ListResourceImage = ({
+  resourceImage,
+  isAvailable,
+  loading,
+  type,
+  contentType,
+  background,
+}: ListResourceImageProps) => {
   if (!loading) {
     if (resourceImage.src === "") {
       return (
-        <ContentIconWrapper contentType={contentType}>
-          <ContentTypeBadge type={contentType} background={background} size="x-small" />
+        <ContentIconWrapper contentType={contentType} isAvailable={isAvailable}>
+          <ContentTypeBadge type={contentType} background={background} size="x-small" isAvailable={isAvailable} />
         </ContentIconWrapper>
       );
     } else {
@@ -235,6 +243,7 @@ const ListResource = ({
       <ImageWrapper imageSize={imageType} data-image-size={imageType}>
         <ListResourceImage
           resourceImage={resourceImage}
+          isAvailable={isAvailable}
           loading={isLoading}
           type={imageType}
           background={!!embedResourceType}

--- a/packages/ndla-ui/src/Resource/resourceComponents.tsx
+++ b/packages/ndla-ui/src/Resource/resourceComponents.tsx
@@ -27,6 +27,9 @@ export const ResourceTitleLink = styled(SafeLink)`
   box-shadow: none;
   color: ${colors.brand.primary};
   flex: 1;
+  &[data-warning="true"] {
+    color: ${colors.support.red};
+  }
   :after {
     content: "";
     position: absolute;

--- a/packages/ndla-ui/src/Resource/resourceComponents.tsx
+++ b/packages/ndla-ui/src/Resource/resourceComponents.tsx
@@ -27,8 +27,9 @@ export const ResourceTitleLink = styled(SafeLink)`
   box-shadow: none;
   color: ${colors.brand.primary};
   flex: 1;
-  &[data-warning="true"] {
-    color: ${colors.support.red};
+  &[data-resource-available="false"] {
+    color: ${colors.brand.grey};
+    font-style: italic;
   }
   :after {
     content: "";

--- a/packages/ndla-ui/src/Resource/resourceComponents.tsx
+++ b/packages/ndla-ui/src/Resource/resourceComponents.tsx
@@ -122,6 +122,7 @@ const TagCounterWrapper = styled.span`
 interface ContentIconProps extends HTMLAttributes<HTMLSpanElement> {
   contentType: string;
   children?: ReactNode;
+  isAvailable: boolean;
 }
 
 const StyledContentIconWrapper = styled.span`
@@ -133,13 +134,13 @@ const StyledContentIconWrapper = styled.span`
   background-color: var(--content-background-color);
 `;
 
-export const ContentIconWrapper = ({ contentType, children, ...props }: ContentIconProps) => {
+export const ContentIconWrapper = ({ contentType, children, isAvailable, ...props }: ContentIconProps) => {
   const contentIconWrapperVars = useMemo(
     () =>
       ({
-        "--content-background-color": resourceTypeColor(contentType),
+        "--content-background-color": isAvailable ? resourceTypeColor(contentType) : colors.brand.greyLight,
       }) as unknown as CSSProperties,
-    [contentType],
+    [contentType, isAvailable],
   );
   return (
     <StyledContentIconWrapper {...props} style={contentIconWrapperVars}>

--- a/packages/ndla-ui/src/Resource/resourceComponents.tsx
+++ b/packages/ndla-ui/src/Resource/resourceComponents.tsx
@@ -122,7 +122,6 @@ const TagCounterWrapper = styled.span`
 interface ContentIconProps extends HTMLAttributes<HTMLSpanElement> {
   contentType: string;
   children?: ReactNode;
-  isAvailable: boolean;
 }
 
 const StyledContentIconWrapper = styled.span`
@@ -134,13 +133,13 @@ const StyledContentIconWrapper = styled.span`
   background-color: var(--content-background-color);
 `;
 
-export const ContentIconWrapper = ({ contentType, children, isAvailable, ...props }: ContentIconProps) => {
+export const ContentIconWrapper = ({ contentType, children, ...props }: ContentIconProps) => {
   const contentIconWrapperVars = useMemo(
     () =>
       ({
-        "--content-background-color": isAvailable ? resourceTypeColor(contentType) : colors.brand.greyLight,
+        "--content-background-color": resourceTypeColor(contentType),
       }) as unknown as CSSProperties,
-    [contentType, isAvailable],
+    [contentType],
   );
   return (
     <StyledContentIconWrapper {...props} style={contentIconWrapperVars}>

--- a/packages/ndla-ui/src/utils/resourceTypeColor.tsx
+++ b/packages/ndla-ui/src/utils/resourceTypeColor.tsx
@@ -36,6 +36,8 @@ export const resourceTypeColor = (type: string) => {
     case resourceEmbedTypeMapping.concept:
     case resourceEmbedTypeMapping.audio:
       return colors.brand.greyLight;
+    case contentTypes.MISSING:
+      return colors.brand.greyLight;
     default:
       return "";
   }


### PR DESCRIPTION
Støtte for et ekstra attributt på resources, slik at resources som ikke er tilgjengelig kan få en grå og kursiv tekst med en fallbacktekst:
<img width="1097" alt="image" src="https://github.com/NDLANO/frontend-packages/assets/33912044/8d6213f3-09db-4c83-8f92-ad469eefd552">

Per i dag blir ressursen bare "tom" dersom noe mangler. NDLA har ønsket en fallback-melding dersom den er slettet for å gjøre det mer synlig (https://trello.com/c/kQTBtTTp/771-delt-mappe-siden-finnes-ikke). Vi fjerner ressursen helt den delte mappa, men inne i selve mappa, synliggjør vi med fallbackmelding. Fallback-meldingen i seg selv, når skrift ellers ikke skiller seg særlig ut, gjør egentlig dette mindre synlig. Håpet er at dette tydeliggjør litt mer at det er noe spesielt (altså, at ressursen faktisk er utilgjengelig)