### PR TITLE
Remove `ariaHidden` and `color` props from base Icon. 

### DIFF
--- a/packages/ndla-howto/src/ArticleInModal.tsx
+++ b/packages/ndla-howto/src/ArticleInModal.tsx
@@ -30,7 +30,7 @@ const Content = ({ pageId }: ModalContentProps) => {
     <Wrapper>
       <div>
         <InModalHeader>
-          <InformationOutline size="large" color={colors.brand.primary} style={{ position: "absolute" }} />
+          <InformationOutline size="large" style={{ position: "absolute", color: colors.brand.primary }} />
           <Heading id={headingId} inModal>
             {useStory.title}
           </Heading>

--- a/packages/ndla-icons/src/Icon.tsx
+++ b/packages/ndla-icons/src/Icon.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { ReactNode, SVGAttributes, useMemo } from "react";
+import { ReactNode, SVGAttributes } from "react";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { spacing } from "@ndla/core";
@@ -16,7 +16,6 @@ export interface Props extends SVGAttributes<SVGSVGElement> {
   description?: string;
   children?: ReactNode;
   size?: keyof typeof sizes;
-  ariaHidden?: boolean;
 }
 
 const StyledIcon = styled.svg`
@@ -52,19 +51,15 @@ const sizes = {
 
 const IconBase = ({
   children,
-  color,
   size = "nsmall",
-  style,
   role,
   title,
   description,
   width,
   height,
-  ariaHidden = true,
+  "aria-hidden": ariaHidden = true,
   ...props
 }: Props) => {
-  const styleObj = useMemo(() => ({ color, ...style }), [color, style]);
-
   return (
     <StyledIcon
       css={sizes[size]}
@@ -74,7 +69,6 @@ const IconBase = ({
       preserveAspectRatio="xMidYMid meet"
       role={role}
       {...props}
-      style={styleObj}
     >
       {title && <title>{title}</title>}
       {description && <desc>{description}</desc>}

--- a/packages/ndla-ui/src/ContactBlock/ContactBlock.tsx
+++ b/packages/ndla-ui/src/ContactBlock/ContactBlock.tsx
@@ -120,6 +120,10 @@ const blobStyling = css`
   width: 165px;
   height: 180px;
   transform: translate(10%, 0);
+  color: ${colors.support.redLight};
+  &[data-green="true"] {
+    color: ${colors.support.greenLight};
+  }
 `;
 const Email = styled.div`
   white-space: nowrap;
@@ -199,7 +203,7 @@ const ContactBlock = ({
             </StyledText>
           </InfoWrapper>
           <BlobWrapper>
-            <Blob css={blobStyling} color={isGreenBlob ? colors.support.greenLight : colors.support.redLight} />
+            <Blob css={blobStyling} data-green={isGreenBlob} />
           </BlobWrapper>
         </TextWrapper>
         <SummaryBlock>{description}</SummaryBlock>

--- a/packages/ndla-ui/src/Navigation/NavigationBox.tsx
+++ b/packages/ndla-ui/src/Navigation/NavigationBox.tsx
@@ -228,7 +228,7 @@ export const NavigationBox = ({
                   >
                     <StyledMarksWrapper>
                       {item.isAdditionalResource && (
-                        <StyledAdditional aria-label={t("resource.additionalTooltip")} ariaHidden={false} />
+                        <StyledAdditional aria-label={t("resource.additionalTooltip")} aria-hidden={false} />
                       )}
                       {item.isRestrictedResource && (
                         <StyledHumanBoardIconWrapper>

--- a/packages/ndla-ui/src/ResourceGroup/ResourceItem.tsx
+++ b/packages/ndla-ui/src/ResourceGroup/ResourceItem.tsx
@@ -211,6 +211,14 @@ const CurrentSmall = styled.small`
   }
 `;
 
+const StyledAdditional = styled(Additional)`
+  color: ${colors.brand.dark};
+`;
+
+const StyledCore = styled(Core)`
+  color: ${colors.brand.primary};
+`;
+
 interface Props {
   id: string;
   showContentTypeDescription?: boolean;
@@ -291,12 +299,12 @@ const ResourceItem = ({
           <>
             {additional && (
               <IconWrapper id={additionalId} aria-label={contentTypeDescription} title={contentTypeDescription}>
-                <Additional color={colors.brand.dark} size="normal" />
+                <StyledAdditional size="normal" />
               </IconWrapper>
             )}
             {!additional && (
               <IconWrapper id={coreId} aria-label={contentTypeDescription} title={contentTypeDescription}>
-                <Core color={colors.brand.primary} size="normal" />
+                <StyledCore size="normal" />
               </IconWrapper>
             )}
           </>

--- a/packages/ndla-ui/src/SearchTypeResult/components/ItemContexts.tsx
+++ b/packages/ndla-ui/src/SearchTypeResult/components/ItemContexts.tsx
@@ -50,6 +50,14 @@ const ContextListItem = styled.li`
   ${fonts.sizes("16px", "28px")};
 `;
 
+const StyledAdditional = styled(Additional)`
+  color: ${colors.brand.dark};
+`;
+
+const StyledCore = styled(Core)`
+  color: ${colors.brand.primary};
+`;
+
 type context = {
   breadcrumb: string[];
   url: string;
@@ -100,19 +108,13 @@ const ItemContexts = ({ contexts, id, title }: ItemContextsType) => {
                     <SafeLink to={context.url}>{title}</SafeLink>
                     <Breadcrumb breadcrumb={context.breadcrumb}>
                       {context.isAdditional ? (
-                        <Additional
+                        <StyledAdditional
                           size="normal"
-                          color={colors.brand.dark}
                           aria-label={t("resource.tooltipAdditionalTopic")}
-                          ariaHidden={false}
+                          aria-hidden={false}
                         />
                       ) : (
-                        <Core
-                          size="normal"
-                          color={colors.brand.primary}
-                          aria-label={t("resource.tooltipCoreTopic")}
-                          ariaHidden={false}
-                        />
+                        <StyledCore size="normal" aria-label={t("resource.tooltipCoreTopic")} aria-hidden={false} />
                       )}
                     </Breadcrumb>
                   </ContextListItem>


### PR DESCRIPTION
We should rely on `aria-hidden` and `style` or `class`.

Denne er strengt tatt litt breaking, men vil ikke påvirke oss.