### PR TITLE
Prevent IconButton resizing

### DIFF
--- a/packages/primitives/src/Button.tsx
+++ b/packages/primitives/src/Button.tsx
@@ -196,6 +196,7 @@ export const iconButtonRecipe = cva({
   base: {
     lineHeight: "1",
     minHeight: "unset",
+    height: "fit-content",
     "& svg": {
       marginInline: "0",
       marginBlock: "0",


### PR DESCRIPTION
Kan se problemet her: https://frontend-packages-pr-2295.vercel.app/?path=/docs/primitives-dialog--docs hvis man setter size til xsmall

Prøvde å sette aspect-ratio også, men det blir ikke 100% uten å sette noe bredde eller høyde på knappen