### PR TITLE
Add Card component

### DIFF
--- a/packages/primitives/src/Card/Card.stories.tsx
+++ b/packages/primitives/src/Card/Card.stories.tsx
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Meta, StoryFn } from "@storybook/react";
+import { Badge, Text } from "@ndla/primitives";
+import { SafeLink } from "@ndla/safelink";
+import { styled } from "@ndla/styled-system/jsx";
+import { linkOverlay } from "@ndla/styled-system/patterns";
+import { CardContent, CardHeading, CardImage, CardRoot } from "./Card";
+
+export default {
+  title: "Primitives/Card",
+  component: CardRoot,
+  tags: ["autodocs"],
+  parameters: {
+    inlineStories: true,
+  },
+} satisfies Meta<typeof CardRoot>;
+
+export const Default: StoryFn<typeof CardRoot> = (args) => (
+  <CardRoot {...args}>
+    <CardContent>
+      <Badge colorTheme="brand1">Fagstoff</Badge>
+      <CardHeading>
+        <SafeLink to="#example" unstyled css={linkOverlay.raw()}>
+          Tittel
+        </SafeLink>
+      </CardHeading>
+      <Text>
+        En metabeskrivelse forteller litt om innholdet til kortet. Dette kortet handler for eksempel om absolutt
+        ingenting.
+      </Text>
+      <Text color="text.subtle" textStyle="label.small">
+        {"Fag > Emne > Underemne"}
+      </Text>
+    </CardContent>
+  </CardRoot>
+);
+
+export const WithImage: StoryFn<typeof CardRoot> = (args) => (
+  <CardRoot {...args}>
+    <CardImage src="https://api.staging.ndla.no/image-api/raw/Ide.jpg" alt="En lyspære" height={200} />
+    <CardContent>
+      <Badge colorTheme="brand1">Fagstoff</Badge>
+      <CardHeading>
+        <SafeLink to="#example" unstyled css={linkOverlay.raw()}>
+          Tittel
+        </SafeLink>
+      </CardHeading>
+      <Text>
+        En metabeskrivelse forteller litt om innholdet til kortet. Dette kortet handler for eksempel om absolutt
+        ingenting.
+      </Text>
+      <Text color="text.subtle" textStyle="label.small">
+        {"Fag > Emne > Underemne"}
+      </Text>
+    </CardContent>
+  </CardRoot>
+);
+
+export const InGrid: StoryFn<typeof CardRoot> = (args) => {
+  const component = (
+    <CardRoot {...args}>
+      <CardImage src="https://api.staging.ndla.no/image-api/raw/Ide.jpg" alt="En lyspære" height={200} />
+      <CardContent>
+        <Badge colorTheme="brand1">Fagstoff</Badge>
+        <CardHeading>
+          <SafeLink to="#example" unstyled css={linkOverlay.raw()}>
+            Tittel
+          </SafeLink>
+        </CardHeading>
+        <Text>
+          En metabeskrivelse forteller litt om innholdet til kortet. Dette kortet handler for eksempel om absolutt
+          ingenting.
+        </Text>
+        <Text color="text.subtle" textStyle="label.small">
+          {"Fag > Emne > Underemne"}
+        </Text>
+      </CardContent>
+    </CardRoot>
+  );
+
+  return (
+    <styled.div
+      css={{
+        display: "grid",
+        gridTemplateColumns: "repeat(3, 1fr)",
+        gap: "xsmall",
+        tabletWideDown: {
+          gridTemplateColumns: "repeat(2, 1fr)",
+        },
+        mobileWideDown: {
+          gridTemplateColumns: "repeat(1, 1fr)",
+        },
+      }}
+    >
+      {component}
+      {component}
+      {component}
+      {component}
+      {component}
+    </styled.div>
+  );
+};

--- a/packages/primitives/src/Card/Card.tsx
+++ b/packages/primitives/src/Card/Card.tsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { forwardRef } from "react";
+import { ark, type HTMLArkProps } from "@ark-ui/react";
+import { sva } from "@ndla/styled-system/css";
+import type { JsxStyleProps } from "@ndla/styled-system/types";
+import { createStyleContext } from "../createStyleContext";
+import { type ImageProps, Image } from "../Image";
+import { Heading, type TextProps } from "../Text";
+
+const cardRecipe = sva({
+  slots: ["root", "title", "content", "image"],
+  base: {
+    root: {
+      position: "relative",
+      border: "1px solid",
+      borderRadius: "xsmall",
+      borderColor: "stroke.subtle",
+      background: "surface.actionSubtle",
+      transitionDuration: "fast",
+      transitionProperty: "background, color",
+      transitionTimingFunction: "default",
+      "&:has(img)": {
+        background: "surface.default",
+      },
+      _hover: {
+        background: "surface.actionSubtle.hover",
+        borderColor: "stroke.hover",
+        "& h1, h2, h3, h4, h5, h6": {
+          textDecoration: "none",
+        },
+      },
+    },
+    content: {
+      display: "flex",
+      flexDirection: "column",
+      gap: "xsmall",
+      paddingBlock: "xsmall",
+      paddingInline: "medium",
+    },
+    title: {
+      textDecoration: "underline",
+    },
+    image: {
+      height: "200px",
+      objectFit: "cover",
+      width: "100%",
+    },
+  },
+});
+
+const { withProvider, withContext } = createStyleContext(cardRecipe);
+
+export const CardRoot = withProvider<HTMLElement, HTMLArkProps<"article"> & JsxStyleProps>(ark.article, "root");
+
+const InternalCardHeading = forwardRef<HTMLHeadingElement, TextProps>(
+  ({ textStyle = "label.large", fontWeight = "bold", ...props }, ref) => (
+    <Heading textStyle={textStyle} fontWeight={fontWeight} {...props} ref={ref} />
+  ),
+);
+
+export const CardHeading = withContext<HTMLHeadingElement, TextProps & HTMLArkProps<"p"> & JsxStyleProps>(
+  InternalCardHeading,
+  "title",
+);
+
+export const CardContent = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "content");
+
+export const CardImage = withContext<HTMLImageElement, ImageProps>(Image, "image");

--- a/packages/primitives/src/Card/Card.tsx
+++ b/packages/primitives/src/Card/Card.tsx
@@ -32,9 +32,6 @@ const cardRecipe = sva({
       _hover: {
         background: "surface.actionSubtle.hover",
         borderColor: "stroke.hover",
-        "& h1, h2, h3, h4, h5, h6": {
-          textDecoration: "none",
-        },
       },
     },
     content: {
@@ -46,6 +43,9 @@ const cardRecipe = sva({
     },
     title: {
       textDecoration: "underline",
+      _hover: {
+        textDecoration: "none",
+      },
     },
     image: {
       height: "200px",

--- a/packages/primitives/src/index.ts
+++ b/packages/primitives/src/index.ts
@@ -33,6 +33,8 @@ export { BlockQuote } from "./BlockQuote";
 export type { ButtonProps, ButtonVariantProps, IconButtonProps, IconButtonVariantProps } from "./Button";
 export { Button, IconButton, buttonBaseRecipe, buttonRecipe, iconButtonRecipe } from "./Button";
 
+export { CardRoot, CardHeading, CardContent, CardImage } from "./Card/Card";
+
 export type { CheckboxVariantProps, CheckboxRootProps } from "./Checkbox";
 
 export {


### PR DESCRIPTION
Dette er grunnlaget for RelatedContent, søkeresultater, tverrfaglige caser og kansje `ProgrammeCard`. Har prøvd å gjøre den så stylable som overhodet mulig.