### PR TITLE
Add back support for right-to-left languages

### DIFF
--- a/packages/ndla-ui/src/Article/ArticleParagraph.tsx
+++ b/packages/ndla-ui/src/Article/ArticleParagraph.tsx
@@ -17,6 +17,9 @@ const StyledParagraph = styled.p`
   &[data-align="center"] {
     text-align: center;
   }
+  &:has(span[dir="rtl"]) {
+    direction: rtl;
+  }
 `;
 
 export const ArticleParagraph = (props: Props) => <StyledParagraph {...props} />;


### PR DESCRIPTION
Fixes: https://github.com/NDLANO/Issues/issues/4057

Så ut som `dir="rtl"` legges på span elementet, ikke paragraph, i ArticleParagraph. Lagt til en selector som tar hensyn til det.