### PR TITLE
Refactor forward css

### DIFF
--- a/packages/ndla-icons/panda.config.ts
+++ b/packages/ndla-icons/panda.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   shorthands: false,
   outExtension: "js",
   include: ["./src/**/*.{js,jsx,ts,tsx}"],
-  exclude: ["./src/**/*.stories.{js,jsx,ts,tsx}"],
+  exclude: ["./src/**/*.stories.{js,jsx,ts,tsx}", "./src/**/*-test.{js,jsx,ts,tsx}"],
   outdir: "../styled-system",
   importMap: "@ndla/styled-system",
   jsxFramework: "react",

--- a/packages/preset-panda/panda.config.ts
+++ b/packages/preset-panda/panda.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   shorthands: false,
   outExtension: "js",
   include: ["./src/**/*.{js,jsx,ts,tsx}"],
-  exclude: ["./src/**/*.stories.{js,jsx,ts,tsx}"],
+  exclude: ["./src/**/*.stories.{js,jsx,ts,tsx}", "./src/**/*-test.{js,jsx,ts,tsx}"],
   importMap: "@ndla/styled-system",
   outdir: "../styled-system",
   jsxFramework: "react",

--- a/packages/preset-panda/src/colors.stories.tsx
+++ b/packages/preset-panda/src/colors.stories.tsx
@@ -30,7 +30,7 @@ interface ColorBlocksProps {
 const ColorBlocks = ({ title, description, children }: ColorBlocksProps) => (
   <div>
     {title && (
-      <Heading asChild>
+      <Heading asChild consumeCss>
         <h2>{title}</h2>
       </Heading>
     )}

--- a/packages/preset-panda/src/plugins/__tests__/forwardCssProp-test.tsx
+++ b/packages/preset-panda/src/plugins/__tests__/forwardCssProp-test.tsx
@@ -1,0 +1,425 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { forwardRef } from "react";
+import { ark, HTMLArkProps } from "@ark-ui/react";
+import { render } from "@testing-library/react";
+import { css } from "@ndla/styled-system/css";
+import { styled } from "@ndla/styled-system/jsx";
+import { JsxStyleProps } from "@ndla/styled-system/types";
+
+describe("CSS prop forwarding", () => {
+  test("Should have a sane default", () => {
+    const StyledComponent = styled("div", {
+      base: {
+        display: "flex",
+      },
+    });
+
+    const { container } = render(<StyledComponent>Hello</StyledComponent>);
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <div
+        class="d_flex"
+      >
+        Hello
+      </div>
+    `);
+  });
+  test("should have a sane default when using the css prop directly on a styled element", () => {
+    const StyledComponent = styled("div", {
+      base: {
+        display: "flex",
+      },
+    });
+
+    const { container } = render(<StyledComponent css={{ display: "block" }}>Hello</StyledComponent>);
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <div
+        class="d_block"
+      >
+        Hello
+      </div>
+    `);
+  });
+  test("Should override a string styled component", () => {
+    const StyledComponent = styled("div", {
+      base: {
+        color: "grey.50",
+        display: "flex",
+      },
+    });
+
+    const StyledStyledComponent = styled(StyledComponent, {
+      base: {
+        padding: "small",
+        display: "block",
+      },
+    });
+
+    const StyledStyledStyledComponent = styled(StyledStyledComponent, {
+      base: {
+        borderRadius: "xsmall",
+        display: "inline",
+      },
+    });
+
+    const { container } = render(<StyledStyledStyledComponent>Hello</StyledStyledStyledComponent>);
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <div
+        class="text_grey.50 d_inline p_small rounded_xsmall"
+      >
+        Hello
+      </div>
+    `);
+  });
+
+  test("css prop should win over styled string component", () => {
+    const StyledComponent = styled("div", {
+      base: {
+        color: "grey.50",
+        display: "flex",
+      },
+    });
+
+    const StyledStyledComponent = styled(StyledComponent, {
+      base: {
+        padding: "small",
+        display: "block",
+      },
+    });
+
+    const { container } = render(
+      <StyledStyledComponent css={{ display: "inline", border: "1px" }}>Hello</StyledStyledComponent>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <div
+        class="text_grey.50 d_inline p_small border_1px"
+      >
+        Hello
+      </div>
+    `);
+  });
+
+  test("css prop should win over styled react component", () => {
+    const StyledComponent = styled(
+      ark.div,
+      {
+        base: {
+          color: "grey.50",
+          display: "flex",
+        },
+      },
+      { baseComponent: true },
+    );
+
+    const StyledStyledComponent = styled(StyledComponent, {
+      base: {
+        padding: "small",
+        display: "block",
+      },
+    });
+
+    const { container } = render(
+      <StyledStyledComponent css={{ display: "inline", border: "1px" }}>Hello</StyledStyledComponent>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <div
+        class="text_grey.50 d_inline p_small border_1px"
+      >
+        Hello
+      </div>
+    `);
+  });
+
+  test("should override a react component styled component", () => {
+    const StyledComponent = styled(
+      ark.div,
+      {
+        base: {
+          color: "grey.50",
+          display: "flex",
+        },
+      },
+      { baseComponent: true },
+    );
+
+    const StyledStyledComponent = styled(StyledComponent, {
+      base: {
+        padding: "xsmall",
+        display: "block",
+      },
+    });
+
+    const StyledStyledStyledComponent = styled(StyledStyledComponent, {
+      base: {
+        borderRadius: "xsmall",
+        display: "inline",
+      },
+    });
+
+    const { container } = render(<StyledStyledStyledComponent>Hello</StyledStyledStyledComponent>);
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <div
+        class="text_grey.50 d_inline p_xsmall rounded_xsmall"
+      >
+        Hello
+      </div>
+    `);
+  });
+
+  test("merging components components with asChild merges the css prop", () => {
+    const StyledOuter = styled(
+      ark.div,
+      {
+        base: {
+          color: "grey.50",
+          display: "flex",
+        },
+      },
+      { baseComponent: true },
+    );
+
+    const StyledMiddle = styled(
+      ark.div,
+      {
+        base: {
+          padding: "xsmall",
+          display: "block",
+        },
+      },
+      { baseComponent: true },
+    );
+
+    const StyledInner = styled(
+      ark.div,
+      {
+        base: {
+          borderRadius: "xsmall",
+          display: "inline",
+        },
+      },
+      { baseComponent: true },
+    );
+
+    const { container } = render(
+      <StyledOuter asChild>
+        <StyledMiddle asChild>
+          <StyledInner>Hello</StyledInner>
+        </StyledMiddle>
+      </StyledOuter>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <div
+        class="rounded_xsmall d_flex p_xsmall text_grey.50"
+      >
+        Hello
+      </div>
+    `);
+  });
+
+  test("when merging inline css and css from asChild, the one from asChild wins", () => {
+    const StyledOuter = styled(
+      ark.div,
+      {
+        base: {
+          display: "flex",
+          color: "grey.50",
+        },
+      },
+      { baseComponent: true },
+    );
+
+    const StyledInner = styled(
+      ark.div,
+      {
+        base: {
+          display: "inline",
+        },
+      },
+      { baseComponent: true },
+    );
+
+    const { container } = render(
+      <StyledOuter asChild>
+        <StyledInner css={{ display: "block" }}>Hello</StyledInner>
+      </StyledOuter>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <div
+        class="d_block"
+      >
+        Hello
+      </div>
+    `);
+  });
+
+  test("css prop usage should win when asChilded onto a styled component", () => {
+    const StyledOuter = styled(
+      ark.div,
+      {
+        base: {
+          display: "flex",
+        },
+      },
+      { baseComponent: true },
+    );
+
+    const StyledInner = styled(
+      ark.div,
+      {
+        base: {
+          borderRadius: "xsmall",
+          display: "inline",
+        },
+      },
+      { baseComponent: true },
+    );
+
+    const { container } = render(
+      <StyledOuter asChild css={{ display: "block", color: "primary" }}>
+        <StyledInner>Hello</StyledInner>
+      </StyledOuter>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <div
+        class="rounded_xsmall d_block text_primary"
+      >
+        Hello
+      </div>
+    `);
+  });
+
+  test("should allow for automatically merging complex components", () => {
+    const Text = ({ children, css: cssProp, ...rest }: HTMLArkProps<"div"> & JsxStyleProps) => {
+      return (
+        <styled.p className={css({ textStyle: "heading.large", display: "block" }, cssProp)} {...rest}>
+          {children}
+        </styled.p>
+      );
+    };
+
+    const StyledText = styled(Text, {
+      base: {
+        textStyle: "heading.small",
+      },
+    });
+
+    const { container } = render(<StyledText>Hello</StyledText>);
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <p
+        class="textStyle_heading.small d_block"
+      >
+        Hello
+      </p>
+    `);
+  });
+
+  test("converts itself to a class name when asChilded onto a regular component", () => {
+    const StyledContainer = styled(
+      ark.div,
+      {
+        base: {
+          display: "flex",
+        },
+      },
+      { baseComponent: true },
+    );
+
+    const { container } = render(
+      <StyledContainer asChild consumeCss>
+        <span>Hello</span>
+      </StyledContainer>,
+    );
+
+    const notAsChildedResult = render(<StyledContainer>Hello</StyledContainer>);
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <span
+        class="d_flex"
+      >
+        Hello
+      </span>
+    `);
+
+    expect(notAsChildedResult.container.firstChild).toMatchInlineSnapshot(`
+      <div
+        class="d_flex"
+      >
+        Hello
+      </div>
+    `);
+  });
+
+  test("should automatically merge complex components wrapped in styled and asChilded to a non-complex component", () => {
+    const StyledBase = styled(
+      ark.div,
+      {
+        base: {
+          textStyle: "heading.medium",
+        },
+      },
+      { baseComponent: true },
+    );
+
+    const Text = forwardRef<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(
+      ({ children, css: cssProp, ...rest }, ref) => {
+        return (
+          <StyledBase css={css.raw({ textStyle: "heading.large" }, cssProp)} {...rest} ref={ref}>
+            {children}
+          </StyledBase>
+        );
+      },
+    );
+
+    const StyledText = styled(Text, {
+      base: {
+        textStyle: "heading.small",
+      },
+    });
+
+    const LinkText = forwardRef<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(
+      ({ children, css: cssProp, ...rest }, ref) => {
+        return (
+          <StyledText css={css.raw({ textStyle: "body.articleLink" }, cssProp)} {...rest} ref={ref}>
+            {children}
+          </StyledText>
+        );
+      },
+    );
+
+    const StyledLinkText = styled(LinkText, {
+      base: {
+        textStyle: "body.link",
+      },
+    });
+
+    const { container } = render(
+      <StyledLinkText asChild consumeCss>
+        <span>Hello</span>
+      </StyledLinkText>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <span
+        class="textStyle_body.link"
+      >
+        Hello
+      </span>
+    `);
+  });
+});

--- a/packages/primitives/panda.config.ts
+++ b/packages/primitives/panda.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   shorthands: false,
   outExtension: "js",
   include: ["./src/**/*.{js,jsx,ts,tsx}"],
