### PR TITLE
minor typo - mapper

### DIFF
--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -1155,7 +1155,7 @@ const messages = {
       },
     },
     iconMenu: {
-      folders: "Mappar",
+      folders: "Mapper",
       tags: "Emneknaggar",
       subjects: "Favorittfag",
       profile: "Profil",


### PR DESCRIPTION
Bitteliten skrivefeil, vanskeleg å sjå. Mappar -> Mapper i menyen.