### PR TITLE
Parse link block title as html. Remove language from embed types

### DIFF
--- a/packages/article-converter/src/plugins/embed/linkBlockEmbedPlugin.tsx
+++ b/packages/article-converter/src/plugins/embed/linkBlockEmbedPlugin.tsx
@@ -15,5 +15,5 @@ export const linkBlockPlugin: PluginType = (element, _, opts) => {
   const props = attributesToProps(element.attribs);
   const data = JSON.parse(props["data-json"] as string) as LinkBlockMetaData;
 
-  return <LinkBlock {...data.embedData} path={opts.path} />;
+  return <LinkBlock {...data.embedData} path={opts.path} articleLanguage={opts.articleLanguage} />;
 };

--- a/packages/ndla-ui/src/LinkBlock/LinkBlock.stories.tsx
+++ b/packages/ndla-ui/src/LinkBlock/LinkBlock.stories.tsx
@@ -22,8 +22,8 @@ export default {
 } as Meta<typeof LinkBlock>;
 
 const args = {
-  title: "Redaksjonell medarbeider i faget spansk 2",
-  language: "nb",
+  title: "Redaksjonell <em>medarbeider</em> i faget spansk 2",
+  articleLanguage: "nb",
   date: "05. mars 2023",
   url: "",
 };

--- a/packages/ndla-ui/src/LinkBlock/LinkBlock.tsx
+++ b/packages/ndla-ui/src/LinkBlock/LinkBlock.tsx
@@ -8,6 +8,7 @@
 
 import { format } from "date-fns";
 import { enGB, nb, nn } from "date-fns/locale";
+import parse from "html-react-parser";
 import { useMemo } from "react";
 import styled from "@emotion/styled";
 import { breakpoints, colors, spacing, mq } from "@ndla/core";
@@ -75,20 +76,21 @@ const StyledCalenderEd = styled(CalendarEd)`
 
 interface Props extends Omit<LinkBlockEmbedData, "resource"> {
   path?: string;
+  articleLanguage?: string;
 }
 
-const LinkBlock = ({ title, language, date, url, path }: Props) => {
+const LinkBlock = ({ title, articleLanguage, date, url, path }: Props) => {
   const href = getPossiblyRelativeUrl(url, path);
   const formattedDate = useMemo(() => {
     if (!date) return null;
-    const locale = language === "nb" ? nb : language === "nn" ? nn : enGB;
+    const locale = articleLanguage === "nb" ? nb : articleLanguage === "nn" ? nn : enGB;
     return format(new Date(date), "dd. LLLL yyyy", { locale });
-  }, [date, language]);
+  }, [date, articleLanguage]);
   return (
     <StyledSafeLink to={href}>
       <InfoWrapper>
-        <Heading element="h3" margin="none" headingStyle="h3" lang={language === "nb" ? "no" : language}>
-          {title}
+        <Heading element="h3" margin="none" headingStyle="h3">
+          {parse(title)}
         </Heading>
         {date && (
           <StyledDateContainer>

--- a/packages/types-embed/src/linkBlockTypes.ts
+++ b/packages/types-embed/src/linkBlockTypes.ts
@@ -11,7 +11,6 @@ import { MetaData } from ".";
 export interface LinkBlockEmbedData {
   resource: "link-block";
   title: string;
-  language: string;
   date: string;
   url: string;
 }


### PR DESCRIPTION
https://github.com/NDLANO/Issues/issues/3976
Krever vel en migrering i backend? Usikker på hva den beste måten å gjøre det på er... Fjerne språk og ignorere at det noensinne har blitt satt, eller konvertere `${TITLE}` til `<span lang="nn">${TITLE}</span>`?