### PR TITLE
Adding margin to neighbouring elements

### DIFF
--- a/packages/ndla-ui/src/BlogPost/BlogPost.tsx
+++ b/packages/ndla-ui/src/BlogPost/BlogPost.tsx
@@ -29,6 +29,7 @@ export interface Props {
 }
 
 const Container = styled(SafeLink)`
+  margin: ${spacing.normal} 0;
   display: flex;
   flex-direction: column;
   color: ${colors.text.primary};

--- a/packages/ndla-ui/src/BlogPost/BlogPost.tsx
+++ b/packages/ndla-ui/src/BlogPost/BlogPost.tsx
@@ -29,7 +29,7 @@ export interface Props {
 }
 
 const Container = styled(SafeLink)`
-  margin: ${spacing.normal} 0;
+  margin: 0 0 ${spacing.normal} 0;
   display: flex;
   flex-direction: column;
   color: ${colors.text.primary};


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3986

Ser ut som manglende margin oppstår når andre elementer enn video (f.eks. bilde) følger også, så har lagt på en generell margin under blogposts.