-  exclude: ["./src/**/*.stories.{js,jsx,ts,tsx}"],
+  exclude: ["./src/**/*.stories.{js,jsx,ts,tsx}", "./src/**/*-test.{js,jsx,ts,tsx}"],
   outdir: "../styled-system",
   importMap: "@ndla/styled-system",
   jsxFramework: "react",

--- a/packages/primitives/src/Accordion.stories.tsx
+++ b/packages/primitives/src/Accordion.stories.tsx
@@ -28,7 +28,7 @@ const meta: Meta<typeof AccordionRoot> = {
   render: (args) => (
     <AccordionRoot {...args}>
       <AccordionItem value={"1"}>
-        <Heading asChild textStyle="label.medium" fontWeight="bold">
+        <Heading asChild consumeCss textStyle="label.medium" fontWeight="bold">
           <h2>
             <AccordionItemTrigger>
               Tittel
@@ -46,7 +46,7 @@ const meta: Meta<typeof AccordionRoot> = {
         </AccordionItemContent>
       </AccordionItem>
       <AccordionItem value={"2"}>
-        <Heading asChild textStyle="label.medium" fontWeight="bold">
+        <Heading asChild consumeCss textStyle="label.medium" fontWeight="bold">
           <h2>
             <AccordionItemTrigger>
               Tittel

--- a/packages/primitives/src/ArticleLists.tsx
+++ b/packages/primitives/src/ArticleLists.tsx
@@ -6,15 +6,13 @@
  *
  */
 
-import { HTMLArkProps } from "@ark-ui/react";
+import { forwardRef } from "react";
+import { HTMLArkProps, ark } from "@ark-ui/react";
+import { css, cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
-import { JsxStyleProps, StyledVariantProps } from "@ndla/styled-system/types";
+import { JsxStyleProps, RecipeVariantProps } from "@ndla/styled-system/types";
 
-export type OrderedListVariantProps = StyledVariantProps<typeof OrderedList>;
-
-export type OrderedListProps = HTMLArkProps<"ol"> & JsxStyleProps & OrderedListVariantProps;
-
-export const OrderedList = styled("ol", {
+const orderedListRecipe = cva({
   base: {
     listStyle: "revert",
     listStylePosition: "inside",
@@ -61,6 +59,18 @@ export const OrderedList = styled("ol", {
     },
   },
 });
+
+export type OrderedListVariantProps = RecipeVariantProps<typeof orderedListRecipe>;
+
+export type OrderedListProps = HTMLArkProps<"ol"> & JsxStyleProps & OrderedListVariantProps;
+
+const StyledOrderedList = styled(ark.ol, {}, { baseComponent: true });
+
+export const OrderedList = forwardRef<HTMLOListElement, OrderedListProps>(
+  ({ variant, css: cssProp, ...props }, ref) => (
+    <StyledOrderedList css={css.raw(orderedListRecipe.raw({ variant }), cssProp)} {...props} ref={ref} />
+  ),
+);
 
 export type UnOrderedListProps = HTMLArkProps<"ul"> & JsxStyleProps;
 

--- a/packages/primitives/src/Badge.tsx
+++ b/packages/primitives/src/Badge.tsx
@@ -6,8 +6,9 @@
  *
  */
 
+import { forwardRef } from "react";
 import { HTMLArkProps, ark } from "@ark-ui/react";
-import { RecipeVariantProps, cva } from "@ndla/styled-system/css";
+import { RecipeVariantProps, css, cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
 import { JsxStyleProps } from "@ndla/styled-system/types";
 
@@ -47,4 +48,8 @@ export type BadgeVariantProps = RecipeVariantProps<typeof badgeRecipe>;
 
 export type BadgeProps = HTMLArkProps<"div"> & JsxStyleProps & BadgeVariantProps;
 
-export const Badge = styled(ark.div, badgeRecipe);
+const StyledBadge = styled(ark.div, {}, { baseComponent: true });
+
+export const Badge = forwardRef<HTMLDivElement, BadgeProps>(({ colorTheme, css: cssProp, ...props }, ref) => (
+  <StyledBadge css={css.raw(badgeRecipe.raw({ colorTheme }), cssProp)} {...props} ref={ref} />
+));

--- a/packages/primitives/src/BlockQuote.tsx
+++ b/packages/primitives/src/BlockQuote.tsx
@@ -6,8 +6,9 @@
  *
  */
 
+import { forwardRef } from "react";
 import { HTMLArkProps, ark } from "@ark-ui/react";
-import { RecipeVariantProps, cva } from "@ndla/styled-system/css";
+import { RecipeVariantProps, css, cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
 import { JsxStyleProps } from "@ndla/styled-system/types";
 
@@ -41,4 +42,8 @@ export type BlockQuoteVariantProps = RecipeVariantProps<typeof blockQuoteRecipe>
 
 export type BlockQuoteProps = HTMLArkProps<"blockquote"> & JsxStyleProps & BlockQuoteVariantProps;
 
-export const BlockQuote = styled(ark.blockquote, blockQuoteRecipe);
+const StyledBlockQuote = styled(ark.blockquote, {}, { baseComponent: true });
+
+export const BlockQuote = forwardRef<HTMLQuoteElement, BlockQuoteProps>(({ variant, css: cssProp, ...props }, ref) => (
+  <StyledBlockQuote css={css.raw(blockQuoteRecipe.raw({ variant }), cssProp)} {...props} ref={ref} />
+));

--- a/packages/primitives/src/Button.stories.tsx
+++ b/packages/primitives/src/Button.stories.tsx
@@ -95,17 +95,13 @@ export const WithIcon: StoryObj<typeof Button> = {
   },
 };
 
-const UglyButton = styled(
-  Button,
-  {
-    base: {
-      background: "yellow.1000",
-      color: "text.onAction",
-      paddingBlock: "large",
-      paddingInline: "large",
-    },
+const UglyButton = styled(Button, {
+  base: {
+    background: "yellow.1000",
+    color: "text.onAction",
+    paddingBlock: "large",
+    paddingInline: "large",
   },
-  { forwardCssProp: true },
-);
+});
 
 export const StyledButtonExample = () => <UglyButton>Styled!</UglyButton>;

--- a/packages/primitives/src/Button.tsx
+++ b/packages/primitives/src/Button.tsx
@@ -193,7 +193,7 @@ export type ButtonVariantProps = { variant?: ButtonVariant } & RecipeVariantProp
 
 export type ButtonProps = HTMLArkProps<"button"> & JsxStyleProps & ButtonVariantProps;
 
-const StyledButton = styled(ark.button, {}, { defaultProps: { type: "button" } });
+const StyledButton = styled(ark.button, {}, { baseComponent: true, defaultProps: { type: "button" } });
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(({ variant, size, css: cssProp, ...props }, ref) => (
   <StyledButton
@@ -209,7 +209,7 @@ export type IconButtonVariantProps = { variant?: IconButtonVariant };
 
 export type IconButtonProps = HTMLArkProps<"button"> & IconButtonVariantProps & JsxStyleProps;
 
-const StyledIconButton = styled(ark.button, {}, { defaultProps: { type: "button" } });
+const StyledIconButton = styled(ark.button, {}, { baseComponent: true, defaultProps: { type: "button" } });
 
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(({ variant, css: cssProp, ...props }, ref) => (
   <StyledIconButton

--- a/packages/primitives/src/Checkbox.tsx
+++ b/packages/primitives/src/Checkbox.tsx
@@ -230,7 +230,7 @@ export const CheckboxLabel = ({
   children,
   ...props
 }: Checkbox.LabelProps & TextProps & JsxStyleProps) => (
-  <InternalCheckboxLabel {...props} asChild forwardCssProp>
+  <InternalCheckboxLabel {...props} asChild>
     <Text textStyle={textStyle}>{children}</Text>
   </InternalCheckboxLabel>
 );

--- a/packages/primitives/src/Combobox.stories.tsx
+++ b/packages/primitives/src/Combobox.stories.tsx
@@ -60,16 +60,16 @@ export const Default: StoryFn<typeof ComboboxRoot> = (args) => {
       <ComboboxLabel>Choose your place of residence</ComboboxLabel>
       <ComboboxControl>
         <InputContainer>
-          <ComboboxInput asChild forwardCssProp>
+          <ComboboxInput asChild>
             <Input placeholder="Where do you live?" />
           </ComboboxInput>
-          <ComboboxClearTrigger asChild forwardCssProp>
+          <ComboboxClearTrigger asChild>
             <IconButton variant="clear">
               <Cross />
             </IconButton>
           </ComboboxClearTrigger>
         </InputContainer>
-        <ComboboxTrigger asChild forwardCssProp>
+        <ComboboxTrigger asChild>
           <IconButton variant="secondary">
             <ChevronDown />
           </IconButton>
@@ -106,16 +106,16 @@ export const Disabled: StoryFn<typeof ComboboxRoot> = (args) => {
       <ComboboxLabel>Choose your place of residence</ComboboxLabel>
       <ComboboxControl>
         <InputContainer>
-          <ComboboxInput asChild forwardCssProp>
+          <ComboboxInput asChild>
             <Input placeholder="Where do you live?" />
           </ComboboxInput>
-          <ComboboxClearTrigger asChild forwardCssProp>
+          <ComboboxClearTrigger asChild>
             <IconButton variant="clear">
               <Cross />
             </IconButton>
           </ComboboxClearTrigger>
         </InputContainer>
-        <ComboboxTrigger asChild forwardCssProp>
+        <ComboboxTrigger asChild>
           <IconButton variant="secondary">
             <ChevronDown />
           </IconButton>
@@ -156,16 +156,16 @@ export const DisabledItems: StoryFn<typeof ComboboxRoot> = (args) => {
       <ComboboxLabel>Choose your place of residence</ComboboxLabel>
       <ComboboxControl>
         <InputContainer>
-          <ComboboxInput asChild forwardCssProp>
+          <ComboboxInput asChild>
             <Input placeholder="Where do you live?" />
           </ComboboxInput>
-          <ComboboxClearTrigger asChild forwardCssProp>
+          <ComboboxClearTrigger asChild>
             <IconButton variant="clear">
               <Cross />
             </IconButton>
           </ComboboxClearTrigger>
         </InputContainer>
-        <ComboboxTrigger asChild forwardCssProp>
+        <ComboboxTrigger asChild>
           <IconButton variant="secondary">
             <ChevronDown />
           </IconButton>
@@ -202,16 +202,16 @@ export const Advanced: StoryFn<typeof ComboboxRoot> = (args) => {
       <ComboboxLabel>Framework</ComboboxLabel>
       <ComboboxControl>
         <InputContainer>
-          <ComboboxInput asChild forwardCssProp>
+          <ComboboxInput asChild>
             <Input placeholder="Velg et rammeverk" />
           </ComboboxInput>
-          <ComboboxClearTrigger asChild forwardCssProp>
+          <ComboboxClearTrigger asChild>
             <IconButton variant="clear">
               <Cross />
             </IconButton>
           </ComboboxClearTrigger>
         </InputContainer>
-        <ComboboxTrigger asChild forwardCssProp>
+        <ComboboxTrigger asChild>
           <IconButton variant="secondary">
             <ChevronDown />
           </IconButton>
@@ -272,16 +272,16 @@ export const Grouped: StoryFn<typeof ComboboxRoot> = (args) => {
       <ComboboxLabel>Countries you've visited</ComboboxLabel>
       <ComboboxControl>
         <InputContainer>
-          <ComboboxInput asChild forwardCssProp>
+          <ComboboxInput asChild>
             <Input placeholder="Har du vært i Spania?" />
           </ComboboxInput>
-          <ComboboxClearTrigger asChild forwardCssProp>
+          <ComboboxClearTrigger asChild>
             <IconButton variant="clear">
               <Cross />
             </IconButton>
           </ComboboxClearTrigger>
         </InputContainer>
-        <ComboboxTrigger asChild forwardCssProp>
+        <ComboboxTrigger asChild>
           <IconButton variant="secondary">
             <ChevronDown />
           </IconButton>
@@ -336,16 +336,16 @@ export const WithField: StoryFn<typeof ComboboxRoot> = (args) => {
         <FieldErrorMessage>You have to live somewhere</FieldErrorMessage>
         <ComboboxControl>
           <InputContainer>
-            <ComboboxInput asChild forwardCssProp>
+            <ComboboxInput asChild>
               <Input placeholder="Where do you live?" />
             </ComboboxInput>
-            <ComboboxClearTrigger asChild forwardCssProp>
+            <ComboboxClearTrigger asChild>
               <IconButton variant="clear">
                 <Cross />
               </IconButton>
             </ComboboxClearTrigger>
           </InputContainer>
-          <ComboboxTrigger asChild forwardCssProp>
+          <ComboboxTrigger asChild>
             <IconButton variant="secondary">
               <ChevronDown />
             </IconButton>

--- a/packages/primitives/src/Combobox.tsx
+++ b/packages/primitives/src/Combobox.tsx
@@ -194,8 +194,8 @@ export const ComboboxItemGroupLabel = ({
   fontWeight = "bold",
   ...props
 }: Combobox.ItemGroupLabelProps & TextProps) => (
-  <InternalComboboxItemGroupLabel forwardCssProp asChild>
-    <Text asChild textStyle={textStyle} fontWeight={fontWeight} {...props}>
+  <InternalComboboxItemGroupLabel asChild>
+    <Text asChild consumeCss textStyle={textStyle} fontWeight={fontWeight} {...props}>
       <div>{children}</div>
     </Text>
   </InternalComboboxItemGroupLabel>
@@ -224,10 +224,13 @@ const InternalComboboxItemText = withContext<HTMLDivElement, Assign<JsxStyleProp
 export const ComboboxItemText = ({
   textStyle = "label.medium",
   fontWeight = "bold",
+  children,
   ...props
 }: Combobox.ItemTextProps & TextProps) => (
-  <InternalComboboxItemText forwardCssProp asChild>
-    <Text {...props} />
+  <InternalComboboxItemText asChild>
+    <Text {...props} asChild consumeCss>
+      <div>{children}</div>
+    </Text>
   </InternalComboboxItemText>
 );
 
@@ -241,7 +244,7 @@ export const ComboboxLabel = ({
   fontWeight = "bold",
   ...props
 }: Combobox.LabelProps & TextProps) => (
-  <InternalComboboxLabel forwardCssProp asChild>
+  <InternalComboboxLabel asChild>
     <Label textStyle={textStyle} fontWeight={fontWeight} {...props} />
   </InternalComboboxLabel>
 );

--- a/packages/primitives/src/Dialog.tsx
+++ b/packages/primitives/src/Dialog.tsx
@@ -296,20 +296,29 @@ const InternalDialogDescription = withContext<HTMLParagraphElement, JsxStyleProp
 
 export const DialogDescription = ({
   textStyle = "body.large",
+  children,
   ...rest
 }: Dialog.DescriptionProps & TextProps & JsxStyleProps) => {
   return (
-    <InternalDialogDescription asChild forwardCssProp>
-      <Text textStyle={textStyle} {...rest}></Text>
+    <InternalDialogDescription asChild>
+      <Text textStyle={textStyle} {...rest}>
+        {children}
+      </Text>
     </InternalDialogDescription>
   );
 };
 
 const InternalDialogTitle = withContext<HTMLHeadingElement, JsxStyleProps & Dialog.TitleProps>(Dialog.Title, "title");
 
-export const DialogTitle = ({ textStyle = "title.medium", ...rest }: Dialog.TitleProps & TextProps & JsxStyleProps) => (
-  <InternalDialogTitle asChild forwardCssProp>
-    <Heading textStyle={textStyle} {...rest}></Heading>
+export const DialogTitle = ({
+  textStyle = "title.medium",
+  children,
+  ...rest
+}: Dialog.TitleProps & TextProps & JsxStyleProps) => (
+  <InternalDialogTitle asChild>
+    <Heading textStyle={textStyle} {...rest}>
+      {children}
+    </Heading>
   </InternalDialogTitle>
 );
 

--- a/packages/primitives/src/ExpandableBox.stories.tsx
+++ b/packages/primitives/src/ExpandableBox.stories.tsx
@@ -34,7 +34,7 @@ export const Default: StoryObj<typeof ExpandableBox> = {};
 export const WithHeader: StoryFn<typeof ExpandableBox> = ({ ...args }) => (
   <ExpandableBox {...args}>
     <ExpandableBoxSummary>
-      <Heading asChild>
+      <Heading asChild consumeCss>
         <h2>Open me as header text</h2>
       </Heading>
     </ExpandableBoxSummary>

--- a/packages/primitives/src/ExpandableBox.tsx
+++ b/packages/primitives/src/ExpandableBox.tsx
@@ -32,18 +32,22 @@ export const ExpandableBox = styled("details", {
 
 export type ExpandableBoxSummaryProps = HTMLArkProps<"summary"> & JsxStyleProps;
 
-export const ExpandableBoxSummary = styled(ark.summary, {
-  base: {
-    cursor: "pointer",
-    margin: "-medium",
-    padding: "medium",
-    textStyle: "label.large!",
-    _hover: {
-      color: "text.action",
-    },
-    "& > *": {
-      display: "inline!",
+export const ExpandableBoxSummary = styled(
+  ark.summary,
+  {
+    base: {
+      cursor: "pointer",
+      margin: "-medium",
+      padding: "medium",
       textStyle: "label.large!",
+      _hover: {
+        color: "text.action",
+      },
+      "& > *": {
+        display: "inline!",
+        textStyle: "label.large!",
+      },
     },
   },
-});
+  { baseComponent: true },
+);

--- a/packages/primitives/src/Field.tsx
+++ b/packages/primitives/src/Field.tsx
@@ -9,10 +9,14 @@
 import { Field } from "@ark-ui/react";
 import { styled } from "@ndla/styled-system/jsx";
 
-export const FieldRoot = styled(Field.Root, {
-  base: {
-    display: "flex",
-    flexDirection: "column",
-    gap: "3xsmall",
+export const FieldRoot = styled(
+  Field.Root,
+  {
+    base: {
+      display: "flex",
+      flexDirection: "column",
+      gap: "3xsmall",
+    },
   },
-});
+  { baseComponent: true },
+);

--- a/packages/primitives/src/FieldErrorMessage.tsx
+++ b/packages/primitives/src/FieldErrorMessage.tsx
@@ -13,13 +13,17 @@ import { styled } from "@ndla/styled-system/jsx";
 import { JsxStyleProps } from "@ndla/styled-system/types";
 import { TextProps } from "./Text";
 
-const StyledErrorText = styled(Field.ErrorText, {
-  base: {
-    color: "text.error",
-    whiteSpace: "pre-line",
-    justifyContent: "center",
+const StyledErrorText = styled(
+  Field.ErrorText,
+  {
+    base: {
+      color: "text.error",
+      whiteSpace: "pre-line",
+      justifyContent: "center",
+    },
   },
-});
+  { baseComponent: true },
+);
 
 export const FieldErrorMessage = forwardRef<HTMLSpanElement, TextProps & HTMLArkProps<"div"> & JsxStyleProps>(
   ({ textStyle = "label.small", fontWeight, css: cssProp, color, srOnly, ...props }, ref) => {

--- a/packages/primitives/src/FieldHelper.tsx
+++ b/packages/primitives/src/FieldHelper.tsx
@@ -13,7 +13,7 @@ import { styled } from "@ndla/styled-system/jsx";
 import { JsxStyleProps } from "@ndla/styled-system/types";
 import { TextProps } from "./Text";
 
-const StyledFieldHelper = styled(Field.HelperText);
+const StyledFieldHelper = styled(Field.HelperText, {}, { baseComponent: true });
 
 export const FieldHelper = forwardRef<HTMLDivElement, TextProps & HTMLArkProps<"div"> & JsxStyleProps>(
   ({ textStyle = "label.small", fontWeight, color, srOnly, css: cssProp, ...props }, ref) => {

--- a/packages/primitives/src/Figure.tsx
+++ b/packages/primitives/src/Figure.tsx
@@ -6,9 +6,13 @@
  *
  */
 
+import { forwardRef } from "react";
+import { HTMLArkProps, ark } from "@ark-ui/react";
+import { RecipeVariantProps, css, cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 
-export const Figure = styled("figure", {
+const figureRecipe = cva({
   base: {
     position: "relative",
     transitionDuration: "normal",
@@ -76,3 +80,13 @@ export const Figure = styled("figure", {
     },
   ],
 });
+
+export type FigureVariantProps = RecipeVariantProps<typeof figureRecipe>;
+
+export type FigureProps = HTMLArkProps<"figure"> & JsxStyleProps & FigureVariantProps;
+
+const StyledFigure = styled(ark.figure, {}, { baseComponent: true });
+
+export const Figure = forwardRef<HTMLElement, FigureProps>(({ size, float, css: cssProp, ...props }, ref) => (
+  <StyledFigure css={css.raw(figureRecipe.raw({ size, float }), cssProp)} {...props} ref={ref} />
+));

--- a/packages/primitives/src/FramedContent.tsx
+++ b/packages/primitives/src/FramedContent.tsx
@@ -6,8 +6,9 @@
  *
  */
 
+import { forwardRef } from "react";
 import { HTMLArkProps, ark } from "@ark-ui/react";
-import { cva } from "@ndla/styled-system/css";
+import { css, cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
 import { JsxStyleProps, RecipeVariantProps } from "@ndla/styled-system/types";
 
@@ -42,4 +43,10 @@ export type FramedContentVariantProps = RecipeVariantProps<typeof framedContentR
 
 export type FramedContentProps = HTMLArkProps<"div"> & JsxStyleProps & FramedContentVariantProps;
 
-export const FramedContent = styled(ark.div, framedContentRecipe);
+const StyledFramedContent = styled(ark.div, {}, { baseComponent: true });
+
+export const FramedContent = forwardRef<HTMLDivElement, FramedContentProps>(
+  ({ colorTheme, css: cssProp, ...props }, ref) => (
+    <StyledFramedContent css={css.raw(framedContentRecipe.raw({ colorTheme }), cssProp)} {...props} ref={ref} />
+  ),
+);

--- a/packages/primitives/src/Input.tsx
+++ b/packages/primitives/src/Input.tsx
@@ -56,17 +56,21 @@ const inputCss = css.raw({
   },
 });
 
-const StyledInputContainer = styled(ark.div, {
-  base: {
-    width: "100%",
-    display: "flex",
-    alignItems: "center",
-    "& svg": {
-      width: "medium",
-      height: "medium",
+const StyledInputContainer = styled(
+  ark.div,
+  {
+    base: {
+      width: "100%",
+      display: "flex",
+      alignItems: "center",
+      "& svg": {
+        width: "medium",
+        height: "medium",
+      },
     },
   },
-});
+  { baseComponent: true },
+);
 
 export const InputContainer = forwardRef<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(
   ({ children, css: cssProp, ...rest }, ref) => (
@@ -106,7 +110,7 @@ const baseTextAreaCss = css.raw({
 
 export interface InputProps extends HTMLArkProps<"input">, JsxStyleProps {}
 
-const StyledInput = styled(ark.input);
+const StyledInput = styled(ark.input, {}, { baseComponent: true });
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(({ css: cssProp, ...props }, ref) => {
   const context = useContext(InputContext);
@@ -121,7 +125,7 @@ export const FieldInput = forwardRef<HTMLInputElement, InputProps>((props, ref) 
 
 interface TextAreaProps extends HTMLArkProps<"textarea">, JsxStyleProps {}
 
-const StyledTextArea = styled(ark.textarea);
+const StyledTextArea = styled(ark.textarea, {}, { baseComponent: true });
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(({ css: cssProp, ...props }, ref) => {
   const context = useContext(InputContext);

--- a/packages/primitives/src/Label.tsx
+++ b/packages/primitives/src/Label.tsx
@@ -13,39 +13,47 @@ import { styled } from "@ndla/styled-system/jsx";
 import { JsxStyleProps } from "@ndla/styled-system/types";
 import { TextProps } from "./Text";
 
-const StyledLegend = styled(ark.legend, {
-  base: {
-    float: "none",
-    width: "inherit",
-    _disabled: {
-      color: "text.subtle",
+const StyledLegend = styled(
+  ark.legend,
+  {
+    base: {
+      float: "none",
+      width: "inherit",
+      _disabled: {
+        color: "text.subtle",
+      },
     },
   },
-});
+  { baseComponent: true },
+);
 
 export type LegendProps = HTMLArkProps<"legend"> & JsxStyleProps & TextProps;
 
 // TODO: This is not exported for now. Let's wait and see when ark decides to release their legend and fieldset.
 export const Legend = forwardRef<HTMLLegendElement, LegendProps>(
-  ({ textStyle = "label.medium", fontWeight = "bold", css: cssProp, srOnly, ...rest }, ref) => (
-    <StyledLegend css={css.raw({ textStyle, fontWeight, srOnly }, cssProp)} {...rest} ref={ref} />
+  ({ textStyle = "label.medium", fontWeight = "bold", css: cssProp, srOnly, color, ...rest }, ref) => (
+    <StyledLegend css={css.raw({ textStyle, fontWeight, srOnly, color }, cssProp)} {...rest} ref={ref} />
   ),
 );
 
-const StyledLabel = styled(ark.label, {
-  base: {
-    display: "inline-block",
-    _disabled: {
-      color: "text.subtle",
+const StyledLabel = styled(
+  ark.label,
+  {
+    base: {
+      display: "inline-block",
+      _disabled: {
+        color: "text.subtle",
+      },
     },
   },
-});
+  { baseComponent: true },
+);
 
 export type LabelProps = HTMLArkProps<"label"> & TextProps & JsxStyleProps;
 
 export const Label = forwardRef<HTMLLabelElement, LabelProps>(
-  ({ textStyle = "label.medium", fontWeight = "bold", css: cssProp, srOnly, ...rest }, ref) => (
-    <StyledLabel css={css.raw({ textStyle, fontWeight, srOnly }, cssProp)} {...rest} ref={ref} />
+  ({ textStyle = "label.medium", fontWeight = "bold", css: cssProp, srOnly, color, ...rest }, ref) => (
+    <StyledLabel css={css.raw({ textStyle, fontWeight, srOnly, color }, cssProp)} {...rest} ref={ref} />
   ),
 );
 

--- a/packages/primitives/src/Menu.stories.tsx
+++ b/packages/primitives/src/Menu.stories.tsx
@@ -38,7 +38,7 @@ export default {
 
 export const Default: StoryFn<typeof MenuRoot> = (args) => (
   <MenuRoot {...args}>
-    <MenuTrigger asChild forwardCssProp>
+    <MenuTrigger asChild>
       <Button>Open me!</Button>
     </MenuTrigger>
     <Portal>
@@ -52,7 +52,7 @@ export const Default: StoryFn<typeof MenuRoot> = (args) => (
             <Share />
             Del
           </MenuItem>
-          <MenuItem value="goToShared" asChild forwardCssProp>
+          <MenuItem value="goToShared" asChild>
             <styled.a href="https://ndla.no">
               <ShareArrow />
               Gå til delt mappe
@@ -78,7 +78,7 @@ export const Default: StoryFn<typeof MenuRoot> = (args) => (
 
 export const Grouped: StoryFn<typeof MenuRoot> = (args) => (
   <MenuRoot {...args}>
-    <MenuTrigger asChild forwardCssProp>
+    <MenuTrigger asChild>
       <Button>Open me!</Button>
     </MenuTrigger>
     <Portal>
@@ -122,7 +122,7 @@ export const Grouped: StoryFn<typeof MenuRoot> = (args) => (
 
 export const Nested: StoryFn<typeof MenuRoot> = (args) => (
   <MenuRoot {...args}>
-    <MenuTrigger asChild forwardCssProp>
+    <MenuTrigger asChild>
       <Button>Open me!</Button>
     </MenuTrigger>
     <Portal>

--- a/packages/primitives/src/Menu.tsx
+++ b/packages/primitives/src/Menu.tsx
@@ -151,7 +151,7 @@ export const MenuItemGroupLabel = ({
   children,
   ...props
 }: Menu.ItemGroupLabelProps & JsxStyleProps & TextProps) => (
-  <InternalMenuItemGroupLabel {...props} asChild forwardCssProp>
+  <InternalMenuItemGroupLabel {...props} asChild>
     <Text textStyle={textStyle} fontWeight={fontWeight}>
       {children}
     </Text>

--- a/packages/primitives/src/MessageBox.tsx
+++ b/packages/primitives/src/MessageBox.tsx
@@ -6,8 +6,9 @@
  *
  */
 
+import { forwardRef } from "react";
 import { HTMLArkProps, ark } from "@ark-ui/react";
-import { cva } from "@ndla/styled-system/css";
+import { css, cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
 import { JsxStyleProps, RecipeVariantProps } from "@ndla/styled-system/types";
 
@@ -49,4 +50,8 @@ export type MessageBoxVariantProps = RecipeVariantProps<typeof messageBoxRecipe>
 
 export type MessageBoxProps = HTMLArkProps<"div"> & JsxStyleProps & MessageBoxVariantProps;
 
-export const MessageBox = styled(ark.div, messageBoxRecipe);
+const StyledMessageBox = styled(ark.div, {}, { baseComponent: true });
+
+export const MessageBox = forwardRef<HTMLDivElement, MessageBoxProps>(({ variant, css: cssProp, ...props }, ref) => (
+  <StyledMessageBox css={css.raw(messageBoxRecipe.raw({ variant }), cssProp)} {...props} ref={ref} />
+));

--- a/packages/primitives/src/Pagination.stories.tsx
+++ b/packages/primitives/src/Pagination.stories.tsx
@@ -30,7 +30,7 @@ export default {
   },
   render: (args) => (
     <PaginationRoot {...args}>
-      <PaginationPrevTrigger asChild forwardCssProp>
+      <PaginationPrevTrigger asChild>
         <Button variant="tertiary">
           <ChevronLeft />
           Forrige
@@ -40,12 +40,12 @@ export default {
         {(pagination) =>
           pagination.pages.map((page, index) =>
             page.type === "page" ? (
-              <PaginationItem key={index} {...page} asChild forwardCssProp>
+              <PaginationItem key={index} {...page} asChild>
                 <Button variant={page.value === pagination.page ? "primary" : "tertiary"}>{page.value}</Button>
               </PaginationItem>
             ) : (
-              <PaginationEllipsis key={index} index={index} asChild forwardCssProp>
-                <Text asChild>
+              <PaginationEllipsis key={index} index={index} asChild>
+                <Text asChild consumeCss>
                   <div>&#8230;</div>
                 </Text>
               </PaginationEllipsis>
@@ -53,7 +53,7 @@ export default {
           )
         }
       </PaginationContext>
-      <PaginationNextTrigger asChild forwardCssProp>
+      <PaginationNextTrigger asChild>
         <Button variant="tertiary">
           Neste
           <ChevronRight />

--- a/packages/primitives/src/Popover.stories.tsx
+++ b/packages/primitives/src/Popover.stories.tsx
@@ -32,7 +32,7 @@ export default {
   },
   render: ({ children, ...args }) => (
     <PopoverRoot {...args}>
-      <PopoverTrigger asChild forwardCssProp>
+      <PopoverTrigger asChild>
         <Button>Open me!</Button>
       </PopoverTrigger>
       <Portal>
@@ -59,7 +59,7 @@ export const LeftAligned: StoryObj<typeof PopoverRoot> = {
   },
   render: ({ children, ...args }) => (
     <PopoverRoot {...args}>
-      <PopoverTrigger asChild forwardCssProp>
+      <PopoverTrigger asChild>
         <Button css={{ marginInlineStart: "50%" }}>Open me!</Button>
       </PopoverTrigger>
       <Portal>
@@ -74,7 +74,7 @@ export const LeftAligned: StoryObj<typeof PopoverRoot> = {
 
 export const WithStandaloneComponents: StoryFn = (args) => (
   <PopoverRoot {...args}>
-    <PopoverTrigger asChild forwardCssProp>
+    <PopoverTrigger asChild>
       <Button>Open me!</Button>
     </PopoverTrigger>
     <Portal>

--- a/packages/primitives/src/RadioGroup.tsx
+++ b/packages/primitives/src/RadioGroup.tsx
@@ -119,8 +119,8 @@ export const RadioGroupItemText = ({
   children,
   ...props
 }: RadioGroup.ItemTextProps & TextProps & JsxStyleProps) => (
-  <InternalRadioGroupItemText asChild forwardCssProp>
-    <Text asChild textStyle={textStyle} {...props}>
+  <InternalRadioGroupItemText asChild>
+    <Text asChild consumeCss textStyle={textStyle} {...props}>
       <span>{children}</span>
     </Text>
   </InternalRadioGroupItemText>
@@ -133,7 +133,7 @@ export const InternalRadioGroupLabel = withContext<HTMLLabelElement, RadioGroup.
 
 export const RadioGroupLabel = forwardRef<HTMLLabelElement, RadioGroup.LabelProps & TextProps & JsxStyleProps>(
   ({ textStyle = "label.large", ...props }, ref) => (
-    <InternalRadioGroupLabel ref={ref} asChild forwardCssProp>
+    <InternalRadioGroupLabel ref={ref} asChild>
       <Label textStyle={textStyle} {...props} />
     </InternalRadioGroupLabel>
   ),

--- a/packages/primitives/src/Select.stories.tsx
+++ b/packages/primitives/src/Select.stories.tsx
@@ -60,7 +60,7 @@ export const Default: StoryFn<typeof SelectRoot> = ({ ...args }) => {
     <SelectRoot {...args} items={measurements}>
       <SelectLabel>Measurement</SelectLabel>
       <SelectControl>
-        <SelectTrigger asChild forwardCssProp>
+        <SelectTrigger asChild>
           <Button variant="secondary">
             <SelectValueText placeholder="Select measurement" />
             <SelectIndicator asChild>
@@ -92,7 +92,7 @@ export const Disabled: StoryFn<typeof SelectRoot> = ({ ...args }) => {
     <SelectRoot {...args} disabled items={measurements}>
       <SelectLabel>Measurement</SelectLabel>
       <SelectControl>
-        <SelectTrigger asChild forwardCssProp>
+        <SelectTrigger asChild>
           <Button variant="secondary">
             <SelectValueText placeholder="Select measurement" />
             <SelectIndicator asChild>
@@ -125,7 +125,7 @@ export const DisabledItems: StoryFn<typeof SelectRoot> = ({ ...args }) => {
     <SelectRoot {...args} items={withDisabled}>
       <SelectLabel>Measurement</SelectLabel>
       <SelectControl>
-        <SelectTrigger asChild forwardCssProp>
+        <SelectTrigger asChild>
           <Button variant="secondary">
             <SelectValueText placeholder="Select measurement" />
             <SelectIndicator asChild>
@@ -166,7 +166,7 @@ export const Grouped: StoryFn<typeof SelectRoot> = ({ ...args }) => {
     <SelectRoot {...args} items={europeanCountries}>
       <SelectLabel>Country</SelectLabel>
       <SelectControl>
-        <SelectTrigger asChild forwardCssProp>
+        <SelectTrigger asChild>
           <Button variant="secondary">
             <SelectValueText placeholder="Choose country" />
             <SelectIndicator asChild>
@@ -203,7 +203,7 @@ export const Multiple: StoryFn<typeof SelectRoot> = ({ ...args }) => {
     <SelectRoot {...args} items={europeanCountries} multiple>
       <SelectLabel>Countries you've been to</SelectLabel>
       <SelectControl>
-        <SelectTrigger asChild forwardCssProp>
+        <SelectTrigger asChild>
           <Button variant="secondary">
             <SelectValueText placeholder="Choose country" />
             <SelectIndicator asChild>
@@ -247,7 +247,7 @@ export const MultipleTruncated: StoryFn<typeof SelectRoot> = ({ ...args }) => {
     >
       <SelectLabel>Countries you've been to</SelectLabel>
       <SelectControl>
-        <SelectTrigger asChild forwardCssProp>
+        <SelectTrigger asChild>
           <Button variant="secondary">
             <SelectValueText placeholder="Choose country">
               {value.length > 3
@@ -291,7 +291,7 @@ export const WithClearButton: StoryFn<typeof SelectRoot> = ({ ...args }) => {
     <SelectRoot {...args} items={europeanCountries} multiple>
       <SelectLabel>Countries you've been to</SelectLabel>
       <SelectControl>
-        <SelectTrigger asChild forwardCssProp>
+        <SelectTrigger asChild>
           <Button variant="secondary">
             <SelectValueText placeholder="Choose country" />
             <SelectIndicator asChild>
@@ -299,7 +299,7 @@ export const WithClearButton: StoryFn<typeof SelectRoot> = ({ ...args }) => {
             </SelectIndicator>
           </Button>
         </SelectTrigger>
-        <SelectClearTrigger asChild forwardCssProp>
+        <SelectClearTrigger asChild>
           <IconButton variant="secondary">
             <Cross />
           </IconButton>
@@ -357,7 +357,7 @@ export const InDialog: StoryFn<typeof SelectRoot> = ({ ...args }) => {
           >
             <SelectLabel>Measurement</SelectLabel>
             <SelectControl>
-              <SelectTrigger asChild forwardCssProp>
+              <SelectTrigger asChild>
                 <Button variant="secondary">
                   <SelectValueText placeholder="Select measurement" />
                   <SelectIndicator asChild>
@@ -402,7 +402,7 @@ export const WithField: StoryFn<typeof SelectRoot> = ({ ...args }) => {
         <FieldHelper>You cannot choose centimeter.</FieldHelper>
         <FieldErrorMessage>I told you to choose anything but centimeter...</FieldErrorMessage>
         <SelectControl>
-          <SelectTrigger asChild forwardCssProp>
+          <SelectTrigger asChild>
             <Button variant="secondary">
               <SelectValueText placeholder="Select measurement" />
               <SelectIndicator asChild>
@@ -410,7 +410,7 @@ export const WithField: StoryFn<typeof SelectRoot> = ({ ...args }) => {
               </SelectIndicator>
             </Button>
           </SelectTrigger>
-          <SelectClearTrigger asChild forwardCssProp>
+          <SelectClearTrigger asChild>
             <IconButton variant="secondary">
               <Cross />
             </IconButton>

--- a/packages/primitives/src/Select.tsx
+++ b/packages/primitives/src/Select.tsx
@@ -167,8 +167,8 @@ export const SelectIndicator = withContext<HTMLDivElement, Select.IndicatorProps
 
 export const SelectItemGroupLabel = forwardRef<HTMLDivElement, Select.ItemGroupLabelProps & JsxStyleProps & TextProps>(
   ({ children, ...props }, ref) => (
-    <InternalSelectItemGroupLabel asChild forwardCssProp ref={ref} {...props}>
-      <Label asChild>
+    <InternalSelectItemGroupLabel asChild ref={ref} {...props}>
+      <Label asChild consumeCss>
         <div>{children}</div>
       </Label>
     </InternalSelectItemGroupLabel>
@@ -201,7 +201,7 @@ const InternalSelectLabel = withContext<HTMLLabelElement, Select.LabelProps & Js
 
 export const SelectLabel = forwardRef<HTMLLabelElement, Select.LabelProps & JsxStyleProps & TextProps>(
   ({ children, ...props }, ref) => (
-    <InternalSelectLabel asChild forwardCssProp ref={ref} {...props}>
+    <InternalSelectLabel asChild ref={ref} {...props}>
       <Label>{children}</Label>
     </InternalSelectLabel>
   ),

--- a/packages/primitives/src/Skeleton.tsx
+++ b/packages/primitives/src/Skeleton.tsx
@@ -10,20 +10,24 @@ import { HTMLArkProps, ark } from "@ark-ui/react";
 import { styled } from "@ndla/styled-system/jsx";
 import { JsxStyleProps } from "@ndla/styled-system/types";
 
-export const Skeleton = styled(ark.div, {
-  base: {
-    animation: "skeleton-pulse",
-    backgroundColor: "surface.disabled",
-    backgroundClip: "padding-box",
-    borderRadius: "xsmall",
-    color: "transparent",
-    cursor: "default",
-    pointerEvents: "none",
-    userSelect: "none",
-    "&::before, &::after, *": {
-      visibility: "hidden",
+export const Skeleton = styled(
+  ark.div,
+  {
+    base: {
+      animation: "skeleton-pulse",
+      backgroundColor: "surface.disabled",
+      backgroundClip: "padding-box",
+      borderRadius: "xsmall",
+      color: "transparent",
+      cursor: "default",
+      pointerEvents: "none",
+      userSelect: "none",
+      "&::before, &::after, *": {
+        visibility: "hidden",
+      },
     },
   },
-});
+  { baseComponent: true },
+);
 
 export interface SkeletonProps extends HTMLArkProps<"div">, JsxStyleProps {}

--- a/packages/primitives/src/Slider.tsx
+++ b/packages/primitives/src/Slider.tsx
@@ -101,7 +101,7 @@ export const SliderLabel = ({
   textStyle = "label.medium",
   ...props
 }: Slider.LabelProps & TextProps & JsxStyleProps) => (
-  <InternalSliderLabel asChild forwardCssProp>
+  <InternalSliderLabel asChild>
     <Label textStyle={textStyle} {...props} />
   </InternalSliderLabel>
 );

--- a/packages/primitives/src/Spinner.tsx
+++ b/packages/primitives/src/Spinner.tsx
@@ -6,8 +6,9 @@
  *
  */
 
+import { forwardRef } from "react";
 import { HTMLArkProps, ark } from "@ark-ui/react";
-import { RecipeVariantProps, cva } from "@ndla/styled-system/css";
+import { RecipeVariantProps, css, cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
 import { JsxStyleProps } from "@ndla/styled-system/types";
 
@@ -44,6 +45,10 @@ export const spinnerRecipe = cva({
 
 export type SpinnerVariantProps = RecipeVariantProps<typeof spinnerRecipe>;
 
-export type SpinnerProps = HTMLArkProps<"div"> & SpinnerVariantProps & JsxStyleProps;
+export type SpinnerProps = HTMLArkProps<"div"> & JsxStyleProps & SpinnerVariantProps;
 
-export const Spinner = styled(ark.div, spinnerRecipe);
+const StyledSpinner = styled(ark.div, {}, { baseComponent: true });
+
+export const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(({ size, css: cssProp, ...props }, ref) => (
+  <StyledSpinner css={css.raw(spinnerRecipe.raw({ size }), cssProp)} {...props} ref={ref} />
+));

--- a/packages/primitives/src/Switch.tsx
+++ b/packages/primitives/src/Switch.tsx
@@ -117,8 +117,8 @@ export const SwitchLabel = ({
   children,
   ...props
 }: Switch.LabelProps & TextProps & JsxStyleProps) => (
-  <InternalSwitchLabel asChild forwardCssProp>
-    <Text asChild textStyle={textStyle} {...props}>
+  <InternalSwitchLabel asChild>
+    <Text asChild consumeCss textStyle={textStyle} {...props}>
       <span>{children}</span>
     </Text>
   </InternalSwitchLabel>

--- a/packages/primitives/src/Table.tsx
+++ b/packages/primitives/src/Table.tsx
@@ -12,65 +12,69 @@ import { JsxStyleProps } from "@ndla/styled-system/types";
 
 export type TableProps = HTMLArkProps<"table"> & JsxStyleProps;
 
-export const Table = styled(ark.table, {
-  base: {
-    display: "block",
-    overflowX: "auto",
-    maxWidth: "100%",
-    padding: "4xsmall",
-    tableLayout: "fixed",
-    "& > caption": {
-      fontWeight: "bold",
-      textAlign: "left",
-      textTransform: "uppercase",
-      marginBlockEnd: "xsmall",
-    },
-    "& thead": {
-      overflow: "hidden",
-    },
-    "& thead tr th": {
-      fontWeight: "bold",
-      borderBottom: "3px solid",
-      borderColor: "surface.brand.1.strong",
-      verticalAlign: "text-top",
-    },
-    "& tbody th": {
-      borderRight: "3px solid",
-      borderColor: "surface.brand.1.strong",
-      padding: "3xsmall",
-    },
-    "& thead tr:nth-child(2) th": {
-      border: "1px solid",
-      borderColor: "surface.brand.1.subtle",
-      textTransform: "none",
-      fontWeight: "semibold",
-      height: "large",
-      backgroundColor: "surface.brand.1.subtle",
-      paddingBlock: "4xsmall",
-      paddingInlineEnd: "medium",
-      paddingInlineStart: "3xsmall",
-      _empty: {
-        backgroundColor: "transparent",
-      },
-    },
-    "& td": {
-      border: "1px solid",
-      borderColor: "surface.brand.1.subtle",
-      verticalAlign: "top",
-    },
-    "& td, & th": {
-      display: "table-cell",
-      paddingInline: "xsmall",
-      paddingBlock: "3xsmall",
-      "&[data-align='center']": {
-        textAlign: "center",
-      },
-      "&[data-align='left']": {
+export const Table = styled(
+  ark.table,
+  {
+    base: {
+      display: "block",
+      overflowX: "auto",
+      maxWidth: "100%",
+      padding: "4xsmall",
+      tableLayout: "fixed",
+      "& > caption": {
+        fontWeight: "bold",
         textAlign: "left",
+        textTransform: "uppercase",
+        marginBlockEnd: "xsmall",
       },
-      "&[data-align='right']": {
-        textAlign: "right",
+      "& thead": {
+        overflow: "hidden",
+      },
+      "& thead tr th": {
+        fontWeight: "bold",
+        borderBottom: "3px solid",
+        borderColor: "surface.brand.1.strong",
+        verticalAlign: "text-top",
+      },
+      "& tbody th": {
+        borderRight: "3px solid",
+        borderColor: "surface.brand.1.strong",
+        padding: "3xsmall",
+      },
+      "& thead tr:nth-child(2) th": {
+        border: "1px solid",
+        borderColor: "surface.brand.1.subtle",
+        textTransform: "none",
+        fontWeight: "semibold",
+        height: "large",
+        backgroundColor: "surface.brand.1.subtle",
+        paddingBlock: "4xsmall",
+        paddingInlineEnd: "medium",
+        paddingInlineStart: "3xsmall",
+        _empty: {
+          backgroundColor: "transparent",
+        },
+      },
+      "& td": {
+        border: "1px solid",
+        borderColor: "surface.brand.1.subtle",
+        verticalAlign: "top",
+      },
+      "& td, & th": {
+        display: "table-cell",
+        paddingInline: "xsmall",
+        paddingBlock: "3xsmall",
+        "&[data-align='center']": {
+          textAlign: "center",
+        },
+        "&[data-align='left']": {
+          textAlign: "left",
+        },
+        "&[data-align='right']": {
+          textAlign: "right",
+        },
       },
     },
   },
-});
+  { baseComponent: true },
+);

--- a/packages/primitives/src/Tabs.stories.tsx
+++ b/packages/primitives/src/Tabs.stories.tsx
@@ -35,26 +35,26 @@ export default {
         <TabsIndicator />
       </TabsList>
       <TabsContent value="color">
-        <Heading asChild textStyle="heading.medium">
+        <Heading asChild consumeCss textStyle="heading.medium">
           <h2>Oversikt over farger</h2>
         </Heading>
         <Text>Grønn, blå og rød.</Text>
         <Button>Hallo</Button>
       </TabsContent>
       <TabsContent value="shapes">
-        <Heading asChild textStyle="heading.medium">
+        <Heading asChild consumeCss textStyle="heading.medium">
           <h2>Oversikt over figurer</h2>
         </Heading>
         <Text>Sirkel, trekant og firkant.</Text>
       </TabsContent>
       <TabsContent value="secret">
-        <Heading asChild textStyle="heading.medium">
+        <Heading asChild consumeCss textStyle="heading.medium">
           <h2>Ikke hemmelig</h2>
         </Heading>
         <Text>Egentlig ikke så spennende</Text>
       </TabsContent>
       <TabsContent value="secret2">
-        <Heading asChild textStyle="heading.medium">
+        <Heading asChild consumeCss textStyle="heading.medium">
           <h2>Ikke hemmelig</h2>
         </Heading>
         <Text>Egentlig ikke så spennende</Text>

--- a/packages/primitives/src/TagsInput.stories.tsx
+++ b/packages/primitives/src/TagsInput.stories.tsx
@@ -60,7 +60,7 @@ export const Default: StoryFn<typeof TagsInputRoot> = ({ ...args }) => {
       <HStack gap="4xsmall">
         <TagsInputContext>
           {(api) => (
-            <TagsInputControl forwardCssProp asChild>
+            <TagsInputControl asChild>
               <InputContainer>
                 {api.value.map((value, index) => (
                   <TagsInputItem key={index} index={index} value={value}>
@@ -96,7 +96,7 @@ export const Editable: StoryFn<typeof TagsInputRoot> = ({ ...args }) => {
       <HStack gap="4xsmall">
         <TagsInputContext>
           {(api) => (
-            <TagsInputControl forwardCssProp asChild>
+            <TagsInputControl asChild>
               <InputContainer>
                 {api.value.map((value, index) => (
                   <TagsInputItem key={index} index={index} value={value}>
@@ -133,7 +133,7 @@ export const Disabled: StoryFn<typeof TagsInputRoot> = ({ ...args }) => {
       <HStack gap="4xsmall">
         <TagsInputContext>
           {(api) => (
-            <TagsInputControl forwardCssProp asChild>
+            <TagsInputControl asChild>
               <InputContainer>
                 {api.value.map((value, index) => (
                   <TagsInputItem key={index} index={index} value={value}>
@@ -175,7 +175,7 @@ export const WithField: StoryFn<typeof TagsInputRoot> = ({ ...args }) => {
         <HStack gap="4xsmall">
           <TagsInputContext>
             {(api) => (
-              <TagsInputControl forwardCssProp asChild>
+              <TagsInputControl asChild>
                 <InputContainer>
                   {api.value.map((value, index) => (
                     <TagsInputItem key={index} index={index} value={value}>
@@ -279,8 +279,8 @@ export const ComboboxTags: StoryFn<typeof ComboboxRoot> = () => {
             <TagsInputContext>
               {(tagsInputApi) => (
                 <HStack gap="4xsmall">
-                  <ComboboxControl asChild forwardCssProp>
-                    <TagsInputControl asChild forwardCssProp>
+                  <ComboboxControl asChild>
+                    <TagsInputControl asChild>
                       <InputContainer>
                         {tagsInputApi.value.map((value, index) => (
                           <TagsInputItem index={index} value={value} key={index}>
@@ -292,8 +292,8 @@ export const ComboboxTags: StoryFn<typeof ComboboxRoot> = () => {
                             </TagsInputItemPreview>
                           </TagsInputItem>
                         ))}
-                        <ComboboxInput asChild forwardCssProp>
-                          <TagsInputInput asChild forwardCssProp>
+                        <ComboboxInput asChild>
+                          <TagsInputInput asChild>
                             <Input
                               placeholder="Skriv inn en emneknagg"
                               onKeyDown={(event) => {
@@ -304,7 +304,7 @@ export const ComboboxTags: StoryFn<typeof ComboboxRoot> = () => {
                             />
                           </TagsInputInput>
                         </ComboboxInput>
-                        <ComboboxClearTrigger asChild forwardCssProp>
+                        <ComboboxClearTrigger asChild>
                           <IconButton variant="clear">
                             <Cross />
                           </IconButton>

--- a/packages/primitives/src/TagsInput.tsx
+++ b/packages/primitives/src/TagsInput.tsx
@@ -141,7 +141,7 @@ const InternalTagsInputLabel = withContext<HTMLLabelElement, TagsInput.LabelProp
 
 export const TagsInputLabel = forwardRef<HTMLLabelElement, TagsInput.LabelProps & JsxStyleProps & TextProps>(
   ({ children, ...props }, ref) => (
-    <InternalTagsInputLabel asChild forwardCssProp ref={ref} {...props}>
+    <InternalTagsInputLabel asChild ref={ref} {...props}>
       <Label>{children}</Label>
     </InternalTagsInputLabel>
   ),

--- a/packages/primitives/src/Text.stories.tsx
+++ b/packages/primitives/src/Text.stories.tsx
@@ -177,32 +177,24 @@ export const LabelXsmall: StoryObj<typeof Text> = {
 };
 
 export const Polymorphic: StoryFn<typeof Text> = () => (
-  <Text asChild>
+  <Text asChild consumeCss>
     <div>
       The underlying HTML tag can be changed through the use of the <code>asChild</code> prop!
     </div>
   </Text>
 );
 
-const StyledText = styled(
-  Text,
-  {
-    base: {
-      textStyle: "heading.large",
-    },
+const StyledText = styled(Text, {
+  base: {
+    textStyle: "heading.large",
   },
-  { forwardCssProp: true },
-);
+});
 
-const StyledHeading = styled(
-  Heading,
-  {
-    base: {
-      textStyle: "heading.small",
-    },
+const StyledHeading = styled(Heading, {
+  base: {
+    textStyle: "heading.small",
   },
-  { forwardCssProp: true },
-);
+});
 
 export const Styled = () => (
   <div className={css({ display: "flex", flexDirection: "column", gap: "xsmall" })}>
@@ -210,7 +202,7 @@ export const Styled = () => (
     <StyledText>
       You can restyle components by using the <code>styled</code> function. This will override existing styles.
     </StyledText>
-    <StyledText asChild>
+    <StyledText asChild consumeCss>
       <span>
         This pattern also works flawlessly with the <code>asChild</code> prop.
       </span>

--- a/packages/primitives/src/Text.tsx
+++ b/packages/primitives/src/Text.tsx
@@ -21,7 +21,7 @@ export interface TextProps {
   srOnly?: boolean;
 }
 
-const StyledP = styled(ark.p);
+const StyledP = styled(ark.p, {}, { baseComponent: true });
 
 export const Text = forwardRef<HTMLParagraphElement, HTMLArkProps<"p"> & JsxStyleProps & TextProps>(
   ({ textStyle = "body.medium", fontWeight, color, srOnly, css: cssProp, ...rest }, ref) => (
@@ -29,7 +29,7 @@ export const Text = forwardRef<HTMLParagraphElement, HTMLArkProps<"p"> & JsxStyl
   ),
 );
 
-const StyledH1 = styled(ark.h1);
+const StyledH1 = styled(ark.h1, {}, { baseComponent: true });
 
 export const Heading = forwardRef<HTMLHeadingElement, HTMLArkProps<"h1"> & JsxStyleProps & TextProps>(
   ({ textStyle = "heading.medium", fontWeight, color, srOnly, css: cssProp, ...rest }, ref) => (

--- a/packages/primitives/src/Toast.stories.tsx
+++ b/packages/primitives/src/Toast.stories.tsx
@@ -35,7 +35,7 @@ export const Default: StoryFn<typeof ToastRoot> = ({ ...args }) => (
           <ToastRoot {...args}>
             <ToastTitle>{toast.title}</ToastTitle>
             <ToastDescription>{toast.description}</ToastDescription>
-            <ToastCloseTrigger asChild forwardCssProp>
+            <ToastCloseTrigger asChild>
               <IconButton variant="clearSubtle">
                 <Cross />
               </IconButton>

--- a/packages/primitives/src/Toast.tsx
+++ b/packages/primitives/src/Toast.tsx
@@ -67,8 +67,8 @@ export const ToastDescription = ({
   children,
   ...props
 }: Toast.DescriptionProps & TextProps & JsxStyleProps) => (
-  <InternalToastDescription asChild forwardCssProp>
-    <Text asChild textStyle={textStyle} {...props}>
+  <InternalToastDescription asChild>
+    <Text asChild consumeCss textStyle={textStyle} {...props}>
       <div>{children}</div>
     </Text>
   </InternalToastDescription>
@@ -82,8 +82,8 @@ export const ToastTitle = ({
   children,
   ...props
 }: JsxStyleProps & Toast.TitleProps & TextProps) => (
-  <InternalToastTitle asChild forwardCssProp>
-    <Text asChild fontWeight={fontWeight} textStyle={textStyle} {...props}>
+  <InternalToastTitle asChild>
+    <Text asChild consumeCss fontWeight={fontWeight} textStyle={textStyle} {...props}>
       <div>{children}</div>
     </Text>
   </InternalToastTitle>

--- a/packages/primitives/src/Tooltip.stories.tsx
+++ b/packages/primitives/src/Tooltip.stories.tsx
@@ -27,7 +27,7 @@ export default {
 
 export const Default: StoryFn<typeof TooltipRoot> = ({ ...args }) => (
   <TooltipRoot {...args}>
-    <TooltipTrigger asChild forwardCssProp>
+    <TooltipTrigger asChild>
       <Button>Hover me!</Button>
     </TooltipTrigger>
     <Portal>

--- a/packages/primitives/src/__tests__/createStyleContext-test.tsx
+++ b/packages/primitives/src/__tests__/createStyleContext-test.tsx
@@ -1,0 +1,422 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { ComponentPropsWithRef, ReactNode } from "react";
+import { HTMLArkProps, ark } from "@ark-ui/react";
+import { render } from "@testing-library/react";
+import { sva } from "@ndla/styled-system/css";
+import { styled } from "@ndla/styled-system/jsx";
+import { JsxStyleProps } from "@ndla/styled-system/types";
+import { createStyleContext } from "../createStyleContext";
+
+const svaA = sva({
+  slots: ["root", "child"],
+  base: {
+    root: {
+      display: "flex",
+    },
+    child: {
+      display: "block",
+    },
+  },
+});
+
+const svaB = sva({
+  slots: ["root", "child"],
+  base: {
+    root: {
+      display: "inline",
+    },
+  },
+});
+
+interface MockContextProps {
+  children: ReactNode;
+}
+
+const MockContext = ({ children }: MockContextProps) => {
+  return children;
+};
+
+describe("createStyleContext", () => {
+  test("should have a sane default", () => {
+    const { withProvider, withContext, withRootProvider } = createStyleContext(svaA);
+
+    const RootProviderRoot = withRootProvider<MockContextProps>(MockContext);
+
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div">>(ark.div, "root");
+    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div">>(ark.div, "root");
+
+    const rootProviderResult = render(
+      <RootProviderRoot>
+        <ContextRoot>Hello</ContextRoot>
+      </RootProviderRoot>,
+    );
+    const providerResult = render(<ProviderRoot>Hello</ProviderRoot>);
+    const contextResult = render(
+      <ProviderRoot>
+        <ContextRoot>Hello</ContextRoot>
+      </ProviderRoot>,
+    );
+
+    const inlineSnapshot = `
+      <div
+        class="d_flex"
+      >
+        Hello
+      </div>
+    `;
+
+    expect(rootProviderResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(providerResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(contextResult.container.firstChild?.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+  });
+
+  test("should have a sane default with string components", () => {
+    const { withProvider, withContext, withRootProvider } = createStyleContext(svaA);
+
+    const RootProviderRoot = withRootProvider<MockContextProps>(MockContext);
+
+    const ProviderRoot = withProvider<HTMLDivElement, ComponentPropsWithRef<"div"> & JsxStyleProps>("div", "root");
+    const ContextRoot = withContext<HTMLDivElement, ComponentPropsWithRef<"div"> & JsxStyleProps>("div", "root");
+
+    const rootProviderResult = render(
+      <RootProviderRoot>
+        <ContextRoot>Hello</ContextRoot>
+      </RootProviderRoot>,
+    );
+    const providerResult = render(<ProviderRoot>Hello</ProviderRoot>);
+    const contextResult = render(
+      <ProviderRoot>
+        <ContextRoot>Hello</ContextRoot>
+      </ProviderRoot>,
+    );
+
+    const inlineSnapshot = `
+      <div
+        class="d_flex"
+      >
+        Hello
+      </div>
+    `;
+
+    expect(rootProviderResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(providerResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(contextResult.container.firstChild?.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+  });
+
+  test("should have a sane default when using the css prop directly on a styled element", () => {
+    const { withProvider, withContext, withRootProvider } = createStyleContext(svaA);
+
+    const RootProviderRoot = withRootProvider<MockContextProps>(MockContext);
+
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+
+    const rootProviderResult = render(
+      <RootProviderRoot>
+        <ContextRoot css={{ display: "block" }}>Hello</ContextRoot>
+      </RootProviderRoot>,
+    );
+    const providerResult = render(<ProviderRoot css={{ display: "block" }}>Hello</ProviderRoot>);
+    const contextResult = render(
+      <ProviderRoot>
+        <ContextRoot css={{ display: "block" }}>Hello</ContextRoot>
+      </ProviderRoot>,
+    );
+
+    const inlineSnapshot = `
+      <div
+        class="d_block"
+      >
+        Hello
+      </div>
+    `;
+
+    expect(rootProviderResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(providerResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(contextResult.container.firstChild?.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+  });
+
+  test("should have no problems merging a react component and a string component", () => {
+    const { withProvider, withContext } = createStyleContext(svaA);
+
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const ContextRoot = withContext<HTMLDivElement, ComponentPropsWithRef<"div"> & JsxStyleProps>("div", "child");
+
+    const contextResult = render(
+      <ProviderRoot asChild>
+        <ContextRoot>Hello</ContextRoot>
+      </ProviderRoot>,
+    );
+
+    const inlineSnapshot = `
+      <div
+        class="d_flex"
+      >
+        Hello
+      </div>
+    `;
+
+    expect(contextResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+  });
+
+  test("should not automatically forward css prop regardless of whether you pass in a component or a string", () => {
+    const { withProvider, withContext } = createStyleContext(svaA);
+
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const ContextRoot = withContext<HTMLDivElement, ComponentPropsWithRef<"div"> & JsxStyleProps>("div", "root");
+
+    const providerResult = render(
+      <ProviderRoot>
+        <ContextRoot>Hello</ContextRoot>
+      </ProviderRoot>,
+    );
+
+    const inlineSnapshot = `
+      <div
+        class="d_flex"
+      >
+        <div
+          class="d_flex"
+        >
+          Hello
+        </div>
+      </div>
+    `;
+
+    expect(providerResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+  });
+
+  test("should be automatically overridden with styled", () => {
+    const { withProvider, withContext, withRootProvider } = createStyleContext(svaA);
+
+    const RootProviderRoot = withRootProvider<MockContextProps>(MockContext);
+
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+
+    const StyledProviderRoot = styled(ProviderRoot, {
+      base: {
+        display: "block",
+      },
+    });
+
+    const StyledContextRoot = styled(ContextRoot, {
+      base: {
+        display: "block",
+      },
+    });
+
+    const rootProviderResult = render(
+      <RootProviderRoot>
+        <StyledContextRoot>Hello</StyledContextRoot>
+      </RootProviderRoot>,
+    );
+    const providerResult = render(<StyledProviderRoot>Hello</StyledProviderRoot>);
+    const contextResult = render(
+      <ProviderRoot>
+        <StyledContextRoot>Hello</StyledContextRoot>
+      </ProviderRoot>,
+    );
+
+    const inlineSnapshot = `
+      <div
+        class="d_block"
+      >
+        Hello
+      </div>
+    `;
+
+    expect(rootProviderResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(providerResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(contextResult.container.firstChild?.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+  });
+  test("should merge in css from parent components", () => {
+    const { withProvider, withContext, withRootProvider } = createStyleContext(svaA);
+
+    const RootProviderRoot = withRootProvider<MockContextProps>(MockContext);
+
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+
+    const Parent = styled(
+      ark.div,
+      {
+        base: {
+          display: "block",
+        },
+      },
+      { baseComponent: true },
+    );
+
+    const rootProviderResult = render(
+      <RootProviderRoot>
+        <Parent asChild>
+          <ContextRoot>Hello</ContextRoot>
+        </Parent>
+      </RootProviderRoot>,
+    );
+    const providerResult = render(
+      <Parent asChild>
+        <ProviderRoot>Hello</ProviderRoot>
+      </Parent>,
+    );
+    const contextResult = render(
+      <ProviderRoot>
+        <Parent asChild>
+          <ContextRoot>Hello</ContextRoot>
+        </Parent>
+      </ProviderRoot>,
+    );
+
+    const inlineSnapshot = `
+      <div
+        class="d_block"
+      >
+        Hello
+      </div>
+    `;
+
+    expect(rootProviderResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(providerResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(contextResult.container.firstChild?.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+  });
+
+  test("should automatically forward the css prop when asChild is true", () => {
+    const { withProvider, withContext, withRootProvider } = createStyleContext(svaA);
+
+    const RootProviderRoot = withRootProvider<MockContextProps>(MockContext);
+
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+
+    const Child = styled("div", {
+      base: {
+        display: "inline",
+      },
+    });
+
+    const rootProviderResult = render(
+      <RootProviderRoot>
+        <ContextRoot asChild>
+          <Child>Hello</Child>
+        </ContextRoot>
+      </RootProviderRoot>,
+    );
+    const providerResult = render(
+      <ProviderRoot asChild>
+        <Child>Hello</Child>
+      </ProviderRoot>,
+    );
+    const contextResult = render(
+      <ProviderRoot>
+        <ContextRoot asChild>
+          <Child>Hello</Child>
+        </ContextRoot>
+      </ProviderRoot>,
+    );
+
+    const inlineSnapshot = `
+      <div
+        class="d_flex"
+      >
+        Hello
+      </div>
+    `;
+
+    expect(rootProviderResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(providerResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(contextResult.container.firstChild?.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+  });
+
+  test("seamlessly merges components from two different sets", () => {
+    const styledA = createStyleContext(svaA);
+
+    const ARootProviderRoot = styledA.withRootProvider<MockContextProps>(MockContext);
+
+    const AProviderRoot = styledA.withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const AContextRoot = styledA.withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+
+    const styledB = createStyleContext(svaB);
+
+    const BRootProviderRoot = styledB.withRootProvider<MockContextProps>(MockContext);
+
+    const BProviderRoot = styledB.withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const BContextRoot = styledB.withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+
+    const rootProviderResult = render(
+      <ARootProviderRoot>
+        <BRootProviderRoot>
+          <AContextRoot asChild>
+            <BContextRoot>Hello</BContextRoot>
+          </AContextRoot>
+        </BRootProviderRoot>
+      </ARootProviderRoot>,
+    );
+    const providerResult = render(
+      <AProviderRoot asChild>
+        <BProviderRoot>Hello</BProviderRoot>
+      </AProviderRoot>,
+    );
+
+    const contextResult = render(
+      <AProviderRoot asChild>
+        <BProviderRoot>
+          <AContextRoot asChild>
+            <BContextRoot>Hello</BContextRoot>
+          </AContextRoot>
+        </BProviderRoot>
+      </AProviderRoot>,
+    );
+
+    const inlineSnapshot = `
+      <div
+        class="d_flex"
+      >
+        Hello
+      </div>
+    `;
+
+    expect(rootProviderResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(providerResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(contextResult.container.firstChild?.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+  });
+  test("seamlessly merges components onto non-styled components", () => {
+    const { withProvider, withContext, withRootProvider } = createStyleContext(svaA);
+
+    const RootProviderRoot = withRootProvider<MockContextProps>(MockContext);
+
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+
+    const rootProviderResult = render(
+      <RootProviderRoot>
+        <ContextRoot asChild consumeCss>
+          <span>Hello</span>
+        </ContextRoot>
+      </RootProviderRoot>,
+    );
+    const providerResult = render(
+      <ProviderRoot asChild consumeCss>
+        <span>Hello</span>
+      </ProviderRoot>,
+    );
+
+    const inlineSnapshot = `
+      <span
+        class="d_flex"
+      >
+        Hello
+      </span>
+    `;
+
+    expect(rootProviderResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(providerResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+  });
+});

--- a/packages/primitives/src/createStyleContext.tsx
+++ b/packages/primitives/src/createStyleContext.tsx
@@ -17,7 +17,7 @@ import {
 } from "react";
 import { css } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
-import { SystemStyleObject, WithCss } from "@ndla/styled-system/types";
+import { StyledComponent, SystemStyleObject, WithCss } from "@ndla/styled-system/types";
 
 type Props = Record<string, unknown>;
 type Recipe = {
@@ -30,6 +30,12 @@ type Slot<R extends Recipe> = keyof ReturnType<R>;
 /**
  * A utility for creating a style context for a recipe, allowing one to change the styles of all parts of a component from the root component. Credit: https://github.com/cschroeter/park-ui/blob/main/website/src/lib/create-style-context.tsx.
  */
+
+interface BaseStyleContextProps {
+  asChild?: boolean;
+  consumeCss?: boolean;
+}
+
 export const createStyleContext = <R extends Recipe>(recipe: R) => {
   const StyleContext = createContext<Record<Slot<R>, SystemStyleObject> | null>(null);
 
@@ -47,11 +53,12 @@ export const createStyleContext = <R extends Recipe>(recipe: R) => {
     return StyledComponent;
   };
 
-  const withProvider = <T, P extends { className?: string } & WithCss>(
+  const withProvider = <T, P extends BaseStyleContextProps & WithCss>(
     Component: ElementType,
     slot: Slot<R>,
   ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> => {
-    const StyledComponent = styled(Component);
+    const opts = typeof Component === "string" ? undefined : { baseComponent: true };
+    const StyledComponent = styled(Component, {}, opts) as StyledComponent<ElementType, {}>;
     return forwardRef<T, P>(({ css: cssProp, ...props }, ref) => {
       const [variantProps, otherProps] = recipe.splitVariantProps(props);
 
@@ -65,11 +72,12 @@ export const createStyleContext = <R extends Recipe>(recipe: R) => {
     });
   };
 
-  const withContext = <T, P extends { className?: string } & WithCss>(
+  const withContext = <T, P extends BaseStyleContextProps & WithCss>(
     Component: ElementType,
     slot: Slot<R>,
   ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> => {
-    const StyledComponent = styled(Component);
+    const opts = typeof Component === "string" ? undefined : { baseComponent: true };
+    const StyledComponent = styled(Component, {}, opts) as StyledComponent<ElementType, {}>;
     return forwardRef<T, P>(({ css: cssProp, ...props }, ref) => {
       const slotStyles = useContext(StyleContext);
       return <StyledComponent {...props} ref={ref} css={css.raw(slotStyles?.[slot], cssProp)} />;

--- a/packages/styled-system/jsx/factory.js
+++ b/packages/styled-system/jsx/factory.js
@@ -18,9 +18,14 @@ function styledFn(Dynamic, configOrCva = {}, options = {}) {
   const __cvaFn__ = composeCvaFn(Dynamic.__cva__, cvaFn)
   const __shouldForwardProps__ = composeShouldForwardProps(Dynamic, shouldForwardProp)
   const __base__ = Dynamic.__base__ || Dynamic
+  const contextConsume = options.baseComponent ?? Dynamic.__base__ ?? typeof Dynamic === "string"
 
   const StyledComponent = /* @__PURE__ */ forwardRef(function StyledComponent(props, ref) {
-    const { as: Element = __base__, forwardCssProp, children, ...restProps } = props
+    const { as: Element = __base__, consumeCss, children, ...restProps } = props
+
+    const consume = props.asChild
+      ? consumeCss && options.baseComponent
+      : consumeCss ?? contextConsume
 
     const combinedProps = useMemo(() => Object.assign({}, defaultProps, restProps), [restProps])
 
@@ -37,7 +42,7 @@ function styledFn(Dynamic, configOrCva = {}, options = {}) {
     function cvaClass() {
       const { css: cssStyles, ...propStyles } = styleProps
       const cvaStyles = __cvaFn__.raw(variantProps)
-      if(options.forwardCssProp || forwardCssProp) {
+      if(!consume) {
         return css.raw(cvaStyles, propStyles, cssStyles)
       }
       return cx(css(cvaStyles, propStyles, cssStyles), combinedProps.className)
@@ -50,7 +55,7 @@ function styledFn(Dynamic, configOrCva = {}, options = {}) {
       ...forwardedProps,
       ...elementProps,
       ...normalizeHTMLProps(htmlProps),
-      ...(options.forwardCssProp || forwardCssProp ? { css: classes() } : { className: classes() }),
+      ...(consume ? { className: classes() } : { css: classes(), consumeCss } ),
     }, combinedProps.children ?? children)
   })
 

--- a/packages/styled-system/types/jsx.d.ts
+++ b/packages/styled-system/types/jsx.d.ts
@@ -24,7 +24,14 @@ interface JsxFactoryOptions<TProps extends Dict> {
   dataAttr?: boolean
   defaultProps?: TProps
   shouldForwardProp?(prop: string, variantKeys: string[]): boolean
-  forwardCssProp?: boolean
+  /**
+  * Used when creating styled components from React components that do not support the css prop. If true, the css prop will be consumed and converted to `className` 
+  * @example
+  * import { ark } from "@ark-ui/react"
+  * import { styled } from "@ndla/styled-system/jsx"
+  * const Button = styled(ark.button, { baseComponent: true })
+  */
+  baseComponent?: boolean
 }
 
 export type JsxRecipeProps<T extends ElementType, P extends Dict> = JsxHTMLProps<ComponentProps<T>, P>;

--- a/packages/styled-system/types/system-types.d.ts
+++ b/packages/styled-system/types/system-types.d.ts
@@ -69,7 +69,22 @@ interface WithCss {
   css?: SystemStyleObject | SystemStyleObject[]
 }
 
-export type JsxStyleProps = { forwardCssProp?: boolean } &  WithCss
+export type JsxStyleProps = { 
+  /**
+  * Tells a component to consume the `css` prop and turn it into a `className` prop. This is only used in conjunction with the `baseComponent` prop in the `styled` function to ensure that components that are `asChild`-ed onto non-panda components can consume their css before being merged with their child.
+  * @example
+  * import { ark } from "@ark-ui/react"
+  * import { styled } from "@ndla/styled-system/jsx"
+  * const Button = styled('button', { baseComponent: true })
+  *
+  * return (
+  *   <Button asChild consumeCss>
+  *     <div>Click me</div>
+  *   </Button>
+  * )
+  */
+  consumeCss?: boolean 
+  } &  WithCss
 
 export interface PatchedHTMLProps {
   htmlWidth?: string | number

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   shorthands: false,
   outExtension: "js",
   include: ["./packages/**/*.{js,jsx,ts,tsx}", "./stories/**/*.{js,jsx,ts,tsx}"],
+  exclude: ["./packages/**/*-test.{js,jsx,ts,tsx}"],
   syntax: "object-literal",
   jsxFramework: "react",
 });


### PR DESCRIPTION
Denne begynner å bli ganske klar. Har også opprettet en diskusjon med de som vedlikeholder panda for å se om dette er noe de vil ha inn i core.

Ny oppførsel er som følger:

### Styling av en helt vanlig div
```tsx
const StyledContainer = styled("div", {
  base: {
    display: "flex"
  }
});
```

### Styling av en komponent som ikke støtter `css`-propen til panda
```tsx
const StyledContainer = styled(ark.div, {
  base: {
    display: "flex",
  },
  { base: true },
});
```

### Styling av en komponent som støtter `css`-propen til panda
```tsx
const StyledContainer = styled(Text, {
  base: {
    display: "flex",
  },
});
```

Dersom du vil bruke `asChild`-propen for å merge med en komponent som ikke støtter panda må du legge på `consumeCss`-propen:
```tsx
const StyledContainer = styled(ark.div, {
  base: {
    display: "flex",
  },
  { base: true },
});

return (
  <StyledContainer asChild consumeCss>
    <section>
      Click me
    </section>
  </StyledContainer>
)
```

I bunn og grunn: Dette får `styled`-funksjonen til å fungere tilnærmet likt som den gjorde i emotion. Den eneste forskjellen er at vi må sende inn `{base: true}` til "grunnkomponenter", samt at vi må sende inn `consumeCss` til komponenter som skal merges med primitive komponenter.