### PR TITLE
Create a new version of ContentTypeBadge

### DIFF
--- a/packages/ndla-ui/src/ContentTypeBadge/ContentTypeBadgeNew.stories.tsx
+++ b/packages/ndla-ui/src/ContentTypeBadge/ContentTypeBadgeNew.stories.tsx
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { useTranslation } from "react-i18next";
+import { Meta, StoryFn, StoryObj } from "@storybook/react";
+import { Video } from "@ndla/icons/editor";
+import { HStack, styled } from "@ndla/styled-system/jsx";
+import { ContentTypeBadge } from "./ContentTypeBadgeNew";
+
+export default {
+  title: "Components/ContentTypeBadgeNew",
+  component: ContentTypeBadge,
+  tags: ["autodocs"],
+  parameters: {
+    inlineStories: true,
+  },
+  args: {
+    contentType: "subject-material",
+  },
+} satisfies Meta<typeof ContentTypeBadge>;
+
+export const Default: StoryObj<typeof ContentTypeBadge> = {};
+
+const StyledHStack = styled(HStack, {
+  base: {
+    flexWrap: "wrap",
+  },
+});
+
+export const AllBadges: StoryFn<typeof ContentTypeBadge> = () => (
+  <StyledHStack gap="3xsmall">
+    <ContentTypeBadge contentType="subject-material" />
+    <ContentTypeBadge contentType="tasks-and-activities" />
+    <ContentTypeBadge contentType="assessment-resources" />
+    <ContentTypeBadge contentType="subject" />
+    <ContentTypeBadge contentType="source-material" />
+    <ContentTypeBadge contentType="learning-path" />
+    <ContentTypeBadge contentType="topic" />
+    <ContentTypeBadge contentType="multidisciplinary-topic" />
+    <ContentTypeBadge contentType="concept" />
+    <ContentTypeBadge contentType="external" />
+    <ContentTypeBadge contentType="image" />
+    <ContentTypeBadge contentType="audio" />
+    <ContentTypeBadge contentType="video" />
+    <ContentTypeBadge contentType="missing" />
+  </StyledHStack>
+);
+
+const StyledContentTypeBadge = styled(ContentTypeBadge, {
+  base: {
+    display: "flex",
+    gap: "4xsmall",
+    alignItems: "center",
+  },
+});
+
+export const ContentOverride: StoryFn<typeof ContentTypeBadge> = () => {
+  const { t } = useTranslation();
+  return (
+    <StyledContentTypeBadge contentType="video">
+      <Video size="small" />
+      {t("contentTypes.video")}
+    </StyledContentTypeBadge>
+  );
+};

--- a/packages/ndla-ui/src/ContentTypeBadge/ContentTypeBadgeNew.tsx
+++ b/packages/ndla-ui/src/ContentTypeBadge/ContentTypeBadgeNew.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { forwardRef } from "react";
+import { useTranslation } from "react-i18next";
+import { Badge, BadgeProps, type BadgeVariant } from "@ndla/primitives";
+import * as contentTypes from "../model/ContentType";
+
+export interface ContentTypeBadgeProps extends Omit<BadgeProps, "colorTheme"> {
+  contentType: ContentType | undefined;
+}
+
+type ContentType =
+  | typeof contentTypes.SUBJECT_MATERIAL
+  | typeof contentTypes.TASKS_AND_ACTIVITIES
+  | typeof contentTypes.ASSESSMENT_RESOURCES
+  | typeof contentTypes.SUBJECT
+  | typeof contentTypes.SOURCE_MATERIAL
+  | typeof contentTypes.LEARNING_PATH
+  | typeof contentTypes.TOPIC
+  | typeof contentTypes.MULTIDISCIPLINARY_TOPIC
+  | typeof contentTypes.CONCEPT
+  | typeof contentTypes.EXTERNAL
+  | typeof contentTypes.IMAGE
+  | typeof contentTypes.AUDIO
+  | typeof contentTypes.VIDEO
+  | typeof contentTypes.MISSING
+  // This allows for us to fallback to string without getting a ts error, while still keeping intellisense
+  | (string & {});
+
+export const contentTypeToBadgeVariantMap: Record<ContentType, BadgeVariant> = {
+  [contentTypes.SUBJECT_MATERIAL]: "brand1",
+  [contentTypes.TASKS_AND_ACTIVITIES]: "brand2",
+  [contentTypes.ASSESSMENT_RESOURCES]: "brand2",
+  [contentTypes.SUBJECT]: "neutral",
+  [contentTypes.SOURCE_MATERIAL]: "brand1",
+  [contentTypes.LEARNING_PATH]: "brand3",
+  [contentTypes.TOPIC]: "neutral",
+  // TODO: Verify this color
+  [contentTypes.MULTIDISCIPLINARY_TOPIC]: "neutral",
+  [contentTypes.CONCEPT]: "brand1",
+  // TODO: Verify this color
+  [contentTypes.EXTERNAL]: "brand2",
+  // TODO: Verify resourceEmbedTypeMapping colors
+  [contentTypes.IMAGE]: "brand1",
+  [contentTypes.AUDIO]: "brand1",
+  [contentTypes.VIDEO]: "brand1",
+  [contentTypes.MISSING]: "neutral",
+};
+
+export const ContentTypeBadge = forwardRef<HTMLDivElement, ContentTypeBadgeProps>(
+  ({ contentType, children, ...props }, ref) => {
+    const { t } = useTranslation();
+    return (
+      <Badge
+        colorTheme={contentTypeToBadgeVariantMap[contentType ?? "missing"] ?? contentTypeToBadgeVariantMap["missing"]}
+        {...props}
+        ref={ref}
+      >
+        {children ?? t(`contentTypes.${contentType}`)}
+      </Badge>
+    );
+  },
+);

--- a/packages/ndla-ui/src/index.ts
+++ b/packages/ndla-ui/src/index.ts
@@ -130,6 +130,12 @@ export {
   ConceptBadge,
 } from "./ContentTypeBadge";
 
+export type { ContentTypeBadgeProps } from "./ContentTypeBadge/ContentTypeBadgeNew";
+export {
+  ContentTypeBadge as ContentTypeBadgeNew,
+  contentTypeToBadgeVariantMap,
+} from "./ContentTypeBadge/ContentTypeBadgeNew";
+
 export { default as CopyParagraphButton } from "./CopyParagraphButton";
 
 export { default as ContentPlaceholder } from "./ContentPlaceholder";

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -578,6 +578,7 @@ const messages = {
     h5p: "H5P",
     video: "Video",
     missing: "Unknown",
+    external: "External",
   },
   modal: {
     closeModal: "Close",

--- a/packages/ndla-ui/src/locale/messages-en.ts
+++ b/packages/ndla-ui/src/locale/messages-en.ts
@@ -577,6 +577,7 @@ const messages = {
     podcast: "Podcast",
     h5p: "H5P",
     video: "Video",
+    missing: "Unknown",
   },
   modal: {
     closeModal: "Close",

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -578,6 +578,7 @@ const messages = {
     h5p: "H5P",
     video: "Video",
     missing: "Ukjent",
+    external: "Ekstern",
   },
   modal: {
     closeModal: "Lukk",

--- a/packages/ndla-ui/src/locale/messages-nb.ts
+++ b/packages/ndla-ui/src/locale/messages-nb.ts
@@ -577,6 +577,7 @@ const messages = {
     podcast: "Podkast",
     h5p: "H5P",
     video: "Video",
+    missing: "Ukjent",
   },
   modal: {
     closeModal: "Lukk",

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -578,6 +578,7 @@ const messages = {
     h5p: "H5P",
     video: "Video",
     missing: "Ukjent",
+    external: "Ekstern",
   },
   modal: {
     closeModal: "Lukk",

--- a/packages/ndla-ui/src/locale/messages-nn.ts
+++ b/packages/ndla-ui/src/locale/messages-nn.ts
@@ -577,6 +577,7 @@ const messages = {
     podcast: "Podkast",
     h5p: "H5P",
     video: "Video",
+    missing: "Ukjent",
   },
   modal: {
     closeModal: "Lukk",

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -579,6 +579,7 @@ const messages = {
     podcast: "Podkásta",
     h5p: "H5P",
     video: "Video",
+    missing: "Ukjent",
   },
   modal: {
     closeModal: "Govčča",

--- a/packages/ndla-ui/src/locale/messages-se.ts
+++ b/packages/ndla-ui/src/locale/messages-se.ts
@@ -580,6 +580,7 @@ const messages = {
     h5p: "H5P",
     video: "Video",
     missing: "Ukjent",
+    external: "Ekstern",
   },
   modal: {
     closeModal: "Govčča",

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -582,6 +582,7 @@ const messages = {
     h5p: "H5P",
     video: "Video",
     missing: "Ukjent",
+    external: "Ekstern",
   },
   modal: {
     closeModal: "Dahph",

--- a/packages/ndla-ui/src/locale/messages-sma.ts
+++ b/packages/ndla-ui/src/locale/messages-sma.ts
@@ -581,6 +581,7 @@ const messages = {
     podcast: "Podkast",
     h5p: "H5P",
     video: "Video",
+    missing: "Ukjent",
   },
   modal: {
     closeModal: "Dahph",

--- a/packages/ndla-ui/src/model/ContentType.ts
+++ b/packages/ndla-ui/src/model/ContentType.ts
@@ -17,6 +17,9 @@ export const MULTIDISCIPLINARY_TOPIC = "multidisciplinary-topic";
 export const CONCEPT = "concept";
 export const EXTERNAL = "external";
 export const MISSING = "missing";
+export const IMAGE = "image";
+export const VIDEO = "video";
+export const AUDIO = "audio";
 
 export const contentTypes = {
   SUBJECT_MATERIAL,

--- a/packages/primitives/src/Badge.tsx
+++ b/packages/primitives/src/Badge.tsx
@@ -46,6 +46,8 @@ const badgeRecipe = cva({
 
 export type BadgeVariantProps = RecipeVariantProps<typeof badgeRecipe>;
 
+export type BadgeVariant = NonNullable<BadgeVariantProps>["colorTheme"];
+
 export type BadgeProps = HTMLArkProps<"div"> & JsxStyleProps & BadgeVariantProps;
 
 const StyledBadge = styled(ark.div, {}, { baseComponent: true });

--- a/packages/primitives/src/index.ts
+++ b/packages/primitives/src/index.ts
@@ -23,7 +23,7 @@ export type {
 } from "./ArticleLists";
 export { OrderedList, UnOrderedList, DefinitionList } from "./ArticleLists";
 
-export type { BadgeVariantProps, BadgeProps } from "./Badge";
+export type { BadgeVariantProps, BadgeProps, BadgeVariant } from "./Badge";
 
 export { Badge } from "./Badge";
 


### PR DESCRIPTION
Eksporterer heller en ny versjon enn å slette den gamle inntil videre. Den brukes altfor mange steder i ndla-frontend.