### PR TITLE
Reeling the icon back in

### DIFF
--- a/packages/ndla-ui/src/Embed/ImageEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/ImageEmbed.tsx
@@ -263,6 +263,7 @@ const StyledButton = styled.button`
   color: ${colors.white};
   background-color: ${colors.brand.primary};
   border-radius: ${misc.borderRadiusLarge};
+  line-height: 1;
   svg {
     transition: transform 0.4s ease-out;
     height: ${spacing.medium};


### PR DESCRIPTION
Pluss-ikonet i knappen for image resizing vil ellers vandre sørover på f.eks. /article/7640