### PR TITLE
Adding fallback label for generic article

### DIFF
--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -547,6 +547,7 @@ const messages = {
     article: "Article",
     subject: "Subject",
     "topic-article": "Topic article",
+    learningpath: "Learning path",
     "learning-path": "Learning path",
     "subject-material": "Subject material",
     "tasks-and-activities": "Task and activities",

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -544,6 +544,7 @@ const messages = {
   },
   contentTypes: {
     all: "All",
+    article: "Article",
     subject: "Subject",
     "topic-article": "Topic article",
     "learning-path": "Learning path",

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -544,6 +544,7 @@ const messages = {
   },
   contentTypes: {
     all: "Alle",
+    article: "Artikkel",
     subject: "Fag",
     "topic-article": "Emne",
     "learning-path": "Læringssti",

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -547,6 +547,7 @@ const messages = {
     article: "Artikkel",
     subject: "Fag",
     "topic-article": "Emne",
+    learningpath: "Læringssti",
     "learning-path": "Læringssti",
     "subject-material": "Fagstoff",
     "tasks-and-activities": "Oppgaver og aktiviteter",

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -544,6 +544,7 @@ const messages = {
   },
   contentTypes: {
     all: "Alle",
+    article: "Artikkel",
     subject: "Fag",
     "topic-article": "Emne",
     "learning-path": "Læringssti",

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -547,6 +547,7 @@ const messages = {
     article: "Artikkel",
     subject: "Fag",
     "topic-article": "Emne",
+    learningpath: "Læringssti",
     "learning-path": "Læringssti",
     "subject-material": "Fagstoff",
     "tasks-and-activities": "Oppgåver og aktivitetar",

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -549,6 +549,7 @@ const messages = {
     article: "Artikkel",
     subject: "Fága",
     "topic-article": "Fáddá",
+    learningpath: "Oahppanbálggis",
     "learning-path": "Oahppanbálggis",
     "subject-material": "Fágaávdnasat",
     "tasks-and-activities": "Bihtát ja doaimmat",

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -546,6 +546,7 @@ const messages = {
   },
   contentTypes: {
     all: "Buot",
+    article: "Artikkel",
     subject: "Fága",
     "topic-article": "Fáddá",
     "learning-path": "Oahppanbálggis",

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -548,6 +548,7 @@ const messages = {
   },
   contentTypes: {
     all: "Alle",
+    article: "Artikkel",
     subject: "Faagem",
     "topic-article": "Teema",
     "learning-path": "Lïeremebaalka",

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -551,6 +551,7 @@ const messages = {
     article: "Artikkel",
     subject: "Faagem",
     "topic-article": "Teema",
+    learningpath: "Lïeremebaalka",
     "learning-path": "Lïeremebaalka",
     "subject-material": "Faage-aamhtese",
     "tasks-and-activities": "Laavenjassh jïh darjomh",


### PR DESCRIPTION
Legger til en generisk fallback label slik at artikkelressurser som mangler taksonomi kan se slik ut:
![image](https://github.com/NDLANO/frontend-packages/assets/33912044/fd17ad4c-0114-41d2-9475-907621ea37f8)

Og ikke slik:
![image](https://github.com/NDLANO/frontend-packages/assets/33912044/9e1dedfb-5143-4f95-a2cf-a2d341b73915)