### PR TITLE
Remove global emotion types

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -43,9 +43,13 @@ const config: StorybookConfig = {
       plugins: [
         tsconfigPaths.default({ root: "../" }),
         react.default({
-          jsxImportSource: "@emotion/react",
           babel: {
-            plugins: [["@emotion", { autoLabel: "always" }]],
+            overrides: [
+              {
+                exclude: /primitives|preset-panda|styled-system/,
+                plugins: [["@emotion", { autoLabel: "always" }]],
+              },
+            ],
           },
         }),
       ],

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -33,13 +33,7 @@ const config: StorybookConfig = {
     const { mergeConfig } = await import("vite");
     const react = await import("@vitejs/plugin-react");
     const tsconfigPaths = await import("vite-tsconfig-paths");
-    const pandaPostCss = await import("@pandacss/dev/postcss");
     return mergeConfig(config, {
-      css: {
-        postcss: {
-          plugins: [pandaPostCss.default()],
-        },
-      },
       plugins: [
         tsconfigPaths.default({ root: "../" }),
         react.default({

--- a/packages/button/src/ButtonV2.tsx
+++ b/packages/button/src/ButtonV2.tsx
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+
+/** @jsxImportSource @emotion/react */
 import { ButtonHTMLAttributes, forwardRef } from "react";
 import { css, SerializedStyles } from "@emotion/react";
 import { colors, fonts, misc, spacing } from "@ndla/core";

--- a/packages/button/src/IconButtonV2.tsx
+++ b/packages/button/src/IconButtonV2.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { ReactNode, forwardRef } from "react";
 import { css } from "@emotion/react";
 import { spacingUnit } from "@ndla/core";

--- a/packages/carousel/src/Carousel.tsx
+++ b/packages/carousel/src/Carousel.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import {
   cloneElement,
   MouseEvent as ReactMouseEvent,

--- a/packages/ndla-accordion/src/AccordionHeader.tsx
+++ b/packages/ndla-accordion/src/AccordionHeader.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { forwardRef, HTMLAttributes, memo, ReactNode, useMemo } from "react";
 import { SerializedStyles } from "@emotion/react";
 import styled from "@emotion/styled";

--- a/packages/ndla-forms/src/FieldSection.tsx
+++ b/packages/ndla-forms/src/FieldSection.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { ReactNode } from "react";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";

--- a/packages/ndla-forms/src/Input.tsx
+++ b/packages/ndla-forms/src/Input.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { HTMLProps, ReactElement, useEffect, useRef, ReactNode } from "react";
 import { SerializedStyles } from "@emotion/react";
 import styled from "@emotion/styled";

--- a/packages/ndla-forms/src/InputV2.tsx
+++ b/packages/ndla-forms/src/InputV2.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { forwardRef, HTMLProps, ReactElement, ReactNode, useEffect } from "react";
 import { SerializedStyles } from "@emotion/react";
 import styled from "@emotion/styled";

--- a/packages/ndla-forms/src/InputV3.tsx
+++ b/packages/ndla-forms/src/InputV3.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import {
   ComponentProps,
   HTMLAttributes,

--- a/packages/ndla-forms/src/UploadDropZone.tsx
+++ b/packages/ndla-forms/src/UploadDropZone.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { ReactNode, useEffect, useState, useRef, ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { css } from "@emotion/react";

--- a/packages/ndla-icons/src/Icon.tsx
+++ b/packages/ndla-icons/src/Icon.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { ReactNode, SVGAttributes } from "react";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";

--- a/packages/ndla-pager/src/Pager.tsx
+++ b/packages/ndla-pager/src/Pager.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { ElementType, ReactNode } from "react";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";

--- a/packages/ndla-ui/src/Article/Article.tsx
+++ b/packages/ndla-ui/src/Article/Article.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { ReactNode, forwardRef, ComponentPropsWithRef, useMemo, CSSProperties } from "react";
 import { SerializedStyles, css } from "@emotion/react";
 import styled from "@emotion/styled";

--- a/packages/ndla-ui/src/BlogPost/BlogPost.tsx
+++ b/packages/ndla-ui/src/BlogPost/BlogPost.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import parse from "html-react-parser";
 import { useTranslation } from "react-i18next";
 import { css } from "@emotion/react";

--- a/packages/ndla-ui/src/CampaignBlock/CampaignBlock.tsx
+++ b/packages/ndla-ui/src/CampaignBlock/CampaignBlock.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import parse from "html-react-parser";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";

--- a/packages/ndla-ui/src/ContactBlock/ContactBlock.tsx
+++ b/packages/ndla-ui/src/ContactBlock/ContactBlock.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { css } from "@emotion/react";

--- a/packages/ndla-ui/src/ContentTypeBadge/ContentTypeBadge.tsx
+++ b/packages/ndla-ui/src/ContentTypeBadge/ContentTypeBadge.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { CSSProperties, ComponentProps, useMemo } from "react";
 
 import { css } from "@emotion/react";

--- a/packages/ndla-ui/src/Embed/ImageEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/ImageEmbed.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import parse from "html-react-parser";
 import { MouseEventHandler, ReactNode, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";

--- a/packages/ndla-ui/src/Embed/conceptComponents.tsx
+++ b/packages/ndla-ui/src/Embed/conceptComponents.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { forwardRef, ReactNode, RefAttributes } from "react";
 import { useTranslation } from "react-i18next";
 import { css } from "@emotion/react";

--- a/packages/ndla-ui/src/FactBox/FactBox.tsx
+++ b/packages/ndla-ui/src/FactBox/FactBox.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { ComponentProps, ReactNode, forwardRef, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { css } from "@emotion/react";

--- a/packages/ndla-ui/src/Figure/Figure.tsx
+++ b/packages/ndla-ui/src/Figure/Figure.tsx
@@ -8,6 +8,7 @@
 
 // N.B These components is used to render static markup serverside
 
+/** @jsxImportSource @emotion/react */
 import { ComponentPropsWithRef, forwardRef, useMemo } from "react";
 import { SerializedStyles, css } from "@emotion/react";
 import styled from "@emotion/styled";

--- a/packages/ndla-ui/src/Layout/LayoutItem.tsx
+++ b/packages/ndla-ui/src/Layout/LayoutItem.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { HTMLAttributes, ReactNode, useMemo } from "react";
 import { css } from "@emotion/react";
 import { mq, breakpoints } from "@ndla/core";

--- a/packages/ndla-ui/src/Layout/OneColumn.tsx
+++ b/packages/ndla-ui/src/Layout/OneColumn.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { ComponentPropsWithoutRef } from "react";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";

--- a/packages/ndla-ui/src/Layout/PageContainer.tsx
+++ b/packages/ndla-ui/src/Layout/PageContainer.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { ComponentPropsWithoutRef } from "react";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";

--- a/packages/ndla-ui/src/Logo/Logo.tsx
+++ b/packages/ndla-ui/src/Logo/Logo.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { useMemo } from "react";
 import { SerializedStyles, css } from "@emotion/react";
 import styled from "@emotion/styled";

--- a/packages/ndla-ui/src/Notion/NotionImage.tsx
+++ b/packages/ndla-ui/src/Notion/NotionImage.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { useTranslation } from "react-i18next";
 import styled from "@emotion/styled";
 import { animations, breakpoints, colors, mq, spacing } from "@ndla/core";

--- a/packages/ndla-ui/src/Resource/BlockResource.tsx
+++ b/packages/ndla-ui/src/Resource/BlockResource.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { ReactNode, useMemo } from "react";
 import styled from "@emotion/styled";
 import { colors, spacing, stackOrder } from "@ndla/core";

--- a/packages/ndla-ui/src/Resource/ListResource.tsx
+++ b/packages/ndla-ui/src/Resource/ListResource.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { ReactNode, useMemo } from "react";
 import styled from "@emotion/styled";
 import { spacing, colors, breakpoints, mq, stackOrder } from "@ndla/core";

--- a/packages/ndla-ui/src/Search/ContentTypeResult.tsx
+++ b/packages/ndla-ui/src/Search/ContentTypeResult.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { ReactElement, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ButtonV2 } from "@ndla/button";

--- a/packages/ndla-ui/src/Search/SearchResultSleeve.tsx
+++ b/packages/ndla-ui/src/Search/SearchResultSleeve.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "@emotion/styled";

--- a/packages/ndla-ui/src/Table/Table.tsx
+++ b/packages/ndla-ui/src/Table/Table.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import throttle from "lodash.throttle";
 import { ReactNode, UIEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { css } from "@emotion/react";

--- a/packages/ndla-ui/src/TagSelector/DropdownIndicator.tsx
+++ b/packages/ndla-ui/src/TagSelector/DropdownIndicator.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { DropdownIndicatorProps, components } from "react-select";

--- a/packages/ndla-ui/src/TagSelector/Input.tsx
+++ b/packages/ndla-ui/src/TagSelector/Input.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { components, InputProps } from "react-select";
 import { css } from "@emotion/react";
 import { colors, spacing } from "@ndla/core";

--- a/packages/ndla-ui/src/TagSelector/Menu.tsx
+++ b/packages/ndla-ui/src/TagSelector/Menu.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { MenuProps, components } from "react-select";
 import { css } from "@emotion/react";
 import { colors } from "@ndla/core";

--- a/packages/ndla-ui/src/TagSelector/Option.tsx
+++ b/packages/ndla-ui/src/TagSelector/Option.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { OptionProps } from "react-select";
 import styled from "@emotion/styled";
 import { buttonStyleV2 as buttonStyle } from "@ndla/button";

--- a/packages/ndla-ui/src/TagSelector/ValueButton.tsx
+++ b/packages/ndla-ui/src/TagSelector/ValueButton.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { MultiValueProps } from "react-select";
 import styled from "@emotion/styled";
 import { buttonStyleV2 as buttonStyle } from "@ndla/button";

--- a/packages/preset-panda/package.json
+++ b/packages/preset-panda/package.json
@@ -11,7 +11,8 @@
     "prepare": "panda codegen",
     "build": "node ../../scripts/build.js package",
     "build:types": "tsc -p tsconfig.build.json",
-    "prepublish": "concurrently 'yarn build:types' 'mkdir -p dist' 'panda cssgen  --outfile dist/styles.css' 'panda ship --outfile dist/panda.buildinfo.json'"
+    "prepublish": "concurrently 'yarn build:types' 'yarn build:css'",
+    "build:css": "mkdir -p dist && panda cssgen --outfile dist/styles.css"
   },
   "repository": {
     "type": "git",

--- a/packages/preset-panda/panda.config.ts
+++ b/packages/preset-panda/panda.config.ts
@@ -8,9 +8,10 @@
 
 import { defineConfig } from "@pandacss/dev";
 import preset from "./src";
+import { forwardCssPropPlugin } from "./src/plugins/forwardCssPropPlugin";
 
 export default defineConfig({
-  presets: ["@pandacss/dev/presets", preset],
+  presets: [preset],
   preflight: false,
   jsxStyleProps: "minimal",
   strictPropertyValues: true,
@@ -18,8 +19,9 @@ export default defineConfig({
   outExtension: "mjs",
   include: ["./src/**/*.{js,jsx,ts,tsx}"],
   exclude: ["./src/**/*.stories.{js,jsx,ts,tsx}"],
-  outdir: "../styled-system",
   importMap: "@ndla/styled-system",
+  outdir: "../styled-system",
   jsxFramework: "react",
   syntax: "object-literal",
+  plugins: [forwardCssPropPlugin()],
 });

--- a/packages/preset-panda/src/colors.stories.tsx
+++ b/packages/preset-panda/src/colors.stories.tsx
@@ -29,7 +29,11 @@ interface ColorBlocksProps {
 
 const ColorBlocks = ({ title, description, children }: ColorBlocksProps) => (
   <div>
-    {title && <Heading as="h2">{title}</Heading>}
+    {title && (
+      <Heading asChild>
+        <h2>{title}</h2>
+      </Heading>
+    )}
     {description && <Text>{description}</Text>}
     <StyledColorBlocks>{children}</StyledColorBlocks>
   </div>

--- a/packages/preset-panda/src/index.ts
+++ b/packages/preset-panda/src/index.ts
@@ -45,4 +45,6 @@ const preset = definePreset({
   },
 });
 
+export { forwardCssPropPlugin } from "./plugins/forwardCssPropPlugin";
+
 export default preset;

--- a/packages/preset-panda/src/plugins/forwardCssPropPlugin.ts
+++ b/packages/preset-panda/src/plugins/forwardCssPropPlugin.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { CodegenPrepareHookArgs, PandaPlugin } from "@pandacss/types";
+
+const supportedJsxFrameworks = ["react"];
+
+export const forwardCssPropPlugin = (): PandaPlugin => {
+  return {
+    name: "forward-css-prop",
+    hooks: {
+      "config:resolved": (args) => {
+        const jsxFramework = args.config.jsxFramework;
+        if (!supportedJsxFrameworks.includes(jsxFramework as string)) {
+          throw new Error(
+            `[plugin:restrict-styled-props]: Unsupported jsxFramework: ${jsxFramework}. This Panda plugin only supports: ${supportedJsxFrameworks.join(", ")}`,
+          );
+        }
+      },
+      "codegen:prepare": (args) => {
+        return transformStyledFn(args);
+      },
+    },
+  };
+};
+
+export const transformStyledFn = (args: CodegenPrepareHookArgs) => {
+  const factoryArtifact = args.artifacts.find((art) => art.id === "jsx-factory");
+  const factoryJs = factoryArtifact?.files.find((f) => f.file.includes(".mjs") || f.file.includes(".js"));
+  const jsxTypes = args.artifacts.find((art) => art.id === "types-jsx")?.files.find((f) => f.file.includes("jsx"));
+
+  if (!factoryJs?.code || !jsxTypes?.code) {
+    return args.artifacts;
+  }
+
+  const cvaCode = "const cvaStyles = __cvaFn__.raw(variantProps)";
+
+  factoryJs.code = factoryJs.code.replace(
+    cvaCode,
+    `${cvaCode}
+      if(options.forwardCssProp) {
+        return css.raw(cvaStyles, propStyles, cssStyles)
+      }`,
+  );
+
+  factoryJs.code = factoryJs.code.replace(
+    "className: classes()",
+    `...(options.forwardCssProp ? { css: classes() } : { className: classes() })`,
+  );
+
+  const shouldForwardPropCode = "shouldForwardProp?(prop: string, variantKeys: string[]): boolean";
+
+  jsxTypes.code = jsxTypes.code.replace(
+    shouldForwardPropCode,
+    `${shouldForwardPropCode}
+  forwardCssProp?: boolean`,
+  );
+
+  return args.artifacts;
+};

--- a/packages/primitives/src/Accordion.stories.tsx
+++ b/packages/primitives/src/Accordion.stories.tsx
@@ -28,13 +28,15 @@ const meta: Meta<typeof AccordionRoot> = {
   render: (args) => (
     <AccordionRoot {...args}>
       <AccordionItem value={"1"}>
-        <Heading as="h2" textStyle="label.medium" fontWeight="bold">
-          <AccordionItemTrigger>
-            Tittel
-            <AccordionItemIndicator asChild>
-              <ChevronDown size="normal" />
-            </AccordionItemIndicator>
-          </AccordionItemTrigger>
+        <Heading asChild textStyle="label.medium" fontWeight="bold">
+          <h2>
+            <AccordionItemTrigger>
+              Tittel
+              <AccordionItemIndicator asChild>
+                <ChevronDown size="normal" />
+              </AccordionItemIndicator>
+            </AccordionItemTrigger>
+          </h2>
         </Heading>
         <AccordionItemContent>
           <div>
@@ -44,13 +46,15 @@ const meta: Meta<typeof AccordionRoot> = {
         </AccordionItemContent>
       </AccordionItem>
       <AccordionItem value={"2"}>
-        <Heading as="h2" textStyle="label.medium" fontWeight="bold">
-          <AccordionItemTrigger>
-            Tittel
-            <AccordionItemIndicator asChild>
-              <ChevronDown size="normal" />
-            </AccordionItemIndicator>
-          </AccordionItemTrigger>
+        <Heading asChild textStyle="label.medium" fontWeight="bold">
+          <h2>
+            <AccordionItemTrigger>
+              Tittel
+              <AccordionItemIndicator asChild>
+                <ChevronDown size="normal" />
+              </AccordionItemIndicator>
+            </AccordionItemTrigger>
+          </h2>
         </Heading>
         <AccordionItemContent>
           <div>

--- a/packages/primitives/src/Accordion.tsx
+++ b/packages/primitives/src/Accordion.tsx
@@ -7,10 +7,9 @@
  */
 
 import { accordionAnatomy } from "@ark-ui/anatomy";
-import type { Assign } from "@ark-ui/react";
 import { Accordion } from "@ark-ui/react";
 import { sva } from "@ndla/styled-system/css";
-import { SystemProperties } from "@ndla/styled-system/types";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 import { createStyleContext } from "./createStyleContext";
 
 const accordionRecipe = sva({
@@ -98,25 +97,23 @@ const accordionRecipe = sva({
 
 const { withProvider, withContext } = createStyleContext(accordionRecipe);
 
-export interface AccordionRootProps extends Assign<SystemProperties, Accordion.RootProps> {}
+export interface AccordionRootProps extends JsxStyleProps, Accordion.RootProps {}
+
 export const AccordionRoot = withProvider<HTMLDivElement, AccordionRootProps>(Accordion.Root, "root");
 
-export const AccordionItemContent = withContext<HTMLDivElement, Assign<SystemProperties, Accordion.ItemContentProps>>(
+export const AccordionItemContent = withContext<HTMLDivElement, JsxStyleProps & Accordion.ItemContentProps>(
   Accordion.ItemContent,
   "itemContent",
 );
 
-export const AccordionItemIndicator = withContext<
-  HTMLDivElement,
-  Assign<SystemProperties, Accordion.ItemIndicatorProps>
->(Accordion.ItemIndicator, "itemIndicator");
-
-export const AccordionItem = withContext<HTMLDivElement, Assign<SystemProperties, Accordion.ItemProps>>(
-  Accordion.Item,
-  "item",
+export const AccordionItemIndicator = withContext<HTMLDivElement, JsxStyleProps & Accordion.ItemIndicatorProps>(
+  Accordion.ItemIndicator,
+  "itemIndicator",
 );
 
-export const AccordionItemTrigger = withContext<
-  HTMLButtonElement,
-  Assign<SystemProperties, Accordion.ItemTriggerProps>
->(Accordion.ItemTrigger, "itemTrigger");
+export const AccordionItem = withContext<HTMLDivElement, JsxStyleProps & Accordion.ItemProps>(Accordion.Item, "item");
+
+export const AccordionItemTrigger = withContext<HTMLButtonElement, JsxStyleProps & Accordion.ItemTriggerProps>(
+  Accordion.ItemTrigger,
+  "itemTrigger",
+);

--- a/packages/primitives/src/ArticleLists.tsx
+++ b/packages/primitives/src/ArticleLists.tsx
@@ -6,11 +6,15 @@
  *
  */
 
-import { ComponentPropsWithoutRef } from "react";
+import { HTMLArkProps } from "@ark-ui/react";
 import { styled } from "@ndla/styled-system/jsx";
-import { StyledVariantProps } from "@ndla/styled-system/types";
+import { JsxStyleProps, StyledVariantProps } from "@ndla/styled-system/types";
 
-const StyledOrderedList = styled("ol", {
+export type OrderedListVariantProps = StyledVariantProps<typeof OrderedList>;
+
+export type OrderedListProps = HTMLArkProps<"ol"> & JsxStyleProps & OrderedListVariantProps;
+
+export const OrderedList = styled("ol", {
   base: {
     listStyle: "revert",
     listStylePosition: "inside",
@@ -58,15 +62,9 @@ const StyledOrderedList = styled("ol", {
   },
 });
 
-export type OrderedListVariantProps = StyledVariantProps<typeof StyledOrderedList>;
+export type UnOrderedListProps = HTMLArkProps<"ul"> & JsxStyleProps;
 
-export type OrderedListProps = ComponentPropsWithoutRef<"ol"> & OrderedListVariantProps;
-
-export const OrderedList = ({ variant = "numbers", ...props }: OrderedListProps) => (
-  <StyledOrderedList variant={variant} data-variant={variant} {...props} />
-);
-
-const StyledUnOrderedList = styled("ul", {
+export const UnOrderedList = styled("ul", {
   base: {
     listStyle: "revert",
     listStylePosition: "inside",
@@ -80,11 +78,7 @@ const StyledUnOrderedList = styled("ul", {
   },
 });
 
-export type UnOrderedListProps = ComponentPropsWithoutRef<"ul">;
-
-export const UnOrderedList = ({ ...props }: UnOrderedListProps) => <StyledUnOrderedList {...props} />;
-
-const StyledDefinitionList = styled("dl", {
+export const DefinitionList = styled("dl", {
   base: {
     "& dt": {
       fontWeight: "bold",
@@ -95,6 +89,4 @@ const StyledDefinitionList = styled("dl", {
   },
 });
 
-export type DefinitionListProps = ComponentPropsWithoutRef<"dl">;
-
-export const DefinitionList = ({ ...props }: DefinitionListProps) => <StyledDefinitionList {...props} />;
+export type DefinitionListProps = HTMLArkProps<"dl"> & JsxStyleProps;

--- a/packages/primitives/src/Badge.tsx
+++ b/packages/primitives/src/Badge.tsx
@@ -6,9 +6,10 @@
  *
  */
 
-import { ComponentPropsWithoutRef } from "react";
-import { RecipeVariantProps, cva, cx } from "@ndla/styled-system/css";
+import { HTMLArkProps, ark } from "@ark-ui/react";
+import { RecipeVariantProps, cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 
 const badgeRecipe = cva({
   base: {
@@ -44,8 +45,6 @@ const badgeRecipe = cva({
 
 export type BadgeVariantProps = RecipeVariantProps<typeof badgeRecipe>;
 
-export type BadgeProps = BadgeVariantProps & ComponentPropsWithoutRef<"div">;
+export type BadgeProps = HTMLArkProps<"div"> & JsxStyleProps & BadgeVariantProps;
 
-export const Badge = ({ colorTheme, className, ...rest }: BadgeProps) => (
-  <styled.div className={cx(badgeRecipe({ colorTheme }), className)} {...rest} />
-);
+export const Badge = styled(ark.div, badgeRecipe);

--- a/packages/primitives/src/BlockQuote.tsx
+++ b/packages/primitives/src/BlockQuote.tsx
@@ -6,9 +6,10 @@
  *
  */
 
-import { ComponentPropsWithoutRef } from "react";
-import { RecipeVariantProps, cva, cx } from "@ndla/styled-system/css";
+import { HTMLArkProps, ark } from "@ark-ui/react";
+import { RecipeVariantProps, cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 
 const blockQuoteRecipe = cva({
   base: {
@@ -38,8 +39,6 @@ const blockQuoteRecipe = cva({
 
 export type BlockQuoteVariantProps = RecipeVariantProps<typeof blockQuoteRecipe>;
 
-export type BlockQuoteProps = ComponentPropsWithoutRef<"blockquote"> & BlockQuoteVariantProps;
+export type BlockQuoteProps = HTMLArkProps<"blockquote"> & JsxStyleProps & BlockQuoteVariantProps;
 
-export const BlockQuote = ({ className, variant, ...rest }: BlockQuoteProps) => (
-  <styled.blockquote className={cx(blockQuoteRecipe({ variant }), className)} {...rest} />
-);
+export const BlockQuote = styled(ark.blockquote, blockQuoteRecipe);

--- a/packages/primitives/src/Button.stories.tsx
+++ b/packages/primitives/src/Button.stories.tsx
@@ -95,13 +95,17 @@ export const WithIcon: StoryObj<typeof Button> = {
   },
 };
 
-const UglyButton = styled(Button, {
-  base: {
-    background: "yellow.1000",
-    color: "text.onAction",
-    paddingBlock: "large",
-    paddingInline: "large",
+const UglyButton = styled(
+  Button,
+  {
+    base: {
+      background: "yellow.1000",
+      color: "text.onAction",
+      paddingBlock: "large",
+      paddingInline: "large",
+    },
   },
-});
+  { forwardCssProp: true },
+);
 
 export const StyledButtonExample = () => <UglyButton>Styled!</UglyButton>;

--- a/packages/primitives/src/Button.tsx
+++ b/packages/primitives/src/Button.tsx
@@ -6,10 +6,10 @@
  *
  */
 
+import { forwardRef } from "react";
 import { HTMLArkProps, ark } from "@ark-ui/react";
-import { RecipeVariantProps, cva } from "@ndla/styled-system/css";
-import { styled } from "@ndla/styled-system/jsx";
-import { JsxStyleProps, RecipeVariant, StyledComponent } from "@ndla/styled-system/types";
+import { RecipeVariantProps, css, cva, cx } from "@ndla/styled-system/css";
+import { JsxStyleProps, RecipeVariant } from "@ndla/styled-system/types";
 
 export const buttonBaseRecipe = cva({
   base: {
@@ -187,9 +187,15 @@ export type ButtonVariantProps = { variant?: ButtonVariant } & RecipeVariantProp
 
 export type ButtonProps = HTMLArkProps<"button"> & JsxStyleProps & ButtonVariantProps;
 
-const BaseButton = styled(ark.button, buttonBaseRecipe, { defaultProps: { type: "button" } });
-
-export const Button: StyledComponent<"button", NonNullable<ButtonVariantProps>> = styled(BaseButton, buttonRecipe);
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, css: cssProp, ...props }, ref) => (
+    <ark.button
+      {...props}
+      className={cx(css(buttonBaseRecipe.raw({ variant }), buttonRecipe.raw({ size }), cssProp), className)}
+      ref={ref}
+    />
+  ),
+);
 
 type IconButtonVariant = Exclude<Variant, "link">;
 
@@ -197,7 +203,12 @@ export type IconButtonVariantProps = { variant?: IconButtonVariant };
 
 export type IconButtonProps = HTMLArkProps<"button"> & IconButtonVariantProps & JsxStyleProps;
 
-export const IconButton: StyledComponent<"button", NonNullable<IconButtonVariantProps>> = styled(
-  BaseButton,
-  iconButtonRecipe,
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  ({ className, variant, css: cssProp, ...props }, ref) => (
+    <ark.button
+      {...props}
+      className={cx(css(buttonBaseRecipe.raw({ variant }), iconButtonRecipe.raw(), cssProp), className)}
+      ref={ref}
+    />
+  ),
 );

--- a/packages/primitives/src/Button.tsx
+++ b/packages/primitives/src/Button.tsx
@@ -6,9 +6,10 @@
  *
  */
 
-import { ComponentPropsWithRef, forwardRef } from "react";
-import { RecipeVariantProps, css, cva, cx } from "@ndla/styled-system/css";
+import { HTMLArkProps, ark } from "@ark-ui/react";
+import { RecipeVariantProps, cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
+import { JsxStyleProps, RecipeVariant, StyledComponent } from "@ndla/styled-system/types";
 
 export const buttonBaseRecipe = cva({
   base: {
@@ -162,36 +163,6 @@ export const buttonRecipe = cva({
   },
 });
 
-export type ButtonVariantProps = RecipeVariantProps<typeof buttonBaseRecipe> & RecipeVariantProps<typeof buttonRecipe>;
-
-export type ButtonProps = ComponentPropsWithRef<"button"> &
-  ButtonVariantProps & { variant?: Exclude<NonNullable<ButtonVariantProps>["variant"], "clear" | "clearSubtle"> };
-
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(({ type, size, className, variant, ...rest }, ref) => (
-  <styled.button
-    type={type ?? "button"}
-    className={cx(css(buttonBaseRecipe.raw({ variant }), buttonRecipe.raw({ size })), className)}
-    {...rest}
-    ref={ref}
-  />
-));
-
-export type IconButtonVariantProps = RecipeVariantProps<typeof buttonBaseRecipe>;
-
-export type IconButtonProps = ComponentPropsWithRef<"button"> &
-  IconButtonVariantProps & { variant?: Exclude<NonNullable<IconButtonVariantProps>["variant"], "link"> };
-
-export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
-  ({ type, className, variant, ...rest }, ref) => (
-    <styled.button
-      type={type ?? "button"}
-      className={cx(css(buttonBaseRecipe.raw({ variant }), iconButtonRecipe.raw()), className)}
-      {...rest}
-      ref={ref}
-    />
-  ),
-);
-
 export const iconButtonRecipe = cva({
   base: {
     lineHeight: "1",
@@ -207,3 +178,26 @@ export const iconButtonRecipe = cva({
     paddingBlock: "xsmall",
   },
 });
+
+type Variant = RecipeVariant<typeof buttonBaseRecipe>["variant"];
+
+type ButtonVariant = Exclude<Variant, "clear" | "clearSubtle">;
+
+export type ButtonVariantProps = { variant?: ButtonVariant } & RecipeVariantProps<typeof buttonRecipe>;
+
+export type ButtonProps = HTMLArkProps<"button"> & JsxStyleProps & ButtonVariantProps;
+
+const BaseButton = styled(ark.button, buttonBaseRecipe, { defaultProps: { type: "button" } });
+
+export const Button: StyledComponent<"button", NonNullable<ButtonVariantProps>> = styled(BaseButton, buttonRecipe);
+
+type IconButtonVariant = Exclude<Variant, "link">;
+
+export type IconButtonVariantProps = { variant?: IconButtonVariant };
+
+export type IconButtonProps = HTMLArkProps<"button"> & IconButtonVariantProps & JsxStyleProps;
+
+export const IconButton: StyledComponent<"button", NonNullable<IconButtonVariantProps>> = styled(
+  BaseButton,
+  iconButtonRecipe,
+);

--- a/packages/primitives/src/Checkbox.tsx
+++ b/packages/primitives/src/Checkbox.tsx
@@ -10,6 +10,7 @@ import { forwardRef } from "react";
 import { checkboxAnatomy } from "@ark-ui/anatomy";
 import { Checkbox } from "@ark-ui/react";
 import { sva } from "@ndla/styled-system/css";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 import { createStyleContext } from "./createStyleContext";
 import { useFormControl } from "./FormControl";
 import { Text, TextProps } from "./Text";
@@ -85,11 +86,11 @@ const checkboxRecipe = sva({
 
 const { withProvider, withContext } = createStyleContext(checkboxRecipe);
 
-export type CheckboxRootProps = Checkbox.RootProps;
+export type CheckboxRootProps = Checkbox.RootProps & JsxStyleProps;
 
 const InternalCheckboxRoot = withProvider<HTMLLabelElement, Checkbox.RootProps>(Checkbox.Root, "root");
 
-export const CheckboxRoot = forwardRef<HTMLLabelElement, Checkbox.RootProps>((props, ref) => {
+export const CheckboxRoot = forwardRef<HTMLLabelElement, Checkbox.RootProps & JsxStyleProps>((props, ref) => {
   const field = useFormControl(props);
   return (
     <InternalCheckboxRoot
@@ -101,16 +102,29 @@ export const CheckboxRoot = forwardRef<HTMLLabelElement, Checkbox.RootProps>((pr
   );
 });
 
-export const CheckboxIndicator = withContext<HTMLDivElement, Checkbox.IndicatorProps>(Checkbox.Indicator, "indicator");
+export const CheckboxIndicator = withContext<HTMLDivElement, Checkbox.IndicatorProps & JsxStyleProps>(
+  Checkbox.Indicator,
+  "indicator",
+);
 
-const InternalCheckboxLabel = withContext<HTMLSpanElement, Checkbox.LabelProps>(Checkbox.Label, "label");
+const InternalCheckboxLabel = withContext<HTMLSpanElement, JsxStyleProps & Checkbox.LabelProps>(
+  Checkbox.Label,
+  "label",
+);
 
-export const CheckboxLabel = ({ textStyle = "label.medium", children, ...props }: Checkbox.LabelProps & TextProps) => (
+export const CheckboxLabel = ({
+  textStyle = "label.medium",
+  children,
+  ...props
+}: Checkbox.LabelProps & TextProps & JsxStyleProps) => (
   <InternalCheckboxLabel {...props} asChild>
     <Text textStyle={textStyle}>{children}</Text>
   </InternalCheckboxLabel>
 );
 
-export const CheckboxControl = withContext<HTMLDivElement, Checkbox.ControlProps>(Checkbox.Control, "control");
+export const CheckboxControl = withContext<HTMLDivElement, JsxStyleProps & Checkbox.ControlProps>(
+  Checkbox.Control,
+  "control",
+);
 
 export const CheckboxHiddenInput = Checkbox.HiddenInput;

--- a/packages/primitives/src/Dialog.tsx
+++ b/packages/primitives/src/Dialog.tsx
@@ -17,7 +17,6 @@ import { Heading, Text, TextProps } from "./Text";
 
 const dialogRecipe = sva({
   slots: dialogAnatomy.keys(),
-  className: "dialog",
   base: {
     backdrop: {
       position: "fixed",
@@ -302,7 +301,7 @@ export const DialogDescription = ({
 }: Dialog.DescriptionProps & TextProps & JsxStyleProps) => {
   return (
     <InternalDialogDescription asChild>
-      <Text as="p" textStyle={textStyle} {...rest}></Text>
+      <Text textStyle={textStyle} {...rest}></Text>
     </InternalDialogDescription>
   );
 };
@@ -311,7 +310,7 @@ const InternalDialogTitle = withContext<HTMLHeadingElement, JsxStyleProps & Dial
 
 export const DialogTitle = ({ textStyle = "title.medium", ...rest }: Dialog.TitleProps & TextProps & JsxStyleProps) => (
   <InternalDialogTitle asChild>
-    <Heading as="h1" textStyle={textStyle} {...rest}></Heading>
+    <Heading textStyle={textStyle} {...rest}></Heading>
   </InternalDialogTitle>
 );
 

--- a/packages/primitives/src/Dialog.tsx
+++ b/packages/primitives/src/Dialog.tsx
@@ -6,18 +6,17 @@
  *
  */
 
-import { ComponentProps, forwardRef } from "react";
-import type { Assign } from "@ark-ui/react";
+import { forwardRef } from "react";
+import { dialogAnatomy } from "@ark-ui/anatomy";
 import { Dialog } from "@ark-ui/react";
 import { RecipeVariantProps, sva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
-import { SystemProperties } from "@ndla/styled-system/types";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 import { createStyleContext } from "./createStyleContext";
 import { Heading, Text, TextProps } from "./Text";
 
 const dialogRecipe = sva({
-  // We only use a subset of the dialog components, so we roll our own slots instead of relying on @ark/anatomy.
-  slots: ["positioner", "backdrop", "content"],
+  slots: dialogAnatomy.keys(),
   className: "dialog",
   base: {
     backdrop: {
@@ -268,44 +267,52 @@ export const DialogRoot = ({ lazyMount = true, unmountOnExit = true, ...props }:
   <InternalDialogRoot lazyMount={lazyMount} unmountOnExit={unmountOnExit} {...props} />
 );
 
-export const DialogBackdrop = withContext<HTMLDivElement, Assign<SystemProperties, Dialog.BackdropProps>>(
+export const DialogBackdrop = withContext<HTMLDivElement, JsxStyleProps & Dialog.BackdropProps>(
   Dialog.Backdrop,
   "backdrop",
 );
 
-export const DialogStandaloneContent = withContext<HTMLDivElement, Assign<SystemProperties, Dialog.ContentProps>>(
+export const DialogStandaloneContent = withContext<HTMLDivElement, JsxStyleProps & Dialog.ContentProps>(
   Dialog.Content,
   "content",
 );
 
-export const DialogPositioner = withContext<HTMLDivElement, Assign<SystemProperties, Dialog.PositionerProps>>(
+export const DialogPositioner = withContext<HTMLDivElement, JsxStyleProps & Dialog.PositionerProps>(
   Dialog.Positioner,
   "positioner",
 );
 
-export const DialogContent = forwardRef<HTMLDivElement, ComponentProps<typeof DialogStandaloneContent>>(
-  (props, ref) => (
-    <>
-      <DialogBackdrop />
-      <DialogPositioner>
-        <DialogStandaloneContent ref={ref} {...props} />
-      </DialogPositioner>
-    </>
-  ),
+export const DialogContent = forwardRef<HTMLDivElement, Dialog.ContentProps & JsxStyleProps>((props, ref) => (
+  <>
+    <DialogBackdrop />
+    <DialogPositioner>
+      <DialogStandaloneContent ref={ref} {...props} />
+    </DialogPositioner>
+  </>
+));
+
+const InternalDialogDescription = withContext<HTMLParagraphElement, JsxStyleProps & Dialog.DescriptionProps>(
+  Dialog.Description,
+  "description",
 );
 
-export const DialogDescription = ({ textStyle = "body.large", ...rest }: Dialog.DescriptionProps & TextProps) => {
+export const DialogDescription = ({
+  textStyle = "body.large",
+  ...rest
+}: Dialog.DescriptionProps & TextProps & JsxStyleProps) => {
   return (
-    <Dialog.Description asChild>
+    <InternalDialogDescription asChild>
       <Text as="p" textStyle={textStyle} {...rest}></Text>
-    </Dialog.Description>
+    </InternalDialogDescription>
   );
 };
 
-export const DialogTitle = ({ textStyle = "title.medium", ...rest }: Dialog.TitleProps & TextProps) => (
-  <Dialog.Title asChild>
+const InternalDialogTitle = withContext<HTMLHeadingElement, JsxStyleProps & Dialog.TitleProps>(Dialog.Title, "title");
+
+export const DialogTitle = ({ textStyle = "title.medium", ...rest }: Dialog.TitleProps & TextProps & JsxStyleProps) => (
+  <InternalDialogTitle asChild>
     <Heading as="h1" textStyle={textStyle} {...rest}></Heading>
-  </Dialog.Title>
+  </InternalDialogTitle>
 );
 
 export const DialogTrigger = Dialog.Trigger;

--- a/packages/primitives/src/ExpandableBox.stories.tsx
+++ b/packages/primitives/src/ExpandableBox.stories.tsx
@@ -34,7 +34,9 @@ export const Default: StoryObj<typeof ExpandableBox> = {};
 export const WithHeader: StoryFn<typeof ExpandableBox> = ({ ...args }) => (
   <ExpandableBox {...args}>
     <ExpandableBoxSummary>
-      <Heading as="h2">Open me as header text</Heading>
+      <Heading asChild>
+        <h2>Open me as header text</h2>
+      </Heading>
     </ExpandableBoxSummary>
     Everything here is only visible when the box is open
   </ExpandableBox>

--- a/packages/primitives/src/ExpandableBox.tsx
+++ b/packages/primitives/src/ExpandableBox.tsx
@@ -6,10 +6,13 @@
  *
  */
 
-import { ComponentPropsWithoutRef } from "react";
+import { HTMLArkProps, ark } from "@ark-ui/react";
 import { styled } from "@ndla/styled-system/jsx";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 
-const StyledExpandableBox = styled("details", {
+export type ExpandableBoxProps = HTMLArkProps<"details"> & JsxStyleProps;
+
+export const ExpandableBox = styled("details", {
   base: {
     transitionDuration: "fast",
     width: "100%",
@@ -27,11 +30,9 @@ const StyledExpandableBox = styled("details", {
   },
 });
 
-export type ExpandableBoxProps = ComponentPropsWithoutRef<"details">;
+export type ExpandableBoxSummaryProps = HTMLArkProps<"summary"> & JsxStyleProps;
 
-export const ExpandableBox = (props: ExpandableBoxProps) => <StyledExpandableBox {...props} />;
-
-const StyledExpandableBoxSummary = styled("summary", {
+export const ExpandableBoxSummary = styled(ark.summary, {
   base: {
     cursor: "pointer",
     margin: "-medium",
@@ -46,9 +47,3 @@ const StyledExpandableBoxSummary = styled("summary", {
     },
   },
 });
-
-export type ExpandableBoxSummaryProps = ComponentPropsWithoutRef<"summary">;
-
-export const ExpandableBoxSummary = ({ children, ...rest }: ExpandableBoxSummaryProps) => {
-  return <StyledExpandableBoxSummary {...rest}>{children}</StyledExpandableBoxSummary>;
-};

--- a/packages/primitives/src/FieldErrorMessage.tsx
+++ b/packages/primitives/src/FieldErrorMessage.tsx
@@ -6,27 +6,31 @@
  *
  */
 
-import { ComponentPropsWithRef, forwardRef } from "react";
+import { forwardRef } from "react";
+import { HTMLArkProps, ark } from "@ark-ui/react";
 import { css, cx } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
+import { WithCss } from "@ndla/styled-system/types";
 import { useFormControlContext } from "./FormControl";
 import { TextProps } from "./Text";
 
-const StyledErrorMessage = styled("div", {
+const StyledErrorMessage = styled(ark.div, {
   base: {
     color: "text.error",
     whiteSpace: "pre-line",
+    justifyContent: "center",
   },
 });
 
-export const FieldErrorMessage = forwardRef<HTMLSpanElement, TextProps & ComponentPropsWithRef<"div">>(
-  ({ textStyle = "label.small", fontWeight, color, srOnly, className, ...props }, ref) => {
+export const FieldErrorMessage = forwardRef<HTMLSpanElement, TextProps & HTMLArkProps<"div"> & WithCss>(
+  ({ textStyle = "label.small", fontWeight, css: cssProp, color, srOnly, className, ...props }, ref) => {
     const field = useFormControlContext();
     if (field && !field.isInvalid) return null;
+
     return (
       <StyledErrorMessage
         {...(field?.getErrorMessageProps(props, ref) ?? { ref, ...props })}
-        className={cx(css({ textStyle, fontWeight, color, srOnly: srOnly }), className)}
+        className={cx(css({ textStyle, fontWeight, color, srOnly }, cssProp), className)}
       />
     );
   },

--- a/packages/primitives/src/FieldHelper.tsx
+++ b/packages/primitives/src/FieldHelper.tsx
@@ -7,9 +7,8 @@
  */
 
 import { forwardRef } from "react";
-import { HTMLArkProps } from "@ark-ui/react";
+import { HTMLArkProps, ark } from "@ark-ui/react";
 import { css, cx } from "@ndla/styled-system/css";
-import { styled } from "@ndla/styled-system/jsx";
 import { JsxStyleProps } from "@ndla/styled-system/types";
 import { useFormControlContext } from "./FormControl";
 import { TextProps } from "./Text";
@@ -18,7 +17,7 @@ export const FieldHelper = forwardRef<HTMLDivElement, TextProps & HTMLArkProps<"
   ({ textStyle = "label.small", fontWeight, color, srOnly, className, css: cssProp, ...props }, ref) => {
     const field = useFormControlContext();
     return (
-      <styled.div
+      <ark.div
         {...(field?.getHelpTextProps(props, ref) ?? { ref, ...props })}
         className={cx(css({ textStyle, fontWeight, color, srOnly }, cssProp), className)}
       />

--- a/packages/primitives/src/FieldHelper.tsx
+++ b/packages/primitives/src/FieldHelper.tsx
@@ -6,19 +6,21 @@
  *
  */
 
-import { ComponentPropsWithRef, forwardRef } from "react";
+import { forwardRef } from "react";
+import { HTMLArkProps } from "@ark-ui/react";
 import { css, cx } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 import { useFormControlContext } from "./FormControl";
 import { TextProps } from "./Text";
 
-export const FieldHelper = forwardRef<HTMLDivElement, TextProps & ComponentPropsWithRef<"div">>(
-  ({ textStyle = "label.small", fontWeight, color, srOnly, className, ...props }, ref) => {
+export const FieldHelper = forwardRef<HTMLDivElement, TextProps & HTMLArkProps<"div"> & JsxStyleProps>(
+  ({ textStyle = "label.small", fontWeight, color, srOnly, className, css: cssProp, ...props }, ref) => {
     const field = useFormControlContext();
     return (
       <styled.div
         {...(field?.getHelpTextProps(props, ref) ?? { ref, ...props })}
-        className={cx(css({ textStyle, fontWeight, color, srOnly }), className)}
+        className={cx(css({ textStyle, fontWeight, color, srOnly }, cssProp), className)}
       />
     );
   },

--- a/packages/primitives/src/FormControl.tsx
+++ b/packages/primitives/src/FormControl.tsx
@@ -9,7 +9,6 @@
 import {
   ComponentPropsWithRef,
   ElementType,
-  HTMLAttributes,
   Ref,
   RefObject,
   createContext,
@@ -17,7 +16,9 @@ import {
   useContext,
   useState,
 } from "react";
+import { HTMLArkProps, ark } from "@ark-ui/react";
 import { styled } from "@ndla/styled-system/jsx";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 import { composeRefs } from "@ndla/util";
 
 type Merge<T, P> = P & Omit<T, keyof P>;
@@ -37,7 +38,7 @@ export interface FormControlProps extends FormControlOptions {
   id: string;
 }
 
-const StyledFormControl = styled("div", {
+const StyledFormControl = styled(ark.div, {
   base: {
     display: "flex",
     flexDirection: "column",
@@ -129,7 +130,7 @@ export const FormControl = ({
   isInvalid,
   isRequired,
   ...rest
-}: HTMLAttributes<HTMLDivElement> & FormControlProps) => {
+}: HTMLArkProps<"div"> & JsxStyleProps & FormControlProps) => {
   const context = useFormControlProvider({
     id,
     isDisabled,

--- a/packages/primitives/src/FramedContent.tsx
+++ b/packages/primitives/src/FramedContent.tsx
@@ -6,10 +6,10 @@
  *
  */
 
-import { ComponentPropsWithoutRef } from "react";
-import { cva, cx } from "@ndla/styled-system/css";
+import { HTMLArkProps, ark } from "@ark-ui/react";
+import { cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
-import { RecipeVariantProps } from "@ndla/styled-system/types";
+import { JsxStyleProps, RecipeVariantProps } from "@ndla/styled-system/types";
 
 const framedContentRecipe = cva({
   base: {
@@ -44,8 +44,6 @@ const framedContentRecipe = cva({
 
 export type FramedContentVariantProps = RecipeVariantProps<typeof framedContentRecipe>;
 
-export type FramedContentProps = ComponentPropsWithoutRef<"div"> & FramedContentVariantProps;
+export type FramedContentProps = HTMLArkProps<"div"> & JsxStyleProps & FramedContentVariantProps;
 
-export const FramedContent = ({ className, colorTheme, ...rest }: FramedContentProps) => (
-  <styled.div className={cx(framedContentRecipe({ colorTheme }), className)} {...rest} />
-);
+export const FramedContent = styled(ark.div, framedContentRecipe);

--- a/packages/primitives/src/Input.tsx
+++ b/packages/primitives/src/Input.tsx
@@ -6,18 +6,11 @@
  *
  */
 
-import {
-  ComponentPropsWithRef,
-  HTMLAttributes,
-  createContext,
-  forwardRef,
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-} from "react";
+import { createContext, forwardRef, useCallback, useContext, useEffect, useRef } from "react";
+import { HTMLArkProps, ark } from "@ark-ui/react";
 import { css, cx } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 import { composeRefs } from "@ndla/util";
 import { useFormControl } from "./FormControl";
 
@@ -64,7 +57,7 @@ const inputCss = css.raw({
   },
 });
 
-const StyledInputContainer = styled("div", {
+const StyledInputContainer = styled(ark.div, {
   base: {
     width: "100%",
     display: "flex",
@@ -76,10 +69,10 @@ const StyledInputContainer = styled("div", {
   },
 });
 
-export const InputContainer = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ children, className, ...rest }, ref) => (
+export const InputContainer = forwardRef<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(
+  ({ children, css: cssProp, className, ...rest }, ref) => (
     <InputContext.Provider value={{}}>
-      <StyledInputContainer className={cx(css(inputCss), className)} {...rest} ref={ref}>
+      <StyledInputContainer className={cx(css(inputCss, cssProp), className)} {...rest} ref={ref}>
         {children}
       </StyledInputContainer>
     </InputContext.Provider>
@@ -112,21 +105,27 @@ const baseTextAreaCss = css.raw({
   overflowY: "hidden",
 });
 
-export const Input = forwardRef<HTMLInputElement, ComponentPropsWithRef<"input">>(({ className, ...props }, ref) => {
+export interface InputProps extends HTMLArkProps<"input">, JsxStyleProps {}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(({ className, css: cssProp, ...props }, ref) => {
   const context = useContext(InputContext);
   return (
-    <styled.input className={cx(css(baseInputCss, context ? undefined : inputCss), className)} ref={ref} {...props} />
+    <ark.input
+      className={cx(css(baseInputCss, context ? undefined : inputCss, cssProp), className)}
+      ref={ref}
+      {...props}
+    />
   );
 });
 
-export const FormInput = forwardRef<HTMLInputElement, ComponentPropsWithRef<"input">>((props, ref) => {
+export const FormInput = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   const field = useFormControl(props);
   return <Input {...field} ref={ref} />;
 });
 
-interface TextAreaProps extends ComponentPropsWithRef<"textarea"> {}
+interface TextAreaProps extends HTMLArkProps<"textarea">, JsxStyleProps {}
 
-export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(({ className, ...props }, ref) => {
+export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(({ className, css: cssProp, ...props }, ref) => {
   const context = useContext(InputContext);
   const localRef = useRef<HTMLTextAreaElement>(null);
 
@@ -148,8 +147,8 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(({ classN
   }, [resize]);
 
   return (
-    <styled.textarea
-      className={cx(css(baseInputCss, context ? undefined : inputCss, baseTextAreaCss), className)}
+    <ark.textarea
+      className={cx(css(baseInputCss, context ? undefined : inputCss, baseTextAreaCss, cssProp), className)}
       ref={composeRefs(ref, localRef)}
       {...props}
     />

--- a/packages/primitives/src/Label.tsx
+++ b/packages/primitives/src/Label.tsx
@@ -6,13 +6,15 @@
  *
  */
 
-import { ComponentPropsWithRef, forwardRef } from "react";
+import { forwardRef } from "react";
+import { HTMLArkProps, ark } from "@ark-ui/react";
 import { css, cx } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
+import { JsxStyleProps, WithCss } from "@ndla/styled-system/types";
 import { useFormControlContext } from "./FormControl";
 import { TextProps } from "./Text";
 
-const StyledLegend = styled("legend", {
+const StyledLegend = styled(ark.legend, {
   base: {
     float: "none",
     width: "inherit",
@@ -22,11 +24,11 @@ const StyledLegend = styled("legend", {
   },
 });
 
-export type LegendProps = ComponentPropsWithRef<"legend"> & TextProps;
+export type LegendProps = HTMLArkProps<"legend"> & WithCss & TextProps;
 
 export const Legend = forwardRef<HTMLLegendElement, LegendProps>(
-  ({ textStyle = "label.medium", fontWeight = "bold", className, srOnly, ...rest }, ref) => (
-    <StyledLegend className={cx(css({ textStyle, fontWeight, srOnly }), className)} {...rest} ref={ref} />
+  ({ textStyle = "label.medium", fontWeight = "bold", css: cssProp, className, srOnly, ...rest }, ref) => (
+    <StyledLegend className={cx(css({ textStyle, fontWeight, srOnly }, cssProp), className)} {...rest} ref={ref} />
   ),
 );
 
@@ -37,7 +39,7 @@ export const FormLegend = forwardRef<HTMLLegendElement, LegendProps>((props, ref
   return <Legend {...props} {...fieldProps} ref={ref} />;
 });
 
-const StyledLabel = styled("label", {
+const StyledLabel = styled(ark.label, {
   base: {
     display: "inline-block",
     _disabled: {
@@ -46,11 +48,11 @@ const StyledLabel = styled("label", {
   },
 });
 
-export type LabelProps = ComponentPropsWithRef<"label"> & TextProps;
+export type LabelProps = HTMLArkProps<"label"> & TextProps & JsxStyleProps;
 
 export const Label = forwardRef<HTMLLabelElement, LabelProps>(
-  ({ textStyle = "label.medium", fontWeight = "bold", className, srOnly, ...rest }, ref) => (
-    <StyledLabel className={cx(css({ textStyle, fontWeight, srOnly }), className)} {...rest} ref={ref} />
+  ({ textStyle = "label.medium", fontWeight = "bold", className, css: cssProp, srOnly, ...rest }, ref) => (
+    <StyledLabel className={cx(css({ textStyle, fontWeight, srOnly }, cssProp), className)} {...rest} ref={ref} />
   ),
 );
 

--- a/packages/primitives/src/Menu.stories.tsx
+++ b/packages/primitives/src/Menu.stories.tsx
@@ -11,7 +11,6 @@ import { Meta, StoryFn } from "@storybook/react";
 import { Copy, Cross, Pencil, TrashCanOutline } from "@ndla/icons/action";
 import { ChevronRight, Share, ShareArrow } from "@ndla/icons/common";
 import { Settings } from "@ndla/icons/editor";
-import { css } from "@ndla/styled-system/css";
 import { HStack } from "@ndla/styled-system/jsx";
 import { Button } from "./Button";
 import {
@@ -141,7 +140,7 @@ export const Nested: StoryFn<typeof MenuRoot> = (args) => (
             </MenuItem>
           </MenuItemGroup>
           <MenuRoot>
-            <MenuTriggerItem className={css({ justifyContent: "space-between" })}>
+            <MenuTriggerItem css={{ justifyContent: "space-between" }}>
               <HStack gap="3xsmall">
                 <Settings />
                 Mappehandlinger

--- a/packages/primitives/src/Menu.tsx
+++ b/packages/primitives/src/Menu.tsx
@@ -6,15 +6,15 @@
  *
  */
 
+import { forwardRef } from "react";
 import { menuAnatomy } from "@ark-ui/anatomy";
 import { Menu } from "@ark-ui/react";
-import { cva, sva } from "@ndla/styled-system/css";
-import { styled } from "@ndla/styled-system/jsx";
-import { JsxStyleProps, StyledVariantProps, SystemStyleObject } from "@ndla/styled-system/types";
+import { css, cva, sva } from "@ndla/styled-system/css";
+import { JsxStyleProps, RecipeVariantProps, SystemStyleObject } from "@ndla/styled-system/types";
 import { createStyleContext } from "./createStyleContext";
 import { Text, TextProps } from "./Text";
 
-const itemStyle: SystemStyleObject = {
+const itemStyle: SystemStyleObject = css.raw({
   display: "flex",
   alignItems: "center",
   borderRadius: "xsmall",
@@ -48,7 +48,7 @@ const itemStyle: SystemStyleObject = {
       },
     },
   },
-};
+});
 
 const itemCva = cva({
   defaultVariants: {
@@ -166,9 +166,17 @@ export const MenuItemGroup = withContext<HTMLDivElement, JsxStyleProps & Menu.It
 
 const InternalMenuItem = withContext<HTMLDivElement, JsxStyleProps & Menu.ItemProps>(Menu.Item, "item");
 
-export type MenuItemVariantProps = StyledVariantProps<typeof MenuItem>;
+export type MenuItemVariantProps = RecipeVariantProps<typeof itemCva>;
 
-export const MenuItem = styled(InternalMenuItem, itemCva);
+export const MenuItem = forwardRef<HTMLDivElement, Menu.ItemProps & JsxStyleProps & MenuItemVariantProps>(
+  ({ css: cssProp = {}, variant, ...props }, ref) => (
+    <InternalMenuItem
+      css={[itemCva.raw({ variant }), ...(Array.isArray(cssProp) ? cssProp : [cssProp])]}
+      {...props}
+      ref={ref}
+    />
+  ),
+);
 
 export const MenuPositioner = withContext<HTMLDivElement, JsxStyleProps & Menu.PositionerProps>(
   Menu.Positioner,
@@ -180,7 +188,15 @@ const InternalMenuTriggerItem = withContext<HTMLDivElement, JsxStyleProps & Menu
   "triggerItem",
 );
 
-export const MenuTriggerItem = styled(InternalMenuTriggerItem, itemCva);
+export const MenuTriggerItem = forwardRef<HTMLDivElement, Menu.TriggerItemProps & JsxStyleProps & MenuItemVariantProps>(
+  ({ css: cssProp = {}, variant, ...props }, ref) => (
+    <InternalMenuTriggerItem
+      css={[itemCva.raw({ variant }), ...(Array.isArray(cssProp) ? cssProp : [cssProp])]}
+      {...props}
+      ref={ref}
+    />
+  ),
+);
 
 export const MenuTrigger = withContext<HTMLDivElement, JsxStyleProps & Menu.TriggerProps>(Menu.Trigger, "trigger");
 

--- a/packages/primitives/src/Menu.tsx
+++ b/packages/primitives/src/Menu.tsx
@@ -10,7 +10,7 @@ import { menuAnatomy } from "@ark-ui/anatomy";
 import { Menu } from "@ark-ui/react";
 import { cva, sva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
-import { StyledVariantProps, SystemStyleObject } from "@ndla/styled-system/types";
+import { JsxStyleProps, StyledVariantProps, SystemStyleObject } from "@ndla/styled-system/types";
 import { createStyleContext } from "./createStyleContext";
 import { Text, TextProps } from "./Text";
 
@@ -139,9 +139,9 @@ export const MenuRoot = ({ lazyMount = true, unmountOnExit = true, ...props }: M
   <InternalMenuRoot lazyMount={lazyMount} unmountOnExit={unmountOnExit} {...props} />
 );
 
-export const MenuContent = withContext<HTMLDivElement, Menu.ContentProps>(Menu.Content, "content");
+export const MenuContent = withContext<HTMLDivElement, JsxStyleProps & Menu.ContentProps>(Menu.Content, "content");
 
-const InternalMenuItemGroupLabel = withContext<HTMLDivElement, Menu.ItemGroupLabelProps>(
+const InternalMenuItemGroupLabel = withContext<HTMLDivElement, JsxStyleProps & Menu.ItemGroupLabelProps>(
   Menu.ItemGroupLabel,
   "itemGroupLabel",
 );
@@ -151,7 +151,7 @@ export const MenuItemGroupLabel = ({
   fontWeight = "bold",
   children,
   ...props
-}: Menu.ItemGroupLabelProps & TextProps) => (
+}: Menu.ItemGroupLabelProps & JsxStyleProps & TextProps) => (
   <InternalMenuItemGroupLabel {...props} asChild>
     <Text textStyle={textStyle} fontWeight={fontWeight}>
       {children}
@@ -159,20 +159,32 @@ export const MenuItemGroupLabel = ({
   </InternalMenuItemGroupLabel>
 );
 
-export const MenuItemGroup = withContext<HTMLDivElement, Menu.ItemGroupProps>(Menu.ItemGroup, "itemGroup");
+export const MenuItemGroup = withContext<HTMLDivElement, JsxStyleProps & Menu.ItemGroupProps>(
+  Menu.ItemGroup,
+  "itemGroup",
+);
 
-const InternalMenuItem = withContext<HTMLDivElement, Menu.ItemProps>(Menu.Item, "item");
+const InternalMenuItem = withContext<HTMLDivElement, JsxStyleProps & Menu.ItemProps>(Menu.Item, "item");
 
 export type MenuItemVariantProps = StyledVariantProps<typeof MenuItem>;
 
 export const MenuItem = styled(InternalMenuItem, itemCva);
 
-export const MenuPositioner = withContext<HTMLDivElement, Menu.PositionerProps>(Menu.Positioner, "positioner");
+export const MenuPositioner = withContext<HTMLDivElement, JsxStyleProps & Menu.PositionerProps>(
+  Menu.Positioner,
+  "positioner",
+);
 
-const InternalMenuTriggerItem = withContext<HTMLDivElement, Menu.TriggerItemProps>(Menu.TriggerItem, "triggerItem");
+const InternalMenuTriggerItem = withContext<HTMLDivElement, JsxStyleProps & Menu.TriggerItemProps>(
+  Menu.TriggerItem,
+  "triggerItem",
+);
 
 export const MenuTriggerItem = styled(InternalMenuTriggerItem, itemCva);
 
-export const MenuTrigger = withContext<HTMLDivElement, Menu.TriggerProps>(Menu.Trigger, "trigger");
+export const MenuTrigger = withContext<HTMLDivElement, JsxStyleProps & Menu.TriggerProps>(Menu.Trigger, "trigger");
 
-export const MenuSeparator = withContext<HTMLHRElement, Menu.SeparatorProps>(Menu.Separator, "separator");
+export const MenuSeparator = withContext<HTMLHRElement, JsxStyleProps & Menu.SeparatorProps>(
+  Menu.Separator,
+  "separator",
+);

--- a/packages/primitives/src/MessageBox.tsx
+++ b/packages/primitives/src/MessageBox.tsx
@@ -6,10 +6,10 @@
  *
  */
 
-import { ComponentPropsWithoutRef } from "react";
-import { cva, cx } from "@ndla/styled-system/css";
+import { HTMLArkProps, ark } from "@ark-ui/react";
+import { cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
-import { RecipeVariantProps } from "@ndla/styled-system/types";
+import { JsxStyleProps, RecipeVariantProps } from "@ndla/styled-system/types";
 
 const messageBoxRecipe = cva({
   base: {
@@ -47,8 +47,6 @@ const messageBoxRecipe = cva({
 
 export type MessageBoxVariantProps = RecipeVariantProps<typeof messageBoxRecipe>;
 
-export type MessageBoxProps = ComponentPropsWithoutRef<"div"> & MessageBoxVariantProps;
+export type MessageBoxProps = HTMLArkProps<"div"> & JsxStyleProps & MessageBoxVariantProps;
 
-export const MessageBox = ({ className, variant, ...rest }: MessageBoxProps) => (
-  <styled.div className={cx(messageBoxRecipe({ variant }), className)} {...rest} />
-);
+export const MessageBox = styled(ark.div, messageBoxRecipe);

--- a/packages/primitives/src/NdlaLogo.tsx
+++ b/packages/primitives/src/NdlaLogo.tsx
@@ -9,11 +9,12 @@
 import { ComponentPropsWithoutRef } from "react";
 import { css, cx } from "@ndla/styled-system/css";
 import { ColorToken } from "@ndla/styled-system/tokens";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 
-export type LogoProps = ComponentPropsWithoutRef<"svg"> & { color?: ColorToken };
+export type LogoProps = ComponentPropsWithoutRef<"svg"> & { color?: ColorToken } & JsxStyleProps;
 
-const BaseSvg = ({ color = "primary", className, ...props }: LogoProps) => (
-  <svg xmlns="http://www.w3.org/2000/svg" className={cx(css({ color }), className)} {...props} />
+const BaseSvg = ({ color = "primary", className, css: cssProp, ...props }: LogoProps) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={cx(css({ color }, cssProp), className)} {...props} />
 );
 
 export const NdlaLogoEn = (props: LogoProps) => (

--- a/packages/primitives/src/Pagination.stories.tsx
+++ b/packages/primitives/src/Pagination.stories.tsx
@@ -45,7 +45,9 @@ export default {
               </PaginationItem>
             ) : (
               <PaginationEllipsis key={index} index={index} asChild>
-                <Text as="div">&#8230;</Text>
+                <Text asChild>
+                  <div>&#8230;</div>
+                </Text>
               </PaginationEllipsis>
             ),
           )

--- a/packages/primitives/src/Pagination.tsx
+++ b/packages/primitives/src/Pagination.tsx
@@ -9,6 +9,7 @@
 import { paginationAnatomy } from "@ark-ui/anatomy";
 import { Pagination } from "@ark-ui/react";
 import { sva } from "@ndla/styled-system/css";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 import { createStyleContext } from "./createStyleContext";
 
 const paginationRecipe = sva({
@@ -30,23 +31,26 @@ const paginationRecipe = sva({
 
 const { withProvider, withContext } = createStyleContext(paginationRecipe);
 
-export type PaginationRootProps = Pagination.RootProps;
+export type PaginationRootProps = JsxStyleProps & Pagination.RootProps;
 
 export const PaginationRoot = withProvider<HTMLElement, Pagination.RootProps>(Pagination.Root, "root");
 
-export const PaginationItem = withContext<HTMLButtonElement, Pagination.ItemProps>(Pagination.Item, "item");
+export const PaginationItem = withContext<HTMLButtonElement, JsxStyleProps & Pagination.ItemProps>(
+  Pagination.Item,
+  "item",
+);
 
-export const PaginationEllipsis = withContext<HTMLDivElement, Pagination.EllipsisProps>(
+export const PaginationEllipsis = withContext<HTMLDivElement, JsxStyleProps & Pagination.EllipsisProps>(
   Pagination.Ellipsis,
   "ellipsis",
 );
 
-export const PaginationPrevTrigger = withContext<HTMLButtonElement, Pagination.PrevTriggerProps>(
+export const PaginationPrevTrigger = withContext<HTMLButtonElement, JsxStyleProps & Pagination.PrevTriggerProps>(
   Pagination.PrevTrigger,
   "prevTrigger",
 );
 
-export const PaginationNextTrigger = withContext<HTMLButtonElement, Pagination.NextTriggerProps>(
+export const PaginationNextTrigger = withContext<HTMLButtonElement, JsxStyleProps & Pagination.NextTriggerProps>(
   Pagination.NextTrigger,
   "nextTrigger",
 );

--- a/packages/primitives/src/Popover.stories.tsx
+++ b/packages/primitives/src/Popover.stories.tsx
@@ -8,7 +8,6 @@
 
 import { Portal } from "@ark-ui/react";
 import { Meta, StoryFn, StoryObj } from "@storybook/react";
-import { css } from "@ndla/styled-system/css";
 import { Button } from "./Button";
 import {
   PopoverContent,
@@ -61,7 +60,7 @@ export const LeftAligned: StoryObj<typeof PopoverRoot> = {
   render: ({ children, ...args }) => (
     <PopoverRoot {...args}>
       <PopoverTrigger asChild>
-        <Button className={css({ marginInlineStart: "50%" })}>Open me!</Button>
+        <Button css={{ marginInlineStart: "50%" }}>Open me!</Button>
       </PopoverTrigger>
       <Portal>
         <PopoverContent>

--- a/packages/primitives/src/RadioGroup.stories.tsx
+++ b/packages/primitives/src/RadioGroup.stories.tsx
@@ -8,7 +8,6 @@
 
 import { useId, useState } from "react";
 import { Meta, StoryFn } from "@storybook/react";
-import { css } from "@ndla/styled-system/css";
 import { Button } from "./Button";
 import { FieldErrorMessage } from "./FieldErrorMessage";
 import { FieldHelper } from "./FieldHelper";
@@ -55,7 +54,7 @@ export const WithFormControl: StoryFn<typeof RadioGroupRoot> = ({ ...args }) => 
   const [value, setValue] = useState<string | null>(null);
   const isInvalid = !value;
   return (
-    <FormControl id={id} isInvalid={isInvalid} className={css({ alignItems: "flex-start" })}>
+    <FormControl id={id} isInvalid={isInvalid} css={{ alignItems: "flex-start" }}>
       <RadioGroupRoot {...args} value={value} onValueChange={(e) => setValue(e.value)}>
         <RadioGroupLabel>Ditt favorittfag</RadioGroupLabel>
         <FieldHelper>Husk at du må velge riktig fag!</FieldHelper>

--- a/packages/primitives/src/RadioGroup.tsx
+++ b/packages/primitives/src/RadioGroup.tsx
@@ -117,9 +117,15 @@ const InternalRadioGroupItemText = withContext<HTMLSpanElement, RadioGroup.ItemT
   "itemText",
 );
 
-export const RadioGroupItemText = ({ textStyle = "label.medium", ...props }: RadioGroup.ItemTextProps & TextProps) => (
+export const RadioGroupItemText = ({
+  textStyle = "label.medium",
+  children,
+  ...props
+}: RadioGroup.ItemTextProps & TextProps) => (
   <InternalRadioGroupItemText asChild>
-    <Text as="span" textStyle={textStyle} {...props} />
+    <Text asChild textStyle={textStyle} {...props}>
+      <span>{children}</span>
+    </Text>
   </InternalRadioGroupItemText>
 );
 

--- a/packages/primitives/src/Skeleton.tsx
+++ b/packages/primitives/src/Skeleton.tsx
@@ -8,8 +8,9 @@
 
 import { HTMLArkProps, ark } from "@ark-ui/react";
 import { styled } from "@ndla/styled-system/jsx";
+import { WithCss } from "@ndla/styled-system/types";
 
-const StyledDiv = styled(ark.div, {
+export const Skeleton = styled(ark.div, {
   base: {
     animation: "skeleton-pulse",
     backgroundColor: "surface.disabled",
@@ -25,8 +26,4 @@ const StyledDiv = styled(ark.div, {
   },
 });
 
-export interface SkeletonProps extends HTMLArkProps<"div"> {}
-
-export const Skeleton = (props: SkeletonProps) => {
-  return <StyledDiv {...props} />;
-};
+export interface SkeletonProps extends HTMLArkProps<"div">, WithCss {}

--- a/packages/primitives/src/Slider.tsx
+++ b/packages/primitives/src/Slider.tsx
@@ -9,6 +9,7 @@
 import { sliderAnatomy } from "@ark-ui/anatomy";
 import { Slider } from "@ark-ui/react";
 import { sva } from "@ndla/styled-system/css";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 import { createStyleContext } from "./createStyleContext";
 import { Label } from "./Label";
 import { TextProps } from "./Text";
@@ -80,21 +81,27 @@ const sliderRecipe = sva({
 
 const { withProvider, withContext } = createStyleContext(sliderRecipe);
 
-export type SliderRootProps = Slider.RootProps;
+export type SliderRootProps = Slider.RootProps & JsxStyleProps;
 
 export const SliderRoot = withProvider<HTMLDivElement, SliderRootProps>(Slider.Root, "root");
 
-export const SliderControl = withContext<HTMLDivElement, Slider.ControlProps>(Slider.Control, "control");
+export const SliderControl = withContext<HTMLDivElement, JsxStyleProps & Slider.ControlProps>(
+  Slider.Control,
+  "control",
+);
 
-export const SliderTrack = withContext<HTMLDivElement, Slider.TrackProps>(Slider.Track, "track");
+export const SliderTrack = withContext<HTMLDivElement, JsxStyleProps & Slider.TrackProps>(Slider.Track, "track");
 
-export const SliderRange = withContext<HTMLDivElement, Slider.RangeProps>(Slider.Range, "range");
+export const SliderRange = withContext<HTMLDivElement, JsxStyleProps & Slider.RangeProps>(Slider.Range, "range");
 
-export const SliderThumb = withContext<HTMLDivElement, Slider.ThumbProps>(Slider.Thumb, "thumb");
+export const SliderThumb = withContext<HTMLDivElement, JsxStyleProps & Slider.ThumbProps>(Slider.Thumb, "thumb");
 
-const InternalSliderLabel = withContext<HTMLDivElement, Slider.LabelProps>(Slider.Label, "label");
+const InternalSliderLabel = withContext<HTMLDivElement, JsxStyleProps & Slider.LabelProps>(Slider.Label, "label");
 
-export const SliderLabel = ({ textStyle = "label.medium", ...props }: Slider.LabelProps & TextProps) => (
+export const SliderLabel = ({
+  textStyle = "label.medium",
+  ...props
+}: Slider.LabelProps & TextProps & JsxStyleProps) => (
   <InternalSliderLabel asChild>
     <Label textStyle={textStyle} {...props} />
   </InternalSliderLabel>

--- a/packages/primitives/src/Spinner.tsx
+++ b/packages/primitives/src/Spinner.tsx
@@ -6,8 +6,8 @@
  *
  */
 
-import { ComponentPropsWithoutRef } from "react";
-import { RecipeVariantProps, cva, cx } from "@ndla/styled-system/css";
+import { HTMLArkProps, ark } from "@ark-ui/react";
+import { RecipeVariantProps, cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
 
 export const spinnerRecipe = cva({
@@ -43,8 +43,6 @@ export const spinnerRecipe = cva({
 
 export type SpinnerVariantProps = RecipeVariantProps<typeof spinnerRecipe>;
 
-export type SpinnerProps = ComponentPropsWithoutRef<"div"> & SpinnerVariantProps;
+export type SpinnerProps = HTMLArkProps<"div"> & SpinnerVariantProps;
 
-export const Spinner = ({ size, className, ...props }: SpinnerProps) => (
-  <styled.div className={cx(spinnerRecipe({ size }), className)} {...props} />
-);
+export const Spinner = styled(ark.div, spinnerRecipe);

--- a/packages/primitives/src/Switch.tsx
+++ b/packages/primitives/src/Switch.tsx
@@ -122,10 +122,13 @@ const InternalSwitchLabel = withContext<HTMLSpanElement, JsxStyleProps & Switch.
 
 export const SwitchLabel = ({
   textStyle = "label.medium",
+  children,
   ...props
 }: Switch.LabelProps & TextProps & JsxStyleProps) => (
   <InternalSwitchLabel asChild>
-    <Text as="span" textStyle={textStyle} {...props} />
+    <Text asChild textStyle={textStyle} {...props}>
+      <span>{children}</span>
+    </Text>
   </InternalSwitchLabel>
 );
 

--- a/packages/primitives/src/Switch.tsx
+++ b/packages/primitives/src/Switch.tsx
@@ -10,6 +10,7 @@ import { forwardRef } from "react";
 import { switchAnatomy } from "@ark-ui/anatomy";
 import { Switch } from "@ark-ui/react";
 import { RecipeVariantProps, sva } from "@ndla/styled-system/css";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 import { createStyleContext } from "./createStyleContext";
 import { useFormControl } from "./FormControl";
 import { Text, TextProps } from "./Text";
@@ -101,22 +102,28 @@ const { withProvider, withContext } = createStyleContext(switchRecipe);
 
 export type SwitchVariantProps = RecipeVariantProps<typeof switchRecipe>;
 
-export type SwitchRootProps = Switch.RootProps & SwitchVariantProps;
+export type SwitchRootProps = Switch.RootProps & JsxStyleProps & SwitchVariantProps;
 
-export const InternalSwitchRoot = withProvider<HTMLLabelElement, SwitchRootProps>(Switch.Root, "root");
+const InternalSwitchRoot = withProvider<HTMLLabelElement, SwitchRootProps>(Switch.Root, "root");
 
 export const SwitchRoot = forwardRef<HTMLLabelElement, SwitchRootProps>((props, ref) => {
   const field = useFormControl(props);
   return <InternalSwitchRoot invalid={field.invalid ?? !!field["aria-invalid"]} {...field} ref={ref} />;
 });
 
-export const SwitchControl = withContext<HTMLSpanElement, Switch.ControlProps>(Switch.Control, "control");
+export const SwitchControl = withContext<HTMLSpanElement, JsxStyleProps & Switch.ControlProps>(
+  Switch.Control,
+  "control",
+);
 
-export const SwitchThumb = withContext<HTMLSpanElement, Switch.ThumbProps>(Switch.Thumb, "thumb");
+export const SwitchThumb = withContext<HTMLSpanElement, JsxStyleProps & Switch.ThumbProps>(Switch.Thumb, "thumb");
 
-export const InternalSwitchLabel = withContext<HTMLSpanElement, Switch.LabelProps>(Switch.Label, "label");
+const InternalSwitchLabel = withContext<HTMLSpanElement, JsxStyleProps & Switch.LabelProps>(Switch.Label, "label");
 
-export const SwitchLabel = ({ textStyle = "label.medium", ...props }: Switch.LabelProps & TextProps) => (
+export const SwitchLabel = ({
+  textStyle = "label.medium",
+  ...props
+}: Switch.LabelProps & TextProps & JsxStyleProps) => (
   <InternalSwitchLabel asChild>
     <Text as="span" textStyle={textStyle} {...props} />
   </InternalSwitchLabel>

--- a/packages/primitives/src/Table.tsx
+++ b/packages/primitives/src/Table.tsx
@@ -6,10 +6,13 @@
  *
  */
 
-import { ComponentPropsWithoutRef } from "react";
+import { HTMLArkProps, ark } from "@ark-ui/react";
 import { styled } from "@ndla/styled-system/jsx";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 
-const StyledTable = styled("table", {
+export type TableProps = HTMLArkProps<"table"> & JsxStyleProps;
+
+export const Table = styled(ark.table, {
   base: {
     display: "block",
     overflowX: "auto",
@@ -71,7 +74,3 @@ const StyledTable = styled("table", {
     },
   },
 });
-
-export type TableProps = ComponentPropsWithoutRef<"table">;
-
-export const Table = (props: TableProps) => <StyledTable {...props} />;

--- a/packages/primitives/src/Text.stories.tsx
+++ b/packages/primitives/src/Text.stories.tsx
@@ -225,7 +225,8 @@ export const Styled = () => (
       automatically fall back to using className if the component does not support the <code>css</code> prop.
     </Text>
     <StyledText css={{ textStyle: "body.link" }}>
-      As a general rule of thumb, <code>css</code> usage wins over using the <code>styled</code> function
+      As a general rule of thumb, <code>css</code> usage wins over using the <code>styled</code> function. Furthermore,
+      the <code>styled</code> function wins over any allowed style props (like <code>textStyle</code>).
     </StyledText>
   </div>
 );

--- a/packages/primitives/src/Text.stories.tsx
+++ b/packages/primitives/src/Text.stories.tsx
@@ -7,7 +7,9 @@
  */
 
 import { Meta, StoryFn, StoryObj } from "@storybook/react";
-import { Text } from "./Text";
+import { css } from "@ndla/styled-system/css";
+import { styled } from "@ndla/styled-system/jsx";
+import { Heading, Text } from "./Text";
 
 const exampleText = "Nasjonal digital læringsarena";
 
@@ -179,6 +181,39 @@ export const Polymorphic: StoryFn<typeof Text> = () => (
     The underlying HTML tag can be changed through the use of the <code>as</code> prop! To keep TypeScript happy, we
     only allow for a subset of HTML tags.
   </Text>
+);
+
+const StyledText = styled(Text, {
+  base: {
+    textStyle: "heading.large",
+  },
+});
+
+const StyledHeading = styled(Heading, {
+  base: {
+    textStyle: "heading.small",
+  },
+});
+
+export const Styled = () => (
+  <div className={css({ display: "flex", flexDirection: "column", gap: "xsmall" })}>
+    <StyledHeading as="h2">Styling pre-styled components</StyledHeading>
+    <StyledText>
+      You can restyle components by using the <code>styled</code> function. This will override existing styles.
+    </StyledText>
+    <Text css={css.raw({ textStyle: "label.small" })}>
+      You can do the same by using the <code>css</code> prop, as long as the underlying component supports it. This is
+      what the <code>styled</code> function does under the hood.
+    </Text>
+    <Text>
+      Finally, you can style components by using the <code>className</code> prop. This is not as powerful as the two
+      prior options, as it doesn't necessarily override existing styles. The <code>styled</code> function will
+      automatically fall back to using className if the component does not support the <code>css</code> prop.
+    </Text>
+    <StyledText css={{ textStyle: "body.link" }}>
+      As a general rule of thumb, <code>css</code> usage wins over using the <code>styled</code> function
+    </StyledText>
+  </div>
 );
 
 /**

--- a/packages/primitives/src/Text.stories.tsx
+++ b/packages/primitives/src/Text.stories.tsx
@@ -177,29 +177,43 @@ export const LabelXsmall: StoryObj<typeof Text> = {
 };
 
 export const Polymorphic: StoryFn<typeof Text> = () => (
-  <Text as="div">
-    The underlying HTML tag can be changed through the use of the <code>as</code> prop! To keep TypeScript happy, we
-    only allow for a subset of HTML tags.
+  <Text asChild>
+    <div>
+      The underlying HTML tag can be changed through the use of the <code>asChild</code> prop!
+    </div>
   </Text>
 );
 
-const StyledText = styled(Text, {
-  base: {
-    textStyle: "heading.large",
+const StyledText = styled(
+  Text,
+  {
+    base: {
+      textStyle: "heading.large",
+    },
   },
-});
+  { forwardCssProp: true },
+);
 
-const StyledHeading = styled(Heading, {
-  base: {
-    textStyle: "heading.small",
+const StyledHeading = styled(
+  Heading,
+  {
+    base: {
+      textStyle: "heading.small",
+    },
   },
-});
+  { forwardCssProp: true },
+);
 
 export const Styled = () => (
   <div className={css({ display: "flex", flexDirection: "column", gap: "xsmall" })}>
-    <StyledHeading as="h2">Styling pre-styled components</StyledHeading>
+    <StyledHeading>Styling pre-styled components</StyledHeading>
     <StyledText>
       You can restyle components by using the <code>styled</code> function. This will override existing styles.
+    </StyledText>
+    <StyledText asChild>
+      <span>
+        This pattern also works flawlessly with the <code>asChild</code> prop.
+      </span>
     </StyledText>
     <Text css={css.raw({ textStyle: "label.small" })}>
       You can do the same by using the <code>css</code> prop, as long as the underlying component supports it. This is

--- a/packages/primitives/src/Text.tsx
+++ b/packages/primitives/src/Text.tsx
@@ -9,6 +9,7 @@
 import { ComponentPropsWithoutRef, ElementType } from "react";
 import { css, cx } from "@ndla/styled-system/css";
 import { ColorToken, FontWeightToken } from "@ndla/styled-system/tokens";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 import { UtilityValues } from "@ndla/styled-system/types/prop-type";
 
 export interface TextProps {
@@ -18,11 +19,21 @@ export interface TextProps {
   srOnly?: boolean;
 }
 
-type Props<T extends ElementType> = TextProps & { as?: T } & ComponentPropsWithoutRef<T>;
+type Props<T extends ElementType> = TextProps & { as?: T } & ComponentPropsWithoutRef<T> & JsxStyleProps;
 
 const BaseText = <T extends ElementType = "p">(props: Props<T>) => {
-  const { as: As = "p", className, fontWeight, color, textStyle = "body.medium", srOnly, ...rest } = props;
-  return <As className={cx(css({ textStyle, fontWeight, color, srOnly: srOnly }), className)} {...rest} />;
+  const {
+    as: As = "p",
+    className,
+    fontWeight,
+    color,
+    textStyle = "body.medium",
+    srOnly,
+    css: cssProp,
+    ...rest
+  } = props;
+  const base = css(css.raw({ textStyle, fontWeight, color, srOnly }), cssProp);
+  return <As className={cx(base, className)} {...rest} />;
 };
 
 export type HeadingType = Extract<ElementType, "h1" | "h2" | "h3" | "h4" | "h5" | "h6">;

--- a/packages/primitives/src/Text.tsx
+++ b/packages/primitives/src/Text.tsx
@@ -6,7 +6,8 @@
  *
  */
 
-import { ComponentPropsWithoutRef, ElementType } from "react";
+import { forwardRef } from "react";
+import { HTMLArkProps, ark } from "@ark-ui/react";
 import { css, cx } from "@ndla/styled-system/css";
 import { ColorToken, FontWeightToken } from "@ndla/styled-system/tokens";
 import { JsxStyleProps } from "@ndla/styled-system/types";
@@ -19,33 +20,14 @@ export interface TextProps {
   srOnly?: boolean;
 }
 
-type Props<T extends ElementType> = TextProps & { as?: T } & ComponentPropsWithoutRef<T> & JsxStyleProps;
+export const Text = forwardRef<HTMLParagraphElement, HTMLArkProps<"p"> & JsxStyleProps & TextProps>(
+  ({ textStyle = "body.medium", fontWeight, color, srOnly, className, css: cssProp, ...rest }, ref) => (
+    <ark.p className={cx(css({ textStyle, fontWeight, color, srOnly }, cssProp), className)} ref={ref} {...rest} />
+  ),
+);
 
-const BaseText = <T extends ElementType = "p">(props: Props<T>) => {
-  const {
-    as: As = "p",
-    className,
-    fontWeight,
-    color,
-    textStyle = "body.medium",
-    srOnly,
-    css: cssProp,
-    ...rest
-  } = props;
-  const base = css(css.raw({ textStyle, fontWeight, color, srOnly }), cssProp);
-  return <As className={cx(base, className)} {...rest} />;
-};
-
-export type HeadingType = Extract<ElementType, "h1" | "h2" | "h3" | "h4" | "h5" | "h6">;
-
-export const Heading = <T extends HeadingType = "h1">(props: Props<T>) => {
-  const { as = "h1", textStyle = "heading.medium", ...rest } = props;
-  return <BaseText as={as} textStyle={textStyle} {...rest} />;
-};
-
-type TextType = Extract<ElementType, "p" | "span" | "div">;
-
-export const Text = <T extends TextType = "p">(props: Props<T>) => {
-  const { as = "p", textStyle = "body.medium", ...rest } = props;
-  return <BaseText as={as} textStyle={textStyle} {...rest} />;
-};
+export const Heading = forwardRef<HTMLHeadingElement, HTMLArkProps<"h1"> & JsxStyleProps & TextProps>(
+  ({ textStyle = "heading.medium", fontWeight, color, srOnly, className, css: cssProp, ...rest }, ref) => (
+    <ark.h1 className={cx(css({ textStyle, fontWeight, color, srOnly }, cssProp), className)} ref={ref} {...rest} />
+  ),
+);

--- a/packages/primitives/src/Toast.tsx
+++ b/packages/primitives/src/Toast.tsx
@@ -65,10 +65,13 @@ const InternalToastDescription = withContext<HTMLDivElement, JsxStyleProps & Toa
 
 export const ToastDescription = ({
   textStyle = "label.medium",
+  children,
   ...props
 }: Toast.DescriptionProps & TextProps & JsxStyleProps) => (
   <InternalToastDescription asChild>
-    <Text as="div" textStyle={textStyle} {...props} />
+    <Text asChild textStyle={textStyle} {...props}>
+      <div>{children}</div>
+    </Text>
   </InternalToastDescription>
 );
 
@@ -77,9 +80,12 @@ const InternalToastTitle = withContext<HTMLDivElement, JsxStyleProps & Toast.Tit
 export const ToastTitle = ({
   textStyle = "label.medium",
   fontWeight = "semibold",
+  children,
   ...props
 }: JsxStyleProps & Toast.TitleProps & TextProps) => (
   <InternalToastTitle asChild>
-    <Text as="div" fontWeight={fontWeight} textStyle={textStyle} {...props} />
+    <Text asChild fontWeight={fontWeight} textStyle={textStyle} {...props}>
+      <div>{children}</div>
+    </Text>
   </InternalToastTitle>
 );

--- a/packages/primitives/src/Toast.tsx
+++ b/packages/primitives/src/Toast.tsx
@@ -9,6 +9,7 @@
 import { toastAnatomy } from "@ark-ui/anatomy";
 import { Toast } from "@ark-ui/react";
 import { sva } from "@ndla/styled-system/css";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 import { createStyleContext } from "./createStyleContext";
 import { Text, TextProps } from "./Text";
 
@@ -44,37 +45,40 @@ const toastRecipe = sva({
 
 const { withProvider, withContext } = createStyleContext(toastRecipe);
 
-export interface RootProps extends Toast.RootProps {}
+export interface RootProps extends Toast.RootProps, JsxStyleProps {}
 export const ToastRoot = withProvider<HTMLDivElement, RootProps>(Toast.Root, "root");
 
-export const ToastActionTrigger = withContext<HTMLButtonElement, Toast.ActionTriggerProps>(
+export const ToastActionTrigger = withContext<HTMLButtonElement, JsxStyleProps & Toast.ActionTriggerProps>(
   Toast.ActionTrigger,
   "actionTrigger",
 );
 
-export const ToastCloseTrigger = withContext<HTMLDivElement, Toast.CloseTriggerProps>(
+export const ToastCloseTrigger = withContext<HTMLDivElement, JsxStyleProps & Toast.CloseTriggerProps>(
   Toast.CloseTrigger,
   "closeTrigger",
 );
 
-export const InternalToastDescription = withContext<HTMLDivElement, Toast.DescriptionProps>(
+const InternalToastDescription = withContext<HTMLDivElement, JsxStyleProps & Toast.DescriptionProps>(
   Toast.Description,
   "description",
 );
 
-export const ToastDescription = ({ textStyle = "label.medium", ...props }: Toast.DescriptionProps & TextProps) => (
+export const ToastDescription = ({
+  textStyle = "label.medium",
+  ...props
+}: Toast.DescriptionProps & TextProps & JsxStyleProps) => (
   <InternalToastDescription asChild>
     <Text as="div" textStyle={textStyle} {...props} />
   </InternalToastDescription>
 );
 
-export const InternalToastTitle = withContext<HTMLDivElement, Toast.TitleProps>(Toast.Title, "title");
+const InternalToastTitle = withContext<HTMLDivElement, JsxStyleProps & Toast.TitleProps>(Toast.Title, "title");
 
 export const ToastTitle = ({
   textStyle = "label.medium",
   fontWeight = "semibold",
   ...props
-}: Toast.TitleProps & TextProps) => (
+}: JsxStyleProps & Toast.TitleProps & TextProps) => (
   <InternalToastTitle asChild>
     <Text as="div" fontWeight={fontWeight} textStyle={textStyle} {...props} />
   </InternalToastTitle>

--- a/packages/primitives/src/Tooltip.tsx
+++ b/packages/primitives/src/Tooltip.tsx
@@ -10,6 +10,7 @@ import { forwardRef } from "react";
 import { tooltipAnatomy } from "@ark-ui/anatomy";
 import { Tooltip } from "@ark-ui/react";
 import { sva } from "@ndla/styled-system/css";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 import { createStyleContext } from "./createStyleContext";
 
 const tooltipRecipe = sva({
@@ -38,23 +39,37 @@ const { withRootProvider, withContext } = createStyleContext(tooltipRecipe);
 export type TooltipRootProps = Tooltip.RootProps;
 export const TooltipRoot = withRootProvider<TooltipRootProps>(Tooltip.Root);
 
-export const TooltipArrow = withContext<HTMLDivElement, Tooltip.ArrowProps>(Tooltip.Arrow, "arrow");
+export const TooltipArrow = withContext<HTMLDivElement, JsxStyleProps & Tooltip.ArrowProps>(Tooltip.Arrow, "arrow");
 
-export const TooltipArrowTip = withContext<HTMLDivElement, Tooltip.ArrowTipProps>(Tooltip.ArrowTip, "arrowTip");
+export const TooltipArrowTip = withContext<HTMLDivElement, JsxStyleProps & Tooltip.ArrowTipProps>(
+  Tooltip.ArrowTip,
+  "arrowTip",
+);
 
-export const TooltipContentStandalone = withContext<HTMLDivElement, Tooltip.ContentProps>(Tooltip.Content, "content");
+export const TooltipContentStandalone = withContext<HTMLDivElement, JsxStyleProps & Tooltip.ContentProps>(
+  Tooltip.Content,
+  "content",
+);
 
-export const TooltipContent = forwardRef<HTMLDivElement, Tooltip.ContentProps>(({ children, ...props }, ref) => (
-  <TooltipPositioner>
-    <TooltipContentStandalone {...props} ref={ref}>
-      <TooltipArrow>
-        <TooltipArrowTip />
-      </TooltipArrow>
-      {children}
-    </TooltipContentStandalone>
-  </TooltipPositioner>
-));
+export const TooltipContent = forwardRef<HTMLDivElement, JsxStyleProps & Tooltip.ContentProps>(
+  ({ children, ...props }, ref) => (
+    <TooltipPositioner>
+      <TooltipContentStandalone {...props} ref={ref}>
+        <TooltipArrow>
+          <TooltipArrowTip />
+        </TooltipArrow>
+        {children}
+      </TooltipContentStandalone>
+    </TooltipPositioner>
+  ),
+);
 
-export const TooltipPositioner = withContext<HTMLDivElement, Tooltip.PositionerProps>(Tooltip.Positioner, "positioner");
+export const TooltipPositioner = withContext<HTMLDivElement, JsxStyleProps & Tooltip.PositionerProps>(
+  Tooltip.Positioner,
+  "positioner",
+);
 
-export const TooltipTrigger = withContext<HTMLButtonElement, Tooltip.TriggerProps>(Tooltip.Trigger, "trigger");
+export const TooltipTrigger = withContext<HTMLButtonElement, JsxStyleProps & Tooltip.TriggerProps>(
+  Tooltip.Trigger,
+  "trigger",
+);

--- a/packages/primitives/src/createStyleContext.tsx
+++ b/packages/primitives/src/createStyleContext.tsx
@@ -15,12 +15,14 @@ import {
   forwardRef,
   useContext,
 } from "react";
-import { cx } from "@ndla/styled-system/css";
+import { css, cx } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
+import { SystemStyleObject, WithCss } from "@ndla/styled-system/types";
 
 type Props = Record<string, unknown>;
 type Recipe = {
   (props?: Props): Props;
+  raw: (props?: Props) => Props;
   splitVariantProps: (props: Props) => [Props, Props];
 };
 type Slot<R extends Recipe> = keyof ReturnType<R>;
@@ -29,12 +31,12 @@ type Slot<R extends Recipe> = keyof ReturnType<R>;
  * A utility for creating a style context for a recipe, allowing one to change the styles of all parts of a component from the root component. Credit: https://github.com/cschroeter/park-ui/blob/main/website/src/lib/create-style-context.tsx.
  */
 export const createStyleContext = <R extends Recipe>(recipe: R) => {
-  const StyleContext = createContext<Record<Slot<R>, string> | null>(null);
+  const StyleContext = createContext<Record<Slot<R>, SystemStyleObject> | null>(null);
 
   const withRootProvider = <P extends {}>(Component: ElementType) => {
     const StyledComponent = (props: P) => {
       const [variantProps, otherProps] = recipe.splitVariantProps(props);
-      const slotStyles = recipe(variantProps) as Record<Slot<R>, string>;
+      const slotStyles = recipe.raw(variantProps) as Record<Slot<R>, SystemStyleObject>;
 
       return (
         <StyleContext.Provider value={slotStyles}>
@@ -45,31 +47,32 @@ export const createStyleContext = <R extends Recipe>(recipe: R) => {
     return StyledComponent;
   };
 
-  const withProvider = <T, P extends { className?: string }>(
+  const withProvider = <T, P extends { className?: string } & WithCss>(
     Component: ElementType,
     slot: Slot<R>,
   ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> => {
     const StyledComponent = styled(Component);
-    return forwardRef<T, P>((props, ref) => {
+    return forwardRef<T, P>(({ className, css: cssProp, ...props }, ref) => {
       const [variantProps, otherProps] = recipe.splitVariantProps(props);
-      const slotStyles = recipe(variantProps) as Record<Slot<R>, string>;
+
+      const slotStyles = recipe.raw(variantProps) as Record<Slot<R>, SystemStyleObject>;
 
       return (
         <StyleContext.Provider value={slotStyles}>
-          <StyledComponent {...otherProps} ref={ref} className={cx(slotStyles?.[slot], props.className)} />
+          <StyledComponent {...otherProps} ref={ref} className={cx(css(slotStyles?.[slot], cssProp), className)} />
         </StyleContext.Provider>
       );
     });
   };
 
-  const withContext = <T, P extends { className?: string }>(
+  const withContext = <T, P extends { className?: string } & WithCss>(
     Component: ElementType,
     slot: Slot<R>,
   ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> => {
     const StyledComponent = styled(Component);
-    return forwardRef<T, P>((props, ref) => {
+    return forwardRef<T, P>(({ className, css: cssProp, ...props }, ref) => {
       const slotStyles = useContext(StyleContext);
-      return <StyledComponent {...props} ref={ref} className={cx(slotStyles?.[slot], props.className)} />;
+      return <StyledComponent {...props} ref={ref} className={cx(css(slotStyles?.[slot], cssProp), className)} />;
     });
   };
 

--- a/packages/safelink/src/SafeLinkButton.tsx
+++ b/packages/safelink/src/SafeLinkButton.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { forwardRef, ReactNode } from "react";
 import { buttonStyleV2, ButtonStyleProps } from "@ndla/button";
 import SafeLink, { SafeLinkProps } from "./SafeLink";

--- a/packages/safelink/src/SafeLinkIconButton.tsx
+++ b/packages/safelink/src/SafeLinkIconButton.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { forwardRef, ReactNode } from "react";
 import { ButtonStyleProps, iconButtonStyle } from "@ndla/button";
 import SafeLink, { SafeLinkProps } from "./SafeLink";

--- a/packages/select/src/Select/BaseMenu.tsx
+++ b/packages/select/src/Select/BaseMenu.tsx
@@ -6,6 +6,7 @@
  *
  */
 
+/** @jsxImportSource @emotion/react */
 import { MenuProps, components, GroupBase } from "react-select";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -11,15 +11,12 @@ import preset from "./packages/preset-panda/src/";
 
 export default defineConfig({
   presets: [preset],
-  importMap: "@ndla/styled-system",
   preflight: true,
+  importMap: "@ndla/styled-system",
   strictPropertyValues: true,
-  include: [
-    "./packages/primitives/**/*.{js,jsx,ts,tsx}",
-    "./packages/preset-panda/**/*.{js,jsx,ts,tsx}",
-    "./stories/**/*.{js,jsx,ts,tsx}",
-  ],
-  exclude: [],
+  shorthands: false,
+  outExtension: "mjs",
+  include: ["./packages/**/*.{js,jsx,ts,tsx}", "./stories/**/*.{js,jsx,ts,tsx}"],
+  syntax: "object-literal",
   jsxFramework: "react",
-  outdir: "./packages/styled-system",
 });

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -14,8 +14,12 @@ export default defineConfig({
   importMap: "@ndla/styled-system",
   preflight: true,
   strictPropertyValues: true,
-  include: ["./packages/*/src/**/*.{js,jsx,ts,tsx}", "./stories/**/*.{js,jsx,ts,tsx}"],
+  include: [
+    "./packages/primitives/**/*.{js,jsx,ts,tsx}",
+    "./packages/preset-panda/**/*.{js,jsx,ts,tsx}",
+    "./stories/**/*.{js,jsx,ts,tsx}",
+  ],
   exclude: [],
   jsxFramework: "react",
-  outdir: "styled-system",
+  outdir: "./packages/styled-system",
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es5",
     "esModuleInterop": true,
     "jsx": "react-jsx",
-    "jsxImportSource": "@emotion/react",
+    // "jsxImportSource": "@emotion/react",
     "isolatedModules": true,
     "strict": true,
     "allowJs": true,
@@ -15,7 +15,7 @@
     "noEmit": true,
     "sourceMap": true,
     "lib": ["ES2023", "esnext.asynciterable", "dom"],
-    "types": ["@emotion/react", "@emotion/styled", "jest", "node"],
+    "types": ["jest", "node"],
     "paths": {
       "@ndla/article-converter": ["./packages/article-converter/src"],
       "@ndla/button": ["./packages/button/src"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "target": "es5",
     "esModuleInterop": true,
     "jsx": "react-jsx",
-    // "jsxImportSource": "@emotion/react",
     "isolatedModules": true,
     "strict": true,
     "allowJs": true,


### PR DESCRIPTION
Denne PR'en gjør en del forskjellige ting:

* Fjerner globale emotion-typer. `css` vil ikke lenger være tilgjengelig på `div` f.eks
* Kjører kun emotion på filer som ikke ligger i primitives/preset-panda/styled-system.
* Setter inn eksplisitte jsx-pragmaer i filer der vi fortsatt bruker emotion-relatert funksjonalitet (ikke `styled` eller `css`). Ting som å referere til komponenter i css.
* Rydder opp i panda-oppsettet slik at storybook ikke genererer sin egen `styled-system`-mappe
* Legger til et panda-plugin som modifiserer `styled`-funksjonen til å tillate at man kan sende css-propen som genereres fra `styled` videre ned til komponenten man styler. Dette vil være nødvendig i visse situasjoner, f.eks når man har en "kompleks" komponent som inneholder logikk. På sikt håper jeg å få inn noen PR'er i panda som vil gjøre at dette ikke lenger trengs.
* Bytter ut `as` med `asChild` for å få mer konsistent kode. Nå er `asChild` overalt.