### PR TITLE
Add attribute to make messagebox noneditable

### DIFF
--- a/packages/ndla-ui/src/Embed/UuDisclaimerEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/UuDisclaimerEmbed.tsx
@@ -58,7 +58,7 @@ const UuDisclaimerEmbed = ({ embed, children }: Props) => {
 
   return (
     <DisclaimerWrapper role="region">
-      <StyledMessageBox type="info">
+      <StyledMessageBox type="info" contentEditable={false}>
         <InformationOutline />
         <Disclaimer>
           {embedData.disclaimer}

--- a/packages/ndla-ui/src/Messages/MessageBox.tsx
+++ b/packages/ndla-ui/src/Messages/MessageBox.tsx
@@ -27,6 +27,7 @@ interface MessageBoxProps {
   links?: LinkProps[];
   showCloseButton?: boolean;
   onClose?: () => void;
+  contentEditable?: boolean;
 }
 
 const MessageBoxWrapper = styled.div`
@@ -93,10 +94,10 @@ const StyledCloseButton = styled(IconButtonV2)`
   right: ${spacing.xsmall};
 `;
 
-export const MessageBox = ({ type, children, links, showCloseButton, onClose }: MessageBoxProps) => {
+export const MessageBox = ({ type, children, links, showCloseButton, onClose, contentEditable }: MessageBoxProps) => {
   const { t } = useTranslation();
   return (
-    <MessageBoxWrapper data-type={type}>
+    <MessageBoxWrapper data-type={type} contentEditable={contentEditable ?? undefined}>
       <InfoWrapper>
         <div>
           <ChildrenWrapper>{children}</ChildrenWrapper>


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/4040

Flytter contentEditable logikken til MessageBox istedetfor for hele embeden.