### PR TITLE
Remove Aside styling props. They are only used in ways that doesn't alter the component.

### DIFF
--- a/packages/article-converter/src/plugins/asidePlugin.tsx
+++ b/packages/article-converter/src/plugins/asidePlugin.tsx
@@ -13,11 +13,7 @@ export const asidePlugin: PluginType = (node, opts) => {
   if (node.attribs["data-type"] === "factAside") {
     return <FactBox>{domToReact(node.children as DOMNode[], opts)}</FactBox>;
   } else if (node.attribs["data-type"] === "rightAside") {
-    return (
-      <Aside wideScreen alwaysShow>
-        {domToReact(node.children as DOMNode[], opts)}
-      </Aside>
-    );
+    return <Aside>{domToReact(node.children as DOMNode[], opts)}</Aside>;
   }
 
   return null;

--- a/packages/ndla-ui/src/Aside/Aside.tsx
+++ b/packages/ndla-ui/src/Aside/Aside.tsx
@@ -6,19 +6,13 @@
  *
  */
 
-import { ComponentProps, useMemo } from "react";
-import { css } from "@emotion/react";
+import { ComponentPropsWithoutRef } from "react";
 import styled from "@emotion/styled";
 import { breakpoints, colors, fonts, mq, spacing } from "@ndla/core";
 
-interface Props extends ComponentProps<"aside"> {
-  narrowScreen?: boolean;
-  wideScreen?: boolean;
-  alwaysShow?: boolean;
-}
-
 const StyledAside = styled.aside`
   position: relative;
+  display: block;
   margin: ${spacing.large} 0px;
   ${mq.range({ from: breakpoints.tablet })} {
     max-width: 350px;
@@ -34,23 +28,6 @@ const StyledAside = styled.aside`
   }
 
   border-left: 4px solid ${colors.background.dark};
-`;
-
-const wideScreenStyle = css`
-  display: none;
-  ${mq.range({ from: breakpoints.tablet })} {
-    display: block;
-  }
-`;
-
-const narrowScreenStyle = css`
-  ${mq.range({ from: breakpoints.tablet })} {
-    display: none;
-  }
-`;
-
-const alwaysShowStyle = css`
-  display: block !important;
 `;
 
 const StyledAsideContent = styled.div`
@@ -88,23 +65,9 @@ const StyledAsideContent = styled.div`
   }
 `;
 
-const Aside = ({ children, narrowScreen = false, wideScreen = false, alwaysShow = false, ...rest }: Props) => {
-  const styling = useMemo(() => {
-    const styles = [];
-    if (narrowScreen) {
-      styles.push(narrowScreenStyle);
-    }
-    if (wideScreen) {
-      styles.push(wideScreenStyle);
-    }
-    if (alwaysShow) {
-      styles.push(alwaysShowStyle);
-    }
-    return styles;
-  }, [alwaysShow, narrowScreen, wideScreen]);
-
+const Aside = ({ children, ...rest }: ComponentPropsWithoutRef<"aside">) => {
   return (
-    <StyledAside css={styling} {...rest}>
+    <StyledAside {...rest}>
       <StyledAsideContent>{children}</StyledAsideContent>
     </StyledAside>
   );


### PR DESCRIPTION
Er dette egentlig en komponent vi ønsker å fortsette å støtte? Ser ikke ut som at den brukes i nye artikler. Hadde det vært en tanke å fjerne denne fra gamle artikler?