### PR TITLE
added margin similar to ul

### DIFF
--- a/packages/ndla-ui/src/List/OrderedList.tsx
+++ b/packages/ndla-ui/src/List/OrderedList.tsx
@@ -114,8 +114,7 @@ const StyledOl = styled.ol`
   padding: 0;
   list-style-type: none;
   counter-reset: level1;
-
-  margin-left: ${spacing.normal};
+  margin: ${spacing.normal} 0 ${spacing.normal} ${spacing.normal};
 
   > li {
     margin-top: ${spacing.nsmall};


### PR DESCRIPTION
[Trello](https://trello.com/c/Iuj7CA7M/735-manglende-padding-etter-lister)

Gammel sak, men det ser ut som _ul_ og _ol_ har forskjellig margins som gjør at vi får mangel på spacing under _ol_'s og andre elementer. Legger til margin for å matche _ul_ elementet

Kan testes: [localhost](http://localhost:3000/subject:1:51a7271b-a9d5-4205-bade-1c125a8650b5/topic:2:a4bf97c3-9daf-4587-bc9f-822855432151/topic:1:ffac3f03-e3d0-4ac2-ace3-a83ad8cdbfc1/resource:1:19085)