### PR TITLE
Refactor CodeBlock and CodeEmbed. 

### DIFF
--- a/packages/ndla-ui/src/Embed/CodeEmbed.stories.tsx
+++ b/packages/ndla-ui/src/Embed/CodeEmbed.stories.tsx
@@ -1,23 +1,41 @@
 /**
- * Copyright (c) 2023-present, NDLA.
+ * Copyright (c) 2024-present, NDLA.
  *
  * This source code is licensed under the GPLv3 license found in the
  * LICENSE file in the root directory of this source tree.
  *
  */
 
-import { Meta, StoryFn, StoryObj } from "@storybook/react";
-import CodeBlock from "./CodeBlock";
+import { Meta, StoryObj } from "@storybook/react";
+import type { CodeEmbedData, CodeMetaData } from "@ndla/types-embed";
+import CodeEmbed from "./CodeEmbed";
 
-export default {
-  title: "Components/CodeBlock",
-  component: CodeBlock,
-  tags: ["autodocs"],
-  parameters: {
-    inlineStories: true,
-  },
-  args: {
-    format: "html",
+const codeEmbedData: CodeEmbedData = {
+  resource: "code-block",
+  title: "Litt css i hverdagen",
+  codeContent: `<div class="demo-content">
+  <h2>Lorem ipsum</h2>
+  <p>
+    <b>Lorem ipsum</b><br/>
+    <span>is simply dummy text of the printing and typesetting industry</span>
+  </p>
+  <p>
+    <b>Lorem ipsum</b><br/>
+    <span>is simply dummy text of the printing and typesetting industry</span>
+  </p>
+  <p>
+    <b>Lorem ipsum</b><br/>
+    <span>is simply dummy text of the printing and typesetting industry</span>
+  </p>
+</div>`,
+  codeFormat: "html",
+};
+
+const codeEmbed: CodeMetaData = {
+  status: "success",
+  resource: "code-block",
+  embedData: codeEmbedData,
+  data: {
     highlightedCode: `<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>div</span> <span class="token attr-name">class</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>demo-content<span class="token punctuation">"</span></span><span class="token punctuation">></span></span>
   <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>h2</span><span class="token punctuation">></span></span>Lorem ipsum<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>h2</span><span class="token punctuation">></span></span>
   <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>p</span><span class="token punctuation">></span></span>
@@ -33,36 +51,45 @@ export default {
     <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>span</span><span class="token punctuation">></span></span>is simply dummy text of the printing and typesetting industry<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>span</span><span class="token punctuation">></span></span>
   <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>p</span><span class="token punctuation">></span></span>
 <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>div</span><span class="token punctuation">></span></span>`,
-  },
-} as Meta<typeof CodeBlock>;
-
-export const HTML: StoryFn<typeof CodeBlock> = (args) => {
-  return <CodeBlock {...args} />;
-};
-
-export const CSS: StoryObj<typeof CodeBlock> = {
-  args: {
-    highlightedCode: `<span class="token selector">body</span> <span class="token punctuation">{</span>
-  <span class="token property">padding</span><span class="token punctuation">:</span> <span class="token number">20</span><span class="token unit">px</span><span class="token punctuation">;</span>
-  <span class="token property">margin</span><span class="token punctuation">:</span> <span class="token number">10</span><span class="token unit">px</span><span class="token punctuation">;</span>
-  <span class="token property">background</span><span class="token punctuation">:</span> <span class="token hexcode color">#ccc</span><span class="token punctuation">;</span>
-<span class="token punctuation">}</span>`,
-    format: "css",
-  },
-};
-
-export const JS: StoryObj<typeof CodeBlock> = {
-  args: {
-    highlightedCode: `<span class="token keyword">const</span> arr <span class="token operator">=</span> <span class="token punctuation">[</span><span class="token string">"This"</span><span class="token punctuation">,</span> <span class="token string">"Little"</span><span class="token punctuation">,</span> <span class="token string">"Piggy"</span><span class="token punctuation">]</span><span class="token punctuation">;</span>
-<span class="token keyword">const</span> first <span class="token operator">=</span> arr<span class="token punctuation">.</span><span class="token method function property-access">shift</span><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
-<span class="token console class-name">console</span><span class="token punctuation">.</span><span class="token method function property-access">log</span><span class="token punctuation">(</span>first<span class="token punctuation">)</span><span class="token punctuation">;</span>`,
-    format: "js",
+    decodedContent: `<div class="demo-content">
+  <h2>Lorem ipsum</h2>
+  <p>
+    <b>Lorem ipsum</b><br/>
+    <span>is simply dummy text of the printing and typesetting industry</span>
+  </p>
+  <p>
+    <b>Lorem ipsum</b><br/>
+    <span>is simply dummy text of the printing and typesetting industry</span>
+  </p>
+  <p>
+    <b>Lorem ipsum</b><br/>
+    <span>is simply dummy text of the printing and typesetting industry</span>
+  </p>
+</div>`,
   },
 };
 
-export const Text: StoryObj<typeof CodeBlock> = {
+export default {
+  title: "Embeds/CodeEmbed",
+  component: CodeEmbed,
+  tags: ["autodocs"],
+  parameters: {
+    inlineStories: true,
+  },
   args: {
-    highlightedCode: `Pure text without highlighting and no title`,
-    format: "text",
+    embed: codeEmbed,
+  },
+} as Meta<typeof CodeEmbed>;
+
+export const Default: StoryObj<typeof CodeEmbed> = {};
+
+export const Failed: StoryObj<typeof CodeEmbed> = {
+  args: {
+    embed: {
+      resource: "code-block",
+      embedData: codeEmbedData,
+      status: "error",
+      message: "Something horrible happened",
+    },
   },
 };

--- a/packages/ndla-ui/src/Embed/CodeEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/CodeEmbed.tsx
@@ -6,24 +6,79 @@
  *
  */
 
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Copy } from "@ndla/icons/action";
+import { Done } from "@ndla/icons/editor";
+import { Button, Figure } from "@ndla/primitives";
+import { styled } from "@ndla/styled-system/jsx";
 import { CodeMetaData } from "@ndla/types-embed";
-import { CodeBlock } from "../CodeBlock";
-import { Figure } from "../Figure";
+import { copyTextToClipboard } from "@ndla/util";
+import { CodeBlock, codeLanguageOptions } from "../CodeBlock";
+import { ICodeLangugeOption } from "../CodeBlock/codeLanguageOptions";
+
+// TODO: We need an error state for this
 
 interface Props {
   embed: CodeMetaData;
 }
+
+const StyledFigCaption = styled("figcaption", {
+  base: {
+    textStyle: "label.large",
+    fontWeight: "bold",
+  },
+});
+
+const StyledFigure = styled(Figure, {
+  base: {
+    // We apply margin here to allow for the float and size props on figure to work as intended.
+    "& > *:not(:where(:first-child))": {
+      marginBlockStart: "xsmall",
+    },
+  },
+});
+
+const getTitleFromFormat = (format: string) => {
+  const selectedLanguage = codeLanguageOptions.find((item: ICodeLangugeOption) => item.format === format);
+  if (selectedLanguage) {
+    return selectedLanguage.title;
+  }
+  return;
+};
+
 const CodeEmbed = ({ embed }: Props) => {
+  const [isCopied, setIsCopied] = useState(false);
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    if (isCopied) {
+      const timer = setInterval(() => setIsCopied(false), 3000);
+      // ensure interval is cleared - also if unmounted
+      return () => {
+        clearTimeout(timer);
+      };
+    }
+  }, [isCopied]);
+
   return (
-    <Figure>
+    <StyledFigure>
+      <StyledFigCaption>{embed.embedData.title || getTitleFromFormat(embed.embedData.codeFormat)}</StyledFigCaption>
       <CodeBlock
-        title={embed.embedData.title}
-        code={embed.status === "success" ? embed.data.decodedContent : ""}
         highlightedCode={embed.status === "success" ? embed.data.highlightedCode : ""}
         format={embed.embedData.codeFormat}
-        showCopy
       />
-    </Figure>
+      <Button
+        variant="secondary"
+        onClick={() => {
+          copyTextToClipboard(embed.status === "success" ? embed.data.decodedContent : "");
+          setIsCopied(true);
+        }}
+      >
+        {isCopied ? <Done /> : <Copy />}
+        {isCopied ? t("codeBlock.copiedCode") : t("codeBlock.copyCode")}
+      </Button>
+    </StyledFigure>
   );
 };
 


### PR DESCRIPTION
Ligger under "CodeBlock" i designet.

CodeBlock is only responsible for displaying the actual block of code. The copy button and the code block title has been moved to CodeEmbed. This is breaking in ED.