### PR TITLE
Rework createStyleContext to allow for using `asChild` and `consumeCss` on re-styled styled components created through `createStyleContext`

### DIFF
--- a/packages/primitives/src/Accordion.tsx
+++ b/packages/primitives/src/Accordion.tsx
@@ -98,21 +98,28 @@ const { withProvider, withContext } = createStyleContext(accordionRecipe);
 
 export interface AccordionRootProps extends JsxStyleProps, Accordion.RootProps {}
 
-export const AccordionRoot = withProvider<HTMLDivElement, AccordionRootProps>(Accordion.Root, "root");
+export const AccordionRoot = withProvider<HTMLDivElement, AccordionRootProps>(Accordion.Root, "root", {
+  baseComponent: true,
+});
 
 export const AccordionItemContent = withContext<HTMLDivElement, JsxStyleProps & Accordion.ItemContentProps>(
   Accordion.ItemContent,
   "itemContent",
+  { baseComponent: true },
 );
 
 export const AccordionItemIndicator = withContext<HTMLDivElement, JsxStyleProps & Accordion.ItemIndicatorProps>(
   Accordion.ItemIndicator,
   "itemIndicator",
+  { baseComponent: true },
 );
 
-export const AccordionItem = withContext<HTMLDivElement, JsxStyleProps & Accordion.ItemProps>(Accordion.Item, "item");
+export const AccordionItem = withContext<HTMLDivElement, JsxStyleProps & Accordion.ItemProps>(Accordion.Item, "item", {
+  baseComponent: true,
+});
 
 export const AccordionItemTrigger = withContext<HTMLButtonElement, JsxStyleProps & Accordion.ItemTriggerProps>(
   Accordion.ItemTrigger,
   "itemTrigger",
+  { baseComponent: true },
 );

--- a/packages/primitives/src/Card/Card.tsx
+++ b/packages/primitives/src/Card/Card.tsx
@@ -57,7 +57,9 @@ const cardRecipe = sva({
 
 const { withProvider, withContext } = createStyleContext(cardRecipe);
 
-export const CardRoot = withProvider<HTMLElement, HTMLArkProps<"article"> & JsxStyleProps>(ark.article, "root");
+export const CardRoot = withProvider<HTMLElement, HTMLArkProps<"article"> & JsxStyleProps>(ark.article, "root", {
+  baseComponent: true,
+});
 
 const InternalCardHeading = forwardRef<HTMLHeadingElement, TextProps>(
   ({ textStyle = "label.large", fontWeight = "bold", ...props }, ref) => (
@@ -70,6 +72,8 @@ export const CardHeading = withContext<HTMLHeadingElement, TextProps & HTMLArkPr
   "title",
 );
 
-export const CardContent = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "content");
+export const CardContent = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "content", {
+  baseComponent: true,
+});
 
 export const CardImage = withContext<HTMLImageElement, ImageProps>(Image, "image");

--- a/packages/primitives/src/Checkbox.tsx
+++ b/packages/primitives/src/Checkbox.tsx
@@ -213,11 +213,14 @@ export type CheckboxVariantProps = RecipeVariantProps<typeof checkboxRecipe>;
 
 export type CheckboxRootProps = Checkbox.RootProps & CheckboxVariantProps & JsxStyleProps;
 
-export const CheckboxRoot = withProvider<HTMLLabelElement, CheckboxRootProps>(Checkbox.Root, "root");
+export const CheckboxRoot = withProvider<HTMLLabelElement, CheckboxRootProps>(Checkbox.Root, "root", {
+  baseComponent: true,
+});
 
 export const CheckboxIndicator = withContext<HTMLDivElement, Checkbox.IndicatorProps & JsxStyleProps>(
   Checkbox.Indicator,
   "indicator",
+  { baseComponent: true },
 );
 
 const InternalCheckboxLabel = withContext<HTMLSpanElement, JsxStyleProps & Checkbox.LabelProps>(
@@ -238,8 +241,13 @@ export const CheckboxLabel = ({
 export const CheckboxControl = withContext<HTMLDivElement, JsxStyleProps & Checkbox.ControlProps>(
   Checkbox.Control,
   "control",
+  { baseComponent: true },
 );
 
-export const CheckboxGroup = withProvider<HTMLDivElement, JsxStyleProps & Checkbox.GroupProps>(Checkbox.Group, "group");
+export const CheckboxGroup = withProvider<HTMLDivElement, JsxStyleProps & Checkbox.GroupProps>(
+  Checkbox.Group,
+  "group",
+  { baseComponent: true },
+);
 
 export const CheckboxHiddenInput = Checkbox.HiddenInput;

--- a/packages/primitives/src/Combobox.tsx
+++ b/packages/primitives/src/Combobox.tsx
@@ -154,6 +154,7 @@ export type ComboboxRootProps<T extends Combobox.CollectionItem> = Combobox.Root
 const InternalComboboxRoot = withProvider<HTMLDivElement, ComboboxRootProps<Combobox.CollectionItem>>(
   Combobox.Root,
   "root",
+  { baseComponent: true },
 );
 
 export const ComboboxRoot = <T extends Combobox.CollectionItem>({ ...props }: ComboboxRootProps<T>) => {
@@ -168,19 +169,26 @@ export type ComboboxClearTriggerProps = Combobox.ClearTriggerProps & JsxStylePro
 export const ComboboxClearTrigger = withContext<HTMLButtonElement, ComboboxClearTriggerProps>(
   Combobox.ClearTrigger,
   "clearTrigger",
+  { baseComponent: true },
 );
 
 export type ComboboxContentProps = Combobox.ContentProps & JsxStyleProps;
 
-export const ComboboxContent = withContext<HTMLDivElement, ComboboxContentProps>(Combobox.Content, "content");
+export const ComboboxContent = withContext<HTMLDivElement, ComboboxContentProps>(Combobox.Content, "content", {
+  baseComponent: true,
+});
 
 export type ComboboxControlProps = Combobox.ControlProps & JsxStyleProps;
 
-export const ComboboxControl = withContext<HTMLDivElement, ComboboxControlProps>(Combobox.Control, "control");
+export const ComboboxControl = withContext<HTMLDivElement, ComboboxControlProps>(Combobox.Control, "control", {
+  baseComponent: true,
+});
 
 export type ComboboxInputProps = Combobox.InputProps & JsxStyleProps;
 
-export const ComboboxInput = withContext<HTMLInputElement, ComboboxInputProps>(Combobox.Input, "input");
+export const ComboboxInput = withContext<HTMLInputElement, ComboboxInputProps>(Combobox.Input, "input", {
+  baseComponent: true,
+});
 
 const InternalComboboxItemGroupLabel = withContext<HTMLDivElement, Assign<JsxStyleProps, Combobox.ItemGroupLabelProps>>(
   Combobox.ItemGroupLabel,
@@ -204,18 +212,23 @@ export const ComboboxItemGroupLabel = ({
 
 export type ComboboxItemGroupProps = Combobox.ItemGroupProps & JsxStyleProps;
 
-export const ComboboxItemGroup = withContext<HTMLDivElement, ComboboxItemGroupProps>(Combobox.ItemGroup, "itemGroup");
+export const ComboboxItemGroup = withContext<HTMLDivElement, ComboboxItemGroupProps>(Combobox.ItemGroup, "itemGroup", {
+  baseComponent: true,
+});
 
 export type ComboboxItemIndicatorProps = Combobox.ItemIndicatorProps & JsxStyleProps;
 
 export const ComboboxItemIndicator = withContext<HTMLDivElement, ComboboxItemIndicatorProps>(
   Combobox.ItemIndicator,
   "itemIndicator",
+  { baseComponent: true },
 );
 
 export type ComboboxItemProps = Combobox.ItemProps & JsxStyleProps;
 
-export const ComboboxItem = withContext<HTMLDivElement, ComboboxItemProps>(Combobox.Item, "item");
+export const ComboboxItem = withContext<HTMLDivElement, ComboboxItemProps>(Combobox.Item, "item", {
+  baseComponent: true,
+});
 
 const InternalComboboxItemText = withContext<HTMLDivElement, Assign<JsxStyleProps, Combobox.ItemTextProps>>(
   Combobox.ItemText,
@@ -255,8 +268,11 @@ export type ComboboxPositionerProps = Combobox.PositionerProps & JsxStyleProps;
 export const ComboboxPositioner = withContext<HTMLDivElement, ComboboxPositionerProps>(
   Combobox.Positioner,
   "positioner",
+  { baseComponent: true },
 );
 
 export type ComboboxTriggerProps = Combobox.TriggerProps & JsxStyleProps;
 
-export const ComboboxTrigger = withContext<HTMLButtonElement, ComboboxTriggerProps>(Combobox.Trigger, "trigger");
+export const ComboboxTrigger = withContext<HTMLButtonElement, ComboboxTriggerProps>(Combobox.Trigger, "trigger", {
+  baseComponent: true,
+});

--- a/packages/primitives/src/Dialog.tsx
+++ b/packages/primitives/src/Dialog.tsx
@@ -268,16 +268,19 @@ export const DialogRoot = ({ lazyMount = true, unmountOnExit = true, ...props }:
 export const DialogBackdrop = withContext<HTMLDivElement, JsxStyleProps & Dialog.BackdropProps>(
   Dialog.Backdrop,
   "backdrop",
+  { baseComponent: true },
 );
 
 export const DialogStandaloneContent = withContext<HTMLDivElement, JsxStyleProps & Dialog.ContentProps>(
   Dialog.Content,
   "content",
+  { baseComponent: true },
 );
 
 export const DialogPositioner = withContext<HTMLDivElement, JsxStyleProps & Dialog.PositionerProps>(
   Dialog.Positioner,
   "positioner",
+  { baseComponent: true },
 );
 
 export const DialogContent = forwardRef<HTMLDivElement, Dialog.ContentProps & JsxStyleProps>((props, ref) => (

--- a/packages/primitives/src/Menu.tsx
+++ b/packages/primitives/src/Menu.tsx
@@ -138,7 +138,9 @@ export const MenuRoot = ({ lazyMount = true, unmountOnExit = true, ...props }: M
   <InternalMenuRoot lazyMount={lazyMount} unmountOnExit={unmountOnExit} {...props} />
 );
 
-export const MenuContent = withContext<HTMLDivElement, JsxStyleProps & Menu.ContentProps>(Menu.Content, "content");
+export const MenuContent = withContext<HTMLDivElement, JsxStyleProps & Menu.ContentProps>(Menu.Content, "content", {
+  baseComponent: true,
+});
 
 const InternalMenuItemGroupLabel = withContext<HTMLDivElement, JsxStyleProps & Menu.ItemGroupLabelProps>(
   Menu.ItemGroupLabel,
@@ -161,9 +163,12 @@ export const MenuItemGroupLabel = ({
 export const MenuItemGroup = withContext<HTMLDivElement, JsxStyleProps & Menu.ItemGroupProps>(
   Menu.ItemGroup,
   "itemGroup",
+  { baseComponent: true },
 );
 
-const InternalMenuItem = withContext<HTMLDivElement, JsxStyleProps & Menu.ItemProps>(Menu.Item, "item");
+const InternalMenuItem = withContext<HTMLDivElement, JsxStyleProps & Menu.ItemProps>(Menu.Item, "item", {
+  baseComponent: true,
+});
 
 export type MenuItemVariantProps = RecipeVariantProps<typeof itemCva>;
 export type MenuItemProps = Menu.ItemProps & JsxStyleProps & MenuItemVariantProps;
@@ -179,11 +184,13 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(({ css: cssPro
 export const MenuPositioner = withContext<HTMLDivElement, JsxStyleProps & Menu.PositionerProps>(
   Menu.Positioner,
   "positioner",
+  { baseComponent: true },
 );
 
 const InternalMenuTriggerItem = withContext<HTMLDivElement, JsxStyleProps & Menu.TriggerItemProps>(
   Menu.TriggerItem,
   "triggerItem",
+  { baseComponent: true },
 );
 
 export const MenuTriggerItem = forwardRef<HTMLDivElement, Menu.TriggerItemProps & JsxStyleProps & MenuItemVariantProps>(
@@ -196,9 +203,12 @@ export const MenuTriggerItem = forwardRef<HTMLDivElement, Menu.TriggerItemProps 
   ),
 );
 
-export const MenuTrigger = withContext<HTMLDivElement, JsxStyleProps & Menu.TriggerProps>(Menu.Trigger, "trigger");
+export const MenuTrigger = withContext<HTMLDivElement, JsxStyleProps & Menu.TriggerProps>(Menu.Trigger, "trigger", {
+  baseComponent: true,
+});
 
 export const MenuSeparator = withContext<HTMLHRElement, JsxStyleProps & Menu.SeparatorProps>(
   Menu.Separator,
   "separator",
+  { baseComponent: true },
 );

--- a/packages/primitives/src/Pagination.tsx
+++ b/packages/primitives/src/Pagination.tsx
@@ -32,24 +32,30 @@ const { withProvider, withContext } = createStyleContext(paginationRecipe);
 
 export type PaginationRootProps = JsxStyleProps & Pagination.RootProps;
 
-export const PaginationRoot = withProvider<HTMLElement, PaginationRootProps>(Pagination.Root, "root");
+export const PaginationRoot = withProvider<HTMLElement, PaginationRootProps>(Pagination.Root, "root", {
+  baseComponent: true,
+});
 
 export const PaginationItem = withContext<HTMLButtonElement, JsxStyleProps & Pagination.ItemProps>(
   Pagination.Item,
   "item",
+  { baseComponent: true },
 );
 
 export const PaginationEllipsis = withContext<HTMLDivElement, JsxStyleProps & Pagination.EllipsisProps>(
   Pagination.Ellipsis,
   "ellipsis",
+  { baseComponent: true },
 );
 
 export const PaginationPrevTrigger = withContext<HTMLButtonElement, JsxStyleProps & Pagination.PrevTriggerProps>(
   Pagination.PrevTrigger,
   "prevTrigger",
+  { baseComponent: true },
 );
 
 export const PaginationNextTrigger = withContext<HTMLButtonElement, JsxStyleProps & Pagination.NextTriggerProps>(
   Pagination.NextTrigger,
   "nextTrigger",
+  { baseComponent: true },
 );

--- a/packages/primitives/src/Popover.tsx
+++ b/packages/primitives/src/Popover.tsx
@@ -49,11 +49,16 @@ export const PopoverRoot = ({ lazyMount = true, unmountOnExit = true, ...props }
   <InternalPopoverRoot lazyMount={lazyMount} unmountOnExit={unmountOnExit} {...props} />
 );
 
-export const PopoverAnchor = withContext<HTMLDivElement, Popover.AnchorProps & JsxStyleProps>(Popover.Anchor, "anchor");
+export const PopoverAnchor = withContext<HTMLDivElement, Popover.AnchorProps & JsxStyleProps>(
+  Popover.Anchor,
+  "anchor",
+  { baseComponent: true },
+);
 
 export const PopoverArrowStandalone = withContext<HTMLDivElement, Popover.ArrowProps & JsxStyleProps>(
   Popover.Arrow,
   "arrow",
+  { baseComponent: true },
 );
 
 export const PopoverArrow = (props: Popover.ArrowTipProps & JsxStyleProps) => (
@@ -65,16 +70,19 @@ export const PopoverArrow = (props: Popover.ArrowTipProps & JsxStyleProps) => (
 export const PopoverArrowTip = withContext<HTMLDivElement, Popover.ArrowTipProps & JsxStyleProps>(
   Popover.ArrowTip,
   "arrowTip",
+  { baseComponent: true },
 );
 
 export const PopoverCloseTrigger = withContext<HTMLButtonElement, Popover.CloseTriggerProps & JsxStyleProps>(
   Popover.CloseTrigger,
   "closeTrigger",
+  { baseComponent: true },
 );
 
 export const PopoverContentStandalone = withContext<HTMLDivElement, Popover.ContentProps & JsxStyleProps>(
   Popover.Content,
   "content",
+  { baseComponent: true },
 );
 
 export const PopoverContent = (props: Popover.ContentProps & JsxStyleProps) => (
@@ -86,21 +94,27 @@ export const PopoverContent = (props: Popover.ContentProps & JsxStyleProps) => (
 export const PopoverDescription = withContext<HTMLParagraphElement, Popover.DescriptionProps & JsxStyleProps>(
   Popover.Description,
   "description",
+  { baseComponent: true },
 );
 
 export const PopoverIndicator = withContext<HTMLDivElement, Popover.IndicatorProps & JsxStyleProps>(
   Popover.Indicator,
   "indicator",
+  { baseComponent: true },
 );
 
 export const PopoverPositioner = withContext<HTMLDivElement, Popover.PositionerProps & JsxStyleProps>(
   Popover.Positioner,
   "positioner",
+  { baseComponent: true },
 );
 
-export const PopoverTitle = withContext<HTMLDivElement, Popover.TitleProps & JsxStyleProps>(Popover.Title, "title");
+export const PopoverTitle = withContext<HTMLDivElement, Popover.TitleProps & JsxStyleProps>(Popover.Title, "title", {
+  baseComponent: true,
+});
 
 export const PopoverTrigger = withContext<HTMLButtonElement, Popover.TriggerProps & JsxStyleProps>(
   Popover.Trigger,
   "trigger",
+  { baseComponent: true },
 );

--- a/packages/primitives/src/RadioGroup.tsx
+++ b/packages/primitives/src/RadioGroup.tsx
@@ -92,21 +92,26 @@ const { withProvider, withContext } = createStyleContext(radioGroupRecipe);
 
 export interface RadioGroupRootProps extends RadioGroup.RootProps, JsxStyleProps {}
 
-export const RadioGroupRoot = withProvider<HTMLDivElement, RadioGroupRootProps>(RadioGroup.Root, "root");
+export const RadioGroupRoot = withProvider<HTMLDivElement, RadioGroupRootProps>(RadioGroup.Root, "root", {
+  baseComponent: true,
+});
 
 export const RadioGroupIndicator = withContext<HTMLDivElement, RadioGroup.IndicatorProps & JsxStyleProps>(
   RadioGroup.Indicator,
   "indicator",
+  { baseComponent: true },
 );
 
 export const RadioGroupItemControl = withContext<HTMLDivElement, RadioGroup.ItemControlProps & JsxStyleProps>(
   RadioGroup.ItemControl,
   "itemControl",
+  { baseComponent: true },
 );
 
 export const RadioGroupItem = withContext<HTMLLabelElement, RadioGroup.ItemProps & JsxStyleProps>(
   RadioGroup.Item,
   "item",
+  { baseComponent: true },
 );
 
 const InternalRadioGroupItemText = withContext<HTMLSpanElement, RadioGroup.ItemTextProps & JsxStyleProps>(

--- a/packages/primitives/src/Select.tsx
+++ b/packages/primitives/src/Select.tsx
@@ -134,7 +134,9 @@ const selectRecipe = sva({
 const { withProvider, withContext } = createStyleContext(selectRecipe);
 
 export type SelectRootProps<T extends Select.CollectionItem> = Select.RootProps<T> & JsxStyleProps;
-const InternalSelectRoot = withProvider<HTMLDivElement, SelectRootProps<Select.CollectionItem>>(Select.Root, "root");
+const InternalSelectRoot = withProvider<HTMLDivElement, SelectRootProps<Select.CollectionItem>>(Select.Root, "root", {
+  baseComponent: true,
+});
 
 export const SelectRoot = <T extends Select.CollectionItem>({
   lazyMount = true,
@@ -148,21 +150,25 @@ export const SelectRoot = <T extends Select.CollectionItem>({
 export const SelectClearTrigger = withContext<HTMLButtonElement, Select.ClearTriggerProps & JsxStyleProps>(
   Select.ClearTrigger,
   "clearTrigger",
+  { baseComponent: true },
 );
 
 export const SelectContent = withContext<HTMLDivElement, Select.ContentProps & JsxStyleProps>(
   Select.Content,
   "content",
+  { baseComponent: true },
 );
 
 export const SelectControl = withContext<HTMLDivElement, Select.ControlProps & JsxStyleProps>(
   Select.Control,
   "control",
+  { baseComponent: true },
 );
 
 export const SelectIndicator = withContext<HTMLDivElement, Select.IndicatorProps & JsxStyleProps>(
   Select.Indicator,
   "indicator",
+  { baseComponent: true },
 );
 
 export const SelectItemGroupLabel = forwardRef<HTMLDivElement, Select.ItemGroupLabelProps & JsxStyleProps & TextProps>(
@@ -183,18 +189,23 @@ const InternalSelectItemGroupLabel = withContext<HTMLDivElement, Select.ItemGrou
 export const SelectItemGroup = withContext<HTMLDivElement, Select.ItemGroupProps & JsxStyleProps>(
   Select.ItemGroup,
   "itemGroup",
+  { baseComponent: true },
 );
 
 export const SelectItemIndicator = withContext<HTMLDivElement, Select.ItemIndicatorProps & JsxStyleProps>(
   Select.ItemIndicator,
   "itemIndicator",
+  { baseComponent: true },
 );
 
-export const SelectItem = withContext<HTMLDivElement, Select.ItemProps & JsxStyleProps>(Select.Item, "item");
+export const SelectItem = withContext<HTMLDivElement, Select.ItemProps & JsxStyleProps>(Select.Item, "item", {
+  baseComponent: true,
+});
 
 export const SelectItemText = withContext<HTMLDivElement, Select.ItemTextProps & JsxStyleProps>(
   Select.ItemText,
   "itemText",
+  { baseComponent: true },
 );
 
 const InternalSelectLabel = withContext<HTMLLabelElement, Select.LabelProps & JsxStyleProps>(Select.Label, "label");
@@ -210,14 +221,17 @@ export const SelectLabel = forwardRef<HTMLLabelElement, Select.LabelProps & JsxS
 export const SelectPositioner = withContext<HTMLDivElement, Select.PositionerProps & JsxStyleProps>(
   Select.Positioner,
   "positioner",
+  { baseComponent: true },
 );
 
 export const SelectTrigger = withContext<HTMLButtonElement, Select.TriggerProps & JsxStyleProps>(
   Select.Trigger,
   "trigger",
+  { baseComponent: true },
 );
 
 export const SelectValueText = withContext<HTMLSpanElement, Select.ValueTextProps & JsxStyleProps>(
   Select.ValueText,
   "valueText",
+  { baseComponent: true },
 );

--- a/packages/primitives/src/Slider.tsx
+++ b/packages/primitives/src/Slider.tsx
@@ -82,18 +82,25 @@ const { withProvider, withContext } = createStyleContext(sliderRecipe);
 
 export type SliderRootProps = Slider.RootProps & JsxStyleProps;
 
-export const SliderRoot = withProvider<HTMLDivElement, SliderRootProps>(Slider.Root, "root");
+export const SliderRoot = withProvider<HTMLDivElement, SliderRootProps>(Slider.Root, "root", { baseComponent: true });
 
 export const SliderControl = withContext<HTMLDivElement, JsxStyleProps & Slider.ControlProps>(
   Slider.Control,
   "control",
+  { baseComponent: true },
 );
 
-export const SliderTrack = withContext<HTMLDivElement, JsxStyleProps & Slider.TrackProps>(Slider.Track, "track");
+export const SliderTrack = withContext<HTMLDivElement, JsxStyleProps & Slider.TrackProps>(Slider.Track, "track", {
+  baseComponent: true,
+});
 
-export const SliderRange = withContext<HTMLDivElement, JsxStyleProps & Slider.RangeProps>(Slider.Range, "range");
+export const SliderRange = withContext<HTMLDivElement, JsxStyleProps & Slider.RangeProps>(Slider.Range, "range", {
+  baseComponent: true,
+});
 
-export const SliderThumb = withContext<HTMLDivElement, JsxStyleProps & Slider.ThumbProps>(Slider.Thumb, "thumb");
+export const SliderThumb = withContext<HTMLDivElement, JsxStyleProps & Slider.ThumbProps>(Slider.Thumb, "thumb", {
+  baseComponent: true,
+});
 
 const InternalSliderLabel = withContext<HTMLDivElement, JsxStyleProps & Slider.LabelProps>(Slider.Label, "label");
 

--- a/packages/primitives/src/Switch.tsx
+++ b/packages/primitives/src/Switch.tsx
@@ -101,14 +101,17 @@ export type SwitchVariantProps = RecipeVariantProps<typeof switchRecipe>;
 
 export type SwitchRootProps = Switch.RootProps & JsxStyleProps & SwitchVariantProps;
 
-export const SwitchRoot = withProvider<HTMLLabelElement, SwitchRootProps>(Switch.Root, "root");
+export const SwitchRoot = withProvider<HTMLLabelElement, SwitchRootProps>(Switch.Root, "root", { baseComponent: true });
 
 export const SwitchControl = withContext<HTMLSpanElement, JsxStyleProps & Switch.ControlProps>(
   Switch.Control,
   "control",
+  { baseComponent: true },
 );
 
-export const SwitchThumb = withContext<HTMLSpanElement, JsxStyleProps & Switch.ThumbProps>(Switch.Thumb, "thumb");
+export const SwitchThumb = withContext<HTMLSpanElement, JsxStyleProps & Switch.ThumbProps>(Switch.Thumb, "thumb", {
+  baseComponent: true,
+});
 
 const InternalSwitchLabel = withContext<HTMLSpanElement, JsxStyleProps & Switch.LabelProps>(Switch.Label, "label");
 

--- a/packages/primitives/src/Tabs.tsx
+++ b/packages/primitives/src/Tabs.tsx
@@ -205,22 +205,29 @@ export type TabsVariantProps = RecipeVariantProps<typeof tabsRecipe>;
 
 export type TabsRootProps = Tabs.RootProps & TabsVariantProps & JsxStyleProps;
 
-const InternalTabsRoot = withProvider<HTMLDivElement, TabsRootProps>(Tabs.Root, "root");
+const InternalTabsRoot = withProvider<HTMLDivElement, TabsRootProps>(Tabs.Root, "root", { baseComponent: true });
 
 export const TabsRoot = ({ lazyMount = true, unmountOnExit = true, ...props }: TabsRootProps) => (
   <InternalTabsRoot lazyMount={lazyMount} unmountOnExit={unmountOnExit} {...props} />
 );
 
-export const TabsContent = withContext<HTMLDivElement, Tabs.ContentProps & JsxStyleProps>(Tabs.Content, "content");
+export const TabsContent = withContext<HTMLDivElement, Tabs.ContentProps & JsxStyleProps>(Tabs.Content, "content", {
+  baseComponent: true,
+});
 
 export const TabsIndicator = withContext<HTMLDivElement, Tabs.IndicatorProps & JsxStyleProps>(
   Tabs.Indicator,
   "indicator",
+  { baseComponent: true },
 );
 
-export const TabsList = withContext<HTMLDivElement, Tabs.ListProps & JsxStyleProps>(Tabs.List, "list");
+export const TabsList = withContext<HTMLDivElement, Tabs.ListProps & JsxStyleProps>(Tabs.List, "list", {
+  baseComponent: true,
+});
 
-const InternalTabsTrigger = withContext<HTMLButtonElement, Tabs.TriggerProps & JsxStyleProps>(Tabs.Trigger, "trigger");
+const InternalTabsTrigger = withContext<HTMLButtonElement, Tabs.TriggerProps & JsxStyleProps>(Tabs.Trigger, "trigger", {
+  baseComponent: true,
+});
 
 export const TabsTrigger = ({ className, ...props }: Tabs.TriggerProps & JsxStyleProps) => (
   <InternalTabsTrigger className={cx("peer", className)} {...props} />

--- a/packages/primitives/src/TagsInput.tsx
+++ b/packages/primitives/src/TagsInput.tsx
@@ -95,28 +95,36 @@ const tagsInputRecipe = sva({
 const { withProvider, withContext } = createStyleContext(tagsInputRecipe);
 
 export type TagsInputRootProps = TagsInput.RootProps & JsxStyleProps;
-export const TagsInputRoot = withProvider<HTMLDivElement, TagsInputRootProps>(TagsInput.Root, "root");
+export const TagsInputRoot = withProvider<HTMLDivElement, TagsInputRootProps>(TagsInput.Root, "root", {
+  baseComponent: true,
+});
 
 export type TagsInputClearTriggerProps = TagsInput.ClearTriggerProps & JsxStyleProps;
 
 export const TagsInputClearTrigger = withContext<HTMLButtonElement, TagsInputClearTriggerProps>(
   TagsInput.ClearTrigger,
   "clearTrigger",
+  { baseComponent: true },
 );
 
 export type TagsInputControlProps = TagsInput.ControlProps & JsxStyleProps;
 
-export const TagsInputControl = withContext<HTMLDivElement, TagsInputControlProps>(TagsInput.Control, "control");
+export const TagsInputControl = withContext<HTMLDivElement, TagsInputControlProps>(TagsInput.Control, "control", {
+  baseComponent: true,
+});
 
 export type TagsInputInputProps = TagsInput.InputProps & JsxStyleProps;
 
-export const TagsInputInput = withContext<HTMLInputElement, TagsInputInputProps>(TagsInput.Input, "input");
+export const TagsInputInput = withContext<HTMLInputElement, TagsInputInputProps>(TagsInput.Input, "input", {
+  baseComponent: true,
+});
 
 export type TagsInputItemDeleteTriggerProps = TagsInput.ItemDeleteTriggerProps & JsxStyleProps;
 
 export const TagsInputItemDeleteTrigger = withContext<HTMLButtonElement, TagsInputItemDeleteTriggerProps>(
   TagsInput.ItemDeleteTrigger,
   "itemDeleteTrigger",
+  { baseComponent: true },
 );
 
 export type TagsInputItemInputProps = TagsInput.ItemInputProps & JsxStyleProps;
@@ -124,6 +132,7 @@ export type TagsInputItemInputProps = TagsInput.ItemInputProps & JsxStyleProps;
 export const TagsInputItemInput = withContext<HTMLInputElement, TagsInputItemInputProps>(
   TagsInput.ItemInput,
   "itemInput",
+  { baseComponent: true },
 );
 
 export type TagsInputItemPreviewProps = TagsInput.ItemPreviewProps & JsxStyleProps;
@@ -131,15 +140,20 @@ export type TagsInputItemPreviewProps = TagsInput.ItemPreviewProps & JsxStylePro
 export const TagsInputItemPreview = withContext<HTMLDivElement, TagsInputItemPreviewProps>(
   TagsInput.ItemPreview,
   "itemPreview",
+  { baseComponent: true },
 );
 
 export type TagsInputItemProps = TagsInput.ItemProps & JsxStyleProps;
 
-export const TagsInputItem = withContext<HTMLDivElement, TagsInputItemProps>(TagsInput.Item, "item");
+export const TagsInputItem = withContext<HTMLDivElement, TagsInputItemProps>(TagsInput.Item, "item", {
+  baseComponent: true,
+});
 
 export type TagsInputItemTextProps = TagsInput.ItemTextProps & JsxStyleProps;
 
-export const TagsInputItemText = withContext<HTMLSpanElement, TagsInputItemTextProps>(TagsInput.ItemText, "itemText");
+export const TagsInputItemText = withContext<HTMLSpanElement, TagsInputItemTextProps>(TagsInput.ItemText, "itemText", {
+  baseComponent: true,
+});
 
 const InternalTagsInputLabel = withContext<HTMLLabelElement, TagsInput.LabelProps & JsxStyleProps>(
   TagsInput.Label,

--- a/packages/primitives/src/Toast.tsx
+++ b/packages/primitives/src/Toast.tsx
@@ -45,16 +45,18 @@ const toastRecipe = sva({
 const { withProvider, withContext } = createStyleContext(toastRecipe);
 
 export interface ToastRootProps extends Toast.RootProps, JsxStyleProps {}
-export const ToastRoot = withProvider<HTMLDivElement, ToastRootProps>(Toast.Root, "root");
+export const ToastRoot = withProvider<HTMLDivElement, ToastRootProps>(Toast.Root, "root", { baseComponent: true });
 
 export const ToastActionTrigger = withContext<HTMLButtonElement, JsxStyleProps & Toast.ActionTriggerProps>(
   Toast.ActionTrigger,
   "actionTrigger",
+  { baseComponent: true },
 );
 
 export const ToastCloseTrigger = withContext<HTMLDivElement, JsxStyleProps & Toast.CloseTriggerProps>(
   Toast.CloseTrigger,
   "closeTrigger",
+  { baseComponent: true },
 );
 
 const InternalToastDescription = withContext<HTMLDivElement, JsxStyleProps & Toast.DescriptionProps>(

--- a/packages/primitives/src/Tooltip.tsx
+++ b/packages/primitives/src/Tooltip.tsx
@@ -38,16 +38,20 @@ const { withRootProvider, withContext } = createStyleContext(tooltipRecipe);
 export type TooltipRootProps = Tooltip.RootProps;
 export const TooltipRoot = withRootProvider<TooltipRootProps>(Tooltip.Root);
 
-export const TooltipArrow = withContext<HTMLDivElement, JsxStyleProps & Tooltip.ArrowProps>(Tooltip.Arrow, "arrow");
+export const TooltipArrow = withContext<HTMLDivElement, JsxStyleProps & Tooltip.ArrowProps>(Tooltip.Arrow, "arrow", {
+  baseComponent: true,
+});
 
 export const TooltipArrowTip = withContext<HTMLDivElement, JsxStyleProps & Tooltip.ArrowTipProps>(
   Tooltip.ArrowTip,
   "arrowTip",
+  { baseComponent: true },
 );
 
 export const TooltipContentStandalone = withContext<HTMLDivElement, JsxStyleProps & Tooltip.ContentProps>(
   Tooltip.Content,
   "content",
+  { baseComponent: true },
 );
 
 export const TooltipContent = forwardRef<HTMLDivElement, JsxStyleProps & Tooltip.ContentProps>(
@@ -66,9 +70,11 @@ export const TooltipContent = forwardRef<HTMLDivElement, JsxStyleProps & Tooltip
 export const TooltipPositioner = withContext<HTMLDivElement, JsxStyleProps & Tooltip.PositionerProps>(
   Tooltip.Positioner,
   "positioner",
+  { baseComponent: true },
 );
 
 export const TooltipTrigger = withContext<HTMLButtonElement, JsxStyleProps & Tooltip.TriggerProps>(
   Tooltip.Trigger,
   "trigger",
+  { baseComponent: true },
 );

--- a/packages/primitives/src/__tests__/createStyleContext-test.tsx
+++ b/packages/primitives/src/__tests__/createStyleContext-test.tsx
@@ -6,10 +6,10 @@
  *
  */
 
-import React, { ComponentPropsWithRef, ReactNode } from "react";
+import React, { ComponentPropsWithRef, ReactNode, forwardRef } from "react";
 import { HTMLArkProps, ark } from "@ark-ui/react";
 import { render } from "@testing-library/react";
-import { sva } from "@ndla/styled-system/css";
+import { css, sva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
 import { JsxStyleProps } from "@ndla/styled-system/types";
 import { createStyleContext } from "../createStyleContext";
@@ -49,8 +49,8 @@ describe("createStyleContext", () => {
 
     const RootProviderRoot = withRootProvider<MockContextProps>(MockContext);
 
-    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div">>(ark.div, "root");
-    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div">>(ark.div, "root");
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div">>(ark.div, "root", { baseComponent: true });
+    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div">>(ark.div, "root", { baseComponent: true });
 
     const rootProviderResult = render(
       <RootProviderRoot>
@@ -115,8 +115,12 @@ describe("createStyleContext", () => {
 
     const RootProviderRoot = withRootProvider<MockContextProps>(MockContext);
 
-    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
-    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root", {
+      baseComponent: true,
+    });
+    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root", {
+      baseComponent: true,
+    });
 
     const rootProviderResult = render(
       <RootProviderRoot>
@@ -146,7 +150,9 @@ describe("createStyleContext", () => {
   test("should have no problems merging a react component and a string component", () => {
     const { withProvider, withContext } = createStyleContext(svaA);
 
-    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root", {
+      baseComponent: true,
+    });
     const ContextRoot = withContext<HTMLDivElement, ComponentPropsWithRef<"div"> & JsxStyleProps>("div", "child");
 
     const contextResult = render(
@@ -169,7 +175,9 @@ describe("createStyleContext", () => {
   test("should not automatically forward css prop regardless of whether you pass in a component or a string", () => {
     const { withProvider, withContext } = createStyleContext(svaA);
 
-    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root", {
+      baseComponent: true,
+    });
     const ContextRoot = withContext<HTMLDivElement, ComponentPropsWithRef<"div"> & JsxStyleProps>("div", "root");
 
     const providerResult = render(
@@ -198,8 +206,12 @@ describe("createStyleContext", () => {
 
     const RootProviderRoot = withRootProvider<MockContextProps>(MockContext);
 
-    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
-    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root", {
+      baseComponent: true,
+    });
+    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root", {
+      baseComponent: true,
+    });
 
     const StyledProviderRoot = styled(ProviderRoot, {
       base: {
@@ -242,8 +254,12 @@ describe("createStyleContext", () => {
 
     const RootProviderRoot = withRootProvider<MockContextProps>(MockContext);
 
-    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
-    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root", {
+      baseComponent: true,
+    });
+    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root", {
+      baseComponent: true,
+    });
 
     const Parent = styled(
       ark.div,
@@ -293,8 +309,12 @@ describe("createStyleContext", () => {
 
     const RootProviderRoot = withRootProvider<MockContextProps>(MockContext);
 
-    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
-    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root", {
+      baseComponent: true,
+    });
+    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root", {
+      baseComponent: true,
+    });
 
     const Child = styled("div", {
       base: {
@@ -340,15 +360,23 @@ describe("createStyleContext", () => {
 
     const ARootProviderRoot = styledA.withRootProvider<MockContextProps>(MockContext);
 
-    const AProviderRoot = styledA.withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
-    const AContextRoot = styledA.withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const AProviderRoot = styledA.withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root", {
+      baseComponent: true,
+    });
+    const AContextRoot = styledA.withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root", {
+      baseComponent: true,
+    });
 
     const styledB = createStyleContext(svaB);
 
     const BRootProviderRoot = styledB.withRootProvider<MockContextProps>(MockContext);
 
-    const BProviderRoot = styledB.withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
-    const BContextRoot = styledB.withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const BProviderRoot = styledB.withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root", {
+      baseComponent: true,
+    });
+    const BContextRoot = styledB.withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root", {
+      baseComponent: true,
+    });
 
     const rootProviderResult = render(
       <ARootProviderRoot>
@@ -392,8 +420,12 @@ describe("createStyleContext", () => {
 
     const RootProviderRoot = withRootProvider<MockContextProps>(MockContext);
 
-    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
-    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root");
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root", {
+      baseComponent: true,
+    });
+    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(ark.div, "root", {
+      baseComponent: true,
+    });
 
     const rootProviderResult = render(
       <RootProviderRoot>
@@ -418,5 +450,53 @@ describe("createStyleContext", () => {
 
     expect(rootProviderResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
     expect(providerResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+  });
+  test("correctly consumes css when merging a complex styled component onto a primitive", () => {
+    const TextComponent = styled(ark.p, {}, { baseComponent: true });
+
+    const Text = forwardRef<HTMLParagraphElement, HTMLArkProps<"p"> & JsxStyleProps>(
+      ({ css: cssProp, ...rest }, ref) => {
+        return <TextComponent css={css.raw({ display: "block" }, cssProp)} ref={ref} {...rest} />;
+      },
+    );
+
+    const { withProvider, withContext, withRootProvider } = createStyleContext(svaA);
+
+    const RootProviderRoot = withRootProvider<MockContextProps>(MockContext);
+
+    const ProviderRoot = withProvider<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(Text, "root");
+    const ContextRoot = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(Text, "root");
+
+    const rootProviderResult = render(
+      <RootProviderRoot>
+        <ContextRoot asChild consumeCss>
+          <span>Hello</span>
+        </ContextRoot>
+      </RootProviderRoot>,
+    );
+    const providerResult = render(
+      <ProviderRoot asChild consumeCss>
+        <span>Hello</span>
+      </ProviderRoot>,
+    );
+    const contextResult = render(
+      <ProviderRoot>
+        <ContextRoot asChild consumeCss>
+          <span>Hello</span>
+        </ContextRoot>
+      </ProviderRoot>,
+    );
+
+    const inlineSnapshot = `
+      <span
+        class="d_flex"
+      >
+        Hello
+      </span>
+    `;
+
+    expect(rootProviderResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(providerResult.container.firstChild).toMatchInlineSnapshot(inlineSnapshot);
+    expect(contextResult.container.firstChild?.firstChild).toMatchInlineSnapshot(inlineSnapshot);
   });
 });

--- a/packages/primitives/src/createStyleContext.tsx
+++ b/packages/primitives/src/createStyleContext.tsx
@@ -36,6 +36,10 @@ interface BaseStyleContextProps {
   consumeCss?: boolean;
 }
 
+interface CreateStyleContextOptions {
+  baseComponent?: boolean;
+}
+
 export const createStyleContext = <R extends Recipe>(recipe: R) => {
   const StyleContext = createContext<Record<Slot<R>, SystemStyleObject> | null>(null);
 
@@ -56,9 +60,9 @@ export const createStyleContext = <R extends Recipe>(recipe: R) => {
   const withProvider = <T, P extends BaseStyleContextProps & WithCss>(
     Component: ElementType,
     slot: Slot<R>,
+    options?: CreateStyleContextOptions,
   ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> => {
-    const opts = typeof Component === "string" ? undefined : { baseComponent: true };
-    const StyledComponent = styled(Component, {}, opts) as StyledComponent<ElementType, {}>;
+    const StyledComponent = styled(Component, {}, options) as StyledComponent<ElementType, {}>;
     return forwardRef<T, P>(({ css: cssProp, ...props }, ref) => {
       const [variantProps, otherProps] = recipe.splitVariantProps(props);
 
@@ -75,9 +79,9 @@ export const createStyleContext = <R extends Recipe>(recipe: R) => {
   const withContext = <T, P extends BaseStyleContextProps & WithCss>(
     Component: ElementType,
     slot: Slot<R>,
+    options?: CreateStyleContextOptions,
   ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> => {
-    const opts = typeof Component === "string" ? undefined : { baseComponent: true };
-    const StyledComponent = styled(Component, {}, opts) as StyledComponent<ElementType, {}>;
+    const StyledComponent = styled(Component, {}, options) as StyledComponent<ElementType, {}>;
     return forwardRef<T, P>(({ css: cssProp, ...props }, ref) => {
       const slotStyles = useContext(StyleContext);
       return <StyledComponent {...props} ref={ref} css={css.raw(slotStyles?.[slot], cssProp)} />;


### PR DESCRIPTION
Irriterende case, men må håndteres. Nå er oppførselen mer eller mindre klin lik som den er i vanlig `styled`. Tommelfingerregelen er også lik: Hvis man bruker en av våre komponenter eller en string-primitive i `withContext` eller i `withProvider` trenger man ikke sende med `{ baseComponent: true }`.