### PR TITLE
Add mandatory translations for primitives components. Expose hooks that provide them.

### DIFF
--- a/packages/ndla-ui/src/TagSelector/TagSelector.stories.tsx
+++ b/packages/ndla-ui/src/TagSelector/TagSelector.stories.tsx
@@ -32,9 +32,10 @@ import {
   TagSelectorRoot,
   TagSelectorTrigger,
 } from "./TagSelector";
+import { useTagSelectorTranslations } from "../i18n/useComponentTranslations";
 
 export default {
-  title: "Components/TagSelector new",
+  title: "Components/TagSelector",
   component: TagSelectorRoot,
   tags: ["autodocs"],
 } satisfies Meta<typeof TagSelectorRoot>;
@@ -52,9 +53,10 @@ const data = [
   "Education",
 ];
 
-export const Default: StoryFn<typeof TagSelectorRoot> = (args) => {
+export const Default: StoryFn<typeof TagSelectorRoot> = ({ translations, ...args }) => {
   const [options, setOptions] = useState(data);
   const [value, setValue] = useState<string[]>([]);
+  const componentTranslations = useTagSelectorTranslations(translations);
 
   const handleChange = (e: ComboboxInputValueChangeDetails) => {
     const filtered = data.filter((item) => item.toLowerCase().includes(e.inputValue.toLowerCase()));
@@ -68,6 +70,7 @@ export const Default: StoryFn<typeof TagSelectorRoot> = (args) => {
       items={options}
       onInputValueChange={handleChange}
       onValueChange={(details) => setValue(details.value)}
+      translations={componentTranslations}
     >
       <TagSelectorLabel>Emneknagger</TagSelectorLabel>
       <HStack gap="4xsmall">

--- a/packages/ndla-ui/src/TagSelector/TagSelector.tsx
+++ b/packages/ndla-ui/src/TagSelector/TagSelector.tsx
@@ -8,7 +8,7 @@
 
 import { forwardRef, useEffect, useId, useRef } from "react";
 import type { ComboboxCollectionItem } from "@ark-ui/react";
-import { ComboboxContext, useTagsInputContext, useComboboxContext } from "@ark-ui/react";
+import { ComboboxContext, useTagsInputContext } from "@ark-ui/react";
 import { Cross } from "@ndla/icons/action";
 import {
   ComboboxClearTrigger,
@@ -40,7 +40,7 @@ export const TagSelectorRoot = <T extends ComboboxCollectionItem>({
   allowCustomValue = true,
   multiple = true,
   selectionBehavior = "clear",
-  editable = false,
+  editable,
   addOnPaste = false,
   onValueChange,
   children,
@@ -124,14 +124,13 @@ export type TagSelectorInputProps = ComboboxInputProps & TagsInputInputProps;
 export const TagSelectorInputBase = forwardRef<HTMLInputElement, TagSelectorInputProps>(
   ({ children, ...props }, ref) => {
     const tagsApi = useTagsInputContext();
-    const comboboxApi = useComboboxContext();
 
     return (
       <ComboboxInput asChild>
         <TagsInputInput
           {...props}
           onKeyDown={(event) => {
-            if (event.key === "Enter" && comboboxApi.collection.items.length === 0) {
+            if (event.key === "Enter") {
               tagsApi.addValue(tagsApi.inputValue);
             }
           }}
@@ -146,7 +145,6 @@ export const TagSelectorInputBase = forwardRef<HTMLInputElement, TagSelectorInpu
 
 export const TagSelectorInput = forwardRef<HTMLInputElement, TagSelectorInputProps>(({ children, ...props }, ref) => {
   const tagsApi = useTagsInputContext();
-  const comboboxApi = useComboboxContext();
 
   return (
     <>
@@ -158,13 +156,14 @@ export const TagSelectorInput = forwardRef<HTMLInputElement, TagSelectorInputPro
               <Cross />
             </TagsInputItemDeleteTrigger>
           </TagsInputItemPreview>
+          <TagsInputItemInput />
         </TagsInputItem>
       ))}
       <ComboboxInput asChild>
         <TagsInputInput
           {...props}
           onKeyDown={(event) => {
-            if (event.key === "Enter" && comboboxApi.collection.items.length === 0) {
+            if (event.key === "Enter") {
               tagsApi.addValue(tagsApi.inputValue);
             }
           }}

--- a/packages/ndla-ui/src/TagSelector/TagSelector.tsx
+++ b/packages/ndla-ui/src/TagSelector/TagSelector.tsx
@@ -45,6 +45,7 @@ export const TagSelectorRoot = <T extends ComboboxCollectionItem>({
   onValueChange,
   children,
   value,
+  translations,
   ...rest
 }: TagSelectorRootProps<T>) => {
   const ids = {
@@ -69,6 +70,7 @@ export const TagSelectorRoot = <T extends ComboboxCollectionItem>({
       multiple={multiple}
       selectionBehavior={selectionBehavior}
       onValueChange={onValueChange}
+      translations={translations}
       onPointerDownOutside={(event) => {
         if (contains(controlRef.current, event.detail.originalEvent.target)) {
           event.preventDefault();
@@ -86,6 +88,7 @@ export const TagSelectorRoot = <T extends ComboboxCollectionItem>({
             editable={editable}
             onValueChange={onValueChange}
             addOnPaste={addOnPaste}
+            translations={translations}
           >
             {children}
           </TagsInputRoot>

--- a/packages/ndla-ui/src/i18n/index.ts
+++ b/packages/ndla-ui/src/i18n/index.ts
@@ -8,3 +8,8 @@
 
 export { i18nInstance } from "./i18n";
 export { formatNestedMessages } from "./formatNestedMessages";
+export {
+  useComboboxTranslations,
+  useTagSelectorTranslations,
+  useTagsInputTranslations,
+} from "./useComponentTranslations";

--- a/packages/ndla-ui/src/i18n/useComponentTranslations.ts
+++ b/packages/ndla-ui/src/i18n/useComponentTranslations.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useTranslation } from "react-i18next";
+import type { ComboboxCollectionItem } from "@ark-ui/react";
+import type { ComboboxRootProps, TagsInputRootProps } from "@ndla/primitives";
+import { TagSelectorRootProps } from "../TagSelector/TagSelector";
+
+export const useTagsInputTranslations = (
+  translations?: Partial<TagsInputRootProps["translations"]>,
+): TagsInputRootProps["translations"] => {
+  const { t } = useTranslation("translation", { keyPrefix: "component.tagsInput" });
+
+  return {
+    clearTriggerLabel: t("clearTriggerLabel"),
+    deleteTagTriggerLabel: (tag) => t("deleteTagTriggerLabel", { tag }),
+    tagAdded: (tag) => t("tagAdded", { tag }),
+    tagsPasted: (tag) => t("tagsPasted", { length: tag.length }),
+    tagEdited: (tag) => t("tagEdited", { tag }),
+    tagUpdated: (tag) => t("tagUpdated", { tag }),
+    tagDeleted: (tag) => t("tagDeleted", { tag }),
+    tagSelected: (tag) => t("tagSelected", { tag }),
+    ...translations,
+  };
+};
+
+export const useComboboxTranslations = <T extends ComboboxCollectionItem>(
+  translations?: Partial<ComboboxRootProps<T>["translations"]>,
+): ComboboxRootProps<T>["translations"] => {
+  const { t } = useTranslation("translation", { keyPrefix: "component.combobox" });
+
+  return {
+    triggerLabel: t("triggerLabel"),
+    clearTriggerLabel: t("clearTriggerLabel"),
+    ...translations,
+  };
+};
+
+export const useTagSelectorTranslations = <T extends ComboboxCollectionItem>(
+  translations?: Partial<TagSelectorRootProps<T>["translations"]>,
+): TagSelectorRootProps<T>["translations"] => {
+  const tagsInputTranslations = useTagsInputTranslations();
+  const comboboxTranslations = useComboboxTranslations();
+
+  return {
+    ...comboboxTranslations,
+    ...tagsInputTranslations,
+    ...translations,
+  } as TagSelectorRootProps<T>["translations"];
+};

--- a/packages/ndla-ui/src/i18n/useComponentTranslations.ts
+++ b/packages/ndla-ui/src/i18n/useComponentTranslations.ts
@@ -8,7 +8,7 @@
 
 import { useTranslation } from "react-i18next";
 import type { ComboboxCollectionItem } from "@ark-ui/react";
-import type { ComboboxRootProps, TagsInputRootProps } from "@ndla/primitives";
+import type { ComboboxRootProps, PaginationRootProps, TagsInputRootProps } from "@ndla/primitives";
 import { TagSelectorRootProps } from "../TagSelector/TagSelector";
 
 export const useTagsInputTranslations = (
@@ -52,4 +52,21 @@ export const useTagSelectorTranslations = <T extends ComboboxCollectionItem>(
     ...tagsInputTranslations,
     ...translations,
   } as TagSelectorRootProps<T>["translations"];
+};
+
+export const usePaginationTranslations = (
+  translations?: Partial<PaginationRootProps["translations"]>,
+): PaginationRootProps["translations"] => {
+  const { t } = useTranslation("translation", { keyPrefix: "component.pagination" });
+
+  return {
+    rootLabel: t("rootLabel"),
+    prevTriggerLabel: t("prevTriggerLabel"),
+    nextTriggerLabel: t("nextTriggerLabel"),
+    itemLabel: (details) => {
+      const lastPage = details.totalPages > 1 && details.page === details.totalPages;
+      return lastPage ? t("lastPage", { page: details.page }) : t("page", { page: details.page });
+    },
+    ...translations,
+  };
 };

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -107,7 +107,13 @@ export { default as messagesSMA } from "./locale/messages-sma";
 export { default as Breadcrumb, HomeBreadcrumb } from "./Breadcrumb";
 export type { SimpleBreadcrumbItem, IndexedBreadcrumbItem } from "./Breadcrumb";
 
-export { i18nInstance, formatNestedMessages } from "./i18n";
+export {
+  i18nInstance,
+  formatNestedMessages,
+  useTagsInputTranslations,
+  useTagSelectorTranslations,
+  useComboboxTranslations,
+} from "./i18n";
 
 export { default as LayoutItem, OneColumn, PageContainer } from "./Layout";
 

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -1473,6 +1473,22 @@ const messages = {
     menuTitle: "About NDLA",
   },
   login: "Log in",
+  component: {
+    tagsInput: {
+      clearTriggerLabel: "Clear all tags",
+      deleteTagTriggerLabel: "Remove tag {{tag}}",
+      tagAdded: "Added tag {{tag}}",
+      tagsPasted: "Pasted {{length}} tags",
+      tagEdited: "Edited tag {{tag}}. Press enter to save, or escape to cancel.",
+      tagUpdated: "Tag updated to {{tag}}",
+      tagDeleted: "Tag {{tag}} deleted",
+      tagSelected: "Tag {{tag}} selected. Press enter to edit. Press backspace or delete to delete.",
+    },
+    combobox: {
+      triggerLabel: "Show suggestions",
+      clearTriggerLabel: "Clear selection",
+    },
+  },
 };
 
 export default messages;

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -1488,6 +1488,13 @@ const messages = {
       triggerLabel: "Show suggestions",
       clearTriggerLabel: "Clear selection",
     },
+    pagination: {
+      rootLabel: "Pagination",
+      prevTriggerLabel: "Previous page",
+      nextTriggerLabel: "Next page",
+      lastPage: "Last page, page {{page}}",
+      page: "Page {{page}}",
+    },
   },
 };
 

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -1473,6 +1473,22 @@ const messages = {
     menuTitle: "Om NDLA",
   },
   login: "Logg inn",
+  component: {
+    tagsInput: {
+      clearTriggerLabel: "Fjern alle emneknagger",
+      deleteTagTriggerLabel: "Fjern emneknagg {{tag}}",
+      tagAdded: "Emneknagg {{tag}} lagt til",
+      tagsPasted: "Limte inn {{length}} emneknagger",
+      tagEdited: "Redigerer emneknagg {{tag}}. Trykk enter for å lagre, eller esc for å avbryte.",
+      tagUpdated: "Emneknagg oppdatert til {{tag}}",
+      tagDeleted: "Emneknagg {{tag}} slettet",
+      tagSelected: "Emneknagg {{tag}} valgt. Trykk enter for å redigere. Trykk backspace eller delete for å slette",
+    },
+    combobox: {
+      triggerLabel: "Vis resultater",
+      clearTriggerLabel: "Fjern valg",
+    },
+  },
 };
 
 export default messages;

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -1488,6 +1488,13 @@ const messages = {
       triggerLabel: "Vis resultater",
       clearTriggerLabel: "Fjern valg",
     },
+    pagination: {
+      rootLabel: "Sidenavigering",
+      prevTriggerLabel: "Forrige side",
+      nextTriggerLabel: "Neste side",
+      lastPage: "Siste side, side {{page}}",
+      page: "Side {{page}}",
+    },
   },
 };
 

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -1472,6 +1472,22 @@ const messages = {
     menuTitle: "Om NDLA",
   },
   login: "Logg inn",
+  component: {
+    tagsInput: {
+      clearTriggerLabel: "Fjern alle emneknaggar",
+      deleteTagTriggerLabel: "Fjern emneknagg {{tag}}",
+      tagAdded: "Emneknagg {{tag}} lagt til",
+      tagsPasted: "Limte inn {{length}} emneknaggar",
+      tagEdited: "Redigerer emneknagg {{tag}}. Trykk enter for å lagre, eller esc for å avbryte.",
+      tagUpdated: "Emneknagg oppdatret til {{tag}}",
+      tagDeleted: "Emneknagg {{tag}} slettet",
+      tagSelected: "Emneknagg {{tag}} valgt. Trykk enter for å redigere. Trykk backspace eller delete for å slette",
+    },
+    combobox: {
+      triggerLabel: "Vis resultater",
+      clearTriggerLabel: "Fjern valg",
+    },
+  },
 };
 
 export default messages;

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -1487,6 +1487,13 @@ const messages = {
       triggerLabel: "Vis resultater",
       clearTriggerLabel: "Fjern valg",
     },
+    pagination: {
+      rootLabel: "Sidenavigering",
+      prevTriggerLabel: "Førre side",
+      nextTriggerLabel: "Neste side",
+      lastPage: "Siste side, side {{page}}",
+      page: "Side {{page}}",
+    },
   },
 };
 

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -1490,6 +1490,13 @@ const messages = {
       triggerLabel: "Vis resultater",
       clearTriggerLabel: "Fjern valg",
     },
+    pagination: {
+      rootLabel: "Sidenavigering",
+      prevTriggerLabel: "Forrige side",
+      nextTriggerLabel: "Neste side",
+      lastPage: "Siste side, side {{page}}",
+      page: "Side {{page}}",
+    },
   },
 };
 

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -1475,6 +1475,22 @@ const messages = {
     menuTitle: "NDLA birra",
   },
   login: "Čálit sisa",
+  component: {
+    tagsInput: {
+      clearTriggerLabel: "Fjern alle emneknagger",
+      deleteTagTriggerLabel: "Fjern emneknagg {{tag}}",
+      tagAdded: "Emneknagg {{tag}} lagt til",
+      tagsPasted: "Limte inn {{length}} emneknagger",
+      tagEdited: "Redigerer emneknagg {{tag}}. Trykk enter for å lagre, eller esc for å avbryte.",
+      tagUpdated: "Emneknagg oppdatert til {{tag}}",
+      tagDeleted: "Emneknagg {{tag}} slettet",
+      tagSelected: "Emneknagg {{tag}} valgt. Trykk enter for å redigere. Trykk backspace eller delete for å slette",
+    },
+    combobox: {
+      triggerLabel: "Vis resultater",
+      clearTriggerLabel: "Fjern valg",
+    },
+  },
 };
 
 export default messages;

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -1477,6 +1477,22 @@ const messages = {
     menuTitle: "Om NDLA",
   },
   login: "Tjaangh sïjse",
+  component: {
+    tagsInput: {
+      clearTriggerLabel: "Fjern alle emneknagger",
+      deleteTagTriggerLabel: "Fjern emneknagg {{tag}}",
+      tagAdded: "Emneknagg {{tag}} lagt til",
+      tagsPasted: "Limte inn {{length}} emneknagger",
+      tagEdited: "Redigerer emneknagg {{tag}}. Trykk enter for å lagre, eller esc for å avbryte.",
+      tagUpdated: "Emneknagg oppdatert til {{tag}}",
+      tagDeleted: "Emneknagg {{tag}} slettet",
+      tagSelected: "Emneknagg {{tag}} valgt. Trykk enter for å redigere. Trykk backspace eller delete for å slette",
+    },
+    combobox: {
+      triggerLabel: "Vis resultater",
+      clearTriggerLabel: "Fjern valg",
+    },
+  },
 };
 
 export default messages;

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -1492,6 +1492,13 @@ const messages = {
       triggerLabel: "Vis resultater",
       clearTriggerLabel: "Fjern valg",
     },
+    pagination: {
+      rootLabel: "Sidenavigering",
+      prevTriggerLabel: "Forrige side",
+      nextTriggerLabel: "Neste side",
+      lastPage: "Siste side, side {{page}}",
+      page: "Side {{page}}",
+    },
   },
 };
 

--- a/packages/primitives/src/Combobox.stories.tsx
+++ b/packages/primitives/src/Combobox.stories.tsx
@@ -42,6 +42,10 @@ const meta: Meta<typeof ComboboxRoot> = {
   component: ComboboxRoot,
   args: {
     variant: "simple",
+    translations: {
+      triggerLabel: "Vis forslag",
+      clearTriggerLabel: "Fjern valg",
+    },
   },
 };
 

--- a/packages/primitives/src/Combobox.tsx
+++ b/packages/primitives/src/Combobox.tsx
@@ -149,7 +149,11 @@ const { withProvider, withContext } = createStyleContext(comboboxRecipe);
 
 export type ComboboxVariantProps = RecipeVariantProps<typeof comboboxRecipe>;
 
-export type ComboboxRootProps<T extends Combobox.CollectionItem> = Combobox.RootProps<T> & ComboboxVariantProps;
+interface RootProps<T extends Combobox.CollectionItem> extends Combobox.RootProps<T> {
+  translations: Combobox.RootProps<T>["translations"];
+}
+
+export type ComboboxRootProps<T extends Combobox.CollectionItem> = RootProps<T> & ComboboxVariantProps;
 
 const InternalComboboxRoot = withProvider<HTMLDivElement, ComboboxRootProps<Combobox.CollectionItem>>(
   Combobox.Root,

--- a/packages/primitives/src/Combobox.tsx
+++ b/packages/primitives/src/Combobox.tsx
@@ -149,11 +149,8 @@ const { withProvider, withContext } = createStyleContext(comboboxRecipe);
 
 export type ComboboxVariantProps = RecipeVariantProps<typeof comboboxRecipe>;
 
-interface RootProps<T extends Combobox.CollectionItem> extends Combobox.RootProps<T> {
-  translations: Combobox.RootProps<T>["translations"];
-}
-
-export type ComboboxRootProps<T extends Combobox.CollectionItem> = RootProps<T> & ComboboxVariantProps;
+export type ComboboxRootProps<T extends Combobox.CollectionItem> = Combobox.RootProps<T> &
+  ComboboxVariantProps & { translations: Combobox.RootProps<T>["translations"] };
 
 const InternalComboboxRoot = withProvider<HTMLDivElement, ComboboxRootProps<Combobox.CollectionItem>>(
   Combobox.Root,

--- a/packages/primitives/src/Combobox.tsx
+++ b/packages/primitives/src/Combobox.tsx
@@ -150,7 +150,8 @@ const { withProvider, withContext } = createStyleContext(comboboxRecipe);
 export type ComboboxVariantProps = RecipeVariantProps<typeof comboboxRecipe>;
 
 export type ComboboxRootProps<T extends Combobox.CollectionItem> = Combobox.RootProps<T> &
-  ComboboxVariantProps & { translations: Combobox.RootProps<T>["translations"] };
+  ComboboxVariantProps &
+  JsxStyleProps & { translations: Combobox.RootProps<T>["translations"] };
 
 const InternalComboboxRoot = withProvider<HTMLDivElement, ComboboxRootProps<Combobox.CollectionItem>>(
   Combobox.Root,

--- a/packages/primitives/src/Pagination.stories.tsx
+++ b/packages/primitives/src/Pagination.stories.tsx
@@ -27,6 +27,15 @@ export default {
     count: 5000,
     pageSize: 10,
     siblingCount: 2,
+    translations: {
+      nextTriggerLabel: "Neste side",
+      prevTriggerLabel: "Forrige side",
+      rootLabel: "Sidenavigering",
+      itemLabel: (details) => {
+        const lastPage = details.totalPages > 1 && details.page === details.totalPages;
+        return lastPage ? `Forrige side, side ${details.page}` : `Side ${details.page}`;
+      },
+    },
   },
   render: (args) => (
     <PaginationRoot {...args}>

--- a/packages/primitives/src/Pagination.tsx
+++ b/packages/primitives/src/Pagination.tsx
@@ -30,7 +30,11 @@ const paginationRecipe = sva({
 
 const { withProvider, withContext } = createStyleContext(paginationRecipe);
 
-export type PaginationRootProps = JsxStyleProps & Pagination.RootProps;
+interface RootProps extends Pagination.RootProps {
+  translations: Pagination.RootProps["translations"];
+}
+
+export type PaginationRootProps = JsxStyleProps & RootProps;
 
 export const PaginationRoot = withProvider<HTMLElement, PaginationRootProps>(Pagination.Root, "root", {
   baseComponent: true,

--- a/packages/primitives/src/Tabs.tsx
+++ b/packages/primitives/src/Tabs.tsx
@@ -203,7 +203,11 @@ const { withProvider, withContext } = createStyleContext(tabsRecipe);
 
 export type TabsVariantProps = RecipeVariantProps<typeof tabsRecipe>;
 
-export type TabsRootProps = Tabs.RootProps & TabsVariantProps & JsxStyleProps;
+interface RootProps extends Tabs.RootProps {
+  translations: Tabs.RootProps["translations"];
+}
+
+export type TabsRootProps = RootProps & TabsVariantProps & JsxStyleProps;
 
 const InternalTabsRoot = withProvider<HTMLDivElement, TabsRootProps>(Tabs.Root, "root", { baseComponent: true });
 

--- a/packages/primitives/src/TagsInput.stories.tsx
+++ b/packages/primitives/src/TagsInput.stories.tsx
@@ -32,6 +32,19 @@ import {
 const meta: Meta<typeof TagsInputRoot> = {
   title: "Primitives/TagsInput",
   component: TagsInputRoot,
+  args: {
+    translations: {
+      clearTriggerLabel: "Fjern alle emneknagger",
+      deleteTagTriggerLabel: (tag) => `Fjern emneknagg ${tag}`,
+      tagAdded: (tag) => `Emneknagg ${tag} lagt til`,
+      tagsPasted: (tags) => `${tags.length} emneknagger lagt til`,
+      tagEdited: (tag) => `Redigererer emneknagg ${tag}. Trykk enter for å lagre, eller esc for å avbryte.`,
+      tagUpdated: (tag) => `Emneknagg oppdatert til ${tag}`,
+      tagDeleted: (tag) => `Emneknagg ${tag} slettet`,
+      tagSelected: (tag) =>
+        `Emneknagg ${tag} valgt. Trykk enter for å redigere. Trykk backspace eller delete for å slette.`,
+    },
+  },
   tags: ["autodocs"],
 };
 

--- a/packages/primitives/src/TagsInput.tsx
+++ b/packages/primitives/src/TagsInput.tsx
@@ -94,7 +94,11 @@ const tagsInputRecipe = sva({
 });
 const { withProvider, withContext } = createStyleContext(tagsInputRecipe);
 
-export type TagsInputRootProps = TagsInput.RootProps & JsxStyleProps;
+interface RootProps extends TagsInput.RootProps {
+  translations: TagsInput.RootProps["translations"];
+}
+
+export type TagsInputRootProps = RootProps & JsxStyleProps;
 export const TagsInputRoot = withProvider<HTMLDivElement, TagsInputRootProps>(TagsInput.Root, "root", {
   baseComponent: true,
 });


### PR DESCRIPTION
Dette er et forslag til hvordan vi kan holde i18next og react-i18next utenfor primitives. Tenker at vi på sikt kan vurdere hvorvidt translations egentlig hører hjemme i `ndla/ui`, men inntil videre kan de fint leve der.