### PR TITLE
Make input and Select buttons more consistent

### DIFF
--- a/packages/ndla-forms/src/InputV3.tsx
+++ b/packages/ndla-forms/src/InputV3.tsx
@@ -27,16 +27,16 @@ interface InputContextType {}
 const InputContext = createContext<InputContextType | undefined>(undefined);
 
 const inputCss = css`
-  border: 1px solid ${colors.brand.grey};
+  outline: 1px solid ${colors.brand.grey};
   background: ${colors.brand.greyLightest};
-  transition-duration: border-width 100ms ease;
   border-radius: ${misc.borderRadius};
   min-height: ${spacing.large};
   padding: 0px ${spacing.small};
 
   &:focus-within {
-    border-width: 2px;
-    border-color: ${colors.brand.primary};
+    outline-width: 2px;
+    outline-offset: -1px;
+    outline-color: ${colors.brand.primary};
   }
 `;
 
@@ -63,6 +63,7 @@ export const InputContainer = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivE
 const baseInputCss = css`
   width: 100%;
   color: ${colors.text.primary};
+  outline: none;
   background: none;
   border: 0;
   &:disabled {
@@ -70,7 +71,6 @@ const baseInputCss = css`
   }
   &:focus {
     appearance: none;
-    outline: none;
   }
 `;
 

--- a/packages/ndla-forms/src/Select.tsx
+++ b/packages/ndla-forms/src/Select.tsx
@@ -48,8 +48,10 @@ const StyledSelect = styled.select`
   overflow: hidden;
   text-overflow: ellipsis;
   padding-right: 40px;
+  outline: 1px solid ${colors.brand.lighter};
 
   &:focus-within {
+    outline-offset: -1px;
     outline: 2px solid ${colors.brand.dark};
   }
 `;


### PR DESCRIPTION
Select og Input er nå akkurat like høye, uavhengig av fokus-status og sånt. Dette sørger også for at Input ikke krymper bittelitt når den får fokus.