### PR TITLE
Temporarily convert layout components to use panda with old styling

### DIFF
--- a/packages/ndla-ui/src/Layout/LayoutItem.tsx
+++ b/packages/ndla-ui/src/Layout/LayoutItem.tsx
@@ -6,14 +6,13 @@
  *
  */
 
-import { forwardRef } from "react";
-import { ark, type HTMLArkProps } from "@ark-ui/react";
-import { RecipeVariantProps, css, cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
-import { JsxStyleProps } from "@ndla/styled-system/types";
 
 // TODO: Refactor this. This is a copy of our old layout.
-const layoutRecipe = cva({
+export const LayoutItem = styled("section", {
+  defaultVariants: {
+    layout: "center",
+  },
   variants: {
     layout: {
       center: {
@@ -33,15 +32,5 @@ const layoutRecipe = cva({
     },
   },
 });
-
-type LayoutVariantProps = RecipeVariantProps<typeof layoutRecipe>;
-
-const StyledLayout = styled(ark.section, {}, { baseComponent: true });
-
-export const LayoutItem = forwardRef<HTMLElement, HTMLArkProps<"section"> & JsxStyleProps & LayoutVariantProps>(
-  ({ layout, css: cssProp, ...props }, ref) => {
-    return <StyledLayout css={css.raw(layoutRecipe.raw({ layout }), cssProp)} {...props} ref={ref} />;
-  },
-);
 
 export default LayoutItem;

--- a/packages/ndla-ui/src/Layout/LayoutItem.tsx
+++ b/packages/ndla-ui/src/Layout/LayoutItem.tsx
@@ -6,47 +6,42 @@
  *
  */
 
-/** @jsxImportSource @emotion/react */
-import { HTMLAttributes, ReactNode, useMemo } from "react";
-import { css } from "@emotion/react";
-import { mq, breakpoints } from "@ndla/core";
+import { forwardRef } from "react";
+import { ark, type HTMLArkProps } from "@ark-ui/react";
+import { RecipeVariantProps, css, cva } from "@ndla/styled-system/css";
+import { styled } from "@ndla/styled-system/jsx";
+import { JsxStyleProps } from "@ndla/styled-system/types";
 
-interface Props extends HTMLAttributes<HTMLElement> {
-  children?: ReactNode;
-  layout?: "extend" | "center";
-}
+// TODO: Refactor this. This is a copy of our old layout.
+const layoutRecipe = cva({
+  variants: {
+    layout: {
+      center: {
+        position: "relative!",
+        width: "83.333%",
+        right: "auto !important",
+        left: "8.333%",
+      },
+      extend: {
+        tablet: {
+          position: "relative!",
+          width: "83.333%",
+          right: "auto!",
+          left: "8.333%",
+        },
+      },
+    },
+  },
+});
 
-const centerCss = css`
-  position: relative !important;
-  width: 83.333%;
-  right: auto !important;
-  left: 8.333%;
-`;
+type LayoutVariantProps = RecipeVariantProps<typeof layoutRecipe>;
 
-const extendCss = css`
-  ${mq.range({ from: breakpoints.tablet })} {
-    position: relative !important;
-    width: 83.333%;
-    right: auto !important;
-    left: 8.333%;
-  }
-`;
+const StyledLayout = styled(ark.section, {}, { baseComponent: true });
 
-export const LayoutItem = ({ children, layout, ...rest }: Props) => {
-  const style = useMemo(() => {
-    if (layout === "extend") {
-      return extendCss;
-    } else if (layout === "center") {
-      return centerCss;
-    }
-    return undefined;
-  }, [layout]);
-
-  return (
-    <section css={style} {...rest}>
-      {children}
-    </section>
-  );
-};
+export const LayoutItem = forwardRef<HTMLElement, HTMLArkProps<"section"> & JsxStyleProps & LayoutVariantProps>(
+  ({ layout, css: cssProp, ...props }, ref) => {
+    return <StyledLayout css={css.raw(layoutRecipe.raw({ layout }), cssProp)} {...props} ref={ref} />;
+  },
+);
 
 export default LayoutItem;

--- a/packages/ndla-ui/src/Layout/OneColumn.tsx
+++ b/packages/ndla-ui/src/Layout/OneColumn.tsx
@@ -6,14 +6,10 @@
  *
  */
 
-import { forwardRef } from "react";
-import { ark, type HTMLArkProps } from "@ark-ui/react";
-import { css, cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
-import { JsxStyleProps, RecipeVariantProps } from "@ndla/styled-system/types";
 
 // TODO: This is a rewrite of our old layout. Refactor this.
-const oneColumnRecipe = cva({
+export const OneColumn = styled("div", {
   base: {
     marginLeft: "auto",
     marginRight: "auto",
@@ -30,6 +26,9 @@ const oneColumnRecipe = cva({
       clear: "both!",
     },
   },
+  defaultVariants: {
+    wide: false,
+  },
   variants: {
     wide: {
       true: {
@@ -41,15 +40,5 @@ const oneColumnRecipe = cva({
     },
   },
 });
-
-type OneColumnVariantProps = RecipeVariantProps<typeof oneColumnRecipe>;
-
-const StyledOneColumn = styled(ark.div, {}, { baseComponent: true });
-
-export const OneColumn = forwardRef<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps & OneColumnVariantProps>(
-  ({ wide, css: cssProp, ...props }, ref) => (
-    <StyledOneColumn css={css.raw(oneColumnRecipe.raw({ wide }), cssProp)} {...props} ref={ref} />
-  ),
-);
 
 export default OneColumn;

--- a/packages/ndla-ui/src/Layout/OneColumn.tsx
+++ b/packages/ndla-ui/src/Layout/OneColumn.tsx
@@ -6,39 +6,50 @@
  *
  */
 
-/** @jsxImportSource @emotion/react */
-import { ComponentPropsWithoutRef } from "react";
-import { css } from "@emotion/react";
-import styled from "@emotion/styled";
-import { mq, spacing, breakpoints } from "@ndla/core";
+import { forwardRef } from "react";
+import { ark, type HTMLArkProps } from "@ark-ui/react";
+import { css, cva } from "@ndla/styled-system/css";
+import { styled } from "@ndla/styled-system/jsx";
+import { JsxStyleProps, RecipeVariantProps } from "@ndla/styled-system/types";
 
-interface Props extends ComponentPropsWithoutRef<"div"> {
-  wide?: boolean;
-}
+// TODO: This is a rewrite of our old layout. Refactor this.
+const oneColumnRecipe = cva({
+  base: {
+    marginLeft: "auto",
+    marginRight: "auto",
+    width: "100%",
+    paddingLeft: "18px",
+    paddingRight: "18px",
+    mobileWide: {
+      paddingLeft: "medium",
+      paddingRight: "medium",
+    },
+    _after: {
+      content: '""!',
+      display: "block!",
+      clear: "both!",
+    },
+  },
+  variants: {
+    wide: {
+      true: {
+        maxWidth: "1150px",
+      },
+      false: {
+        maxWidth: "1024px",
+      },
+    },
+  },
+});
 
-const StyledOneColumn = styled.div`
-  max-width: 1024px;
-  margin-left: auto;
-  margin-right: auto;
-  width: 100%;
-  padding-left: ${spacing.nsmall};
-  padding-right: ${spacing.nsmall};
+type OneColumnVariantProps = RecipeVariantProps<typeof oneColumnRecipe>;
 
-  ${mq.range({ from: breakpoints.mobileWide })} {
-    padding-left: ${spacing.normal};
-    padding-right: ${spacing.normal};
-  }
-  &::after {
-    content: "" !important;
-    display: block !important;
-    clear: both !important;
-  }
-`;
+const StyledOneColumn = styled(ark.div, {}, { baseComponent: true });
 
-const wideStyle = css`
-  max-width: 1150px;
-`;
-
-export const OneColumn = ({ wide, ...rest }: Props) => <StyledOneColumn css={wide ? wideStyle : undefined} {...rest} />;
+export const OneColumn = forwardRef<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps & OneColumnVariantProps>(
+  ({ wide, css: cssProp, ...props }, ref) => (
+    <StyledOneColumn css={css.raw(oneColumnRecipe.raw({ wide }), cssProp)} {...props} ref={ref} />
+  ),
+);
 
 export default OneColumn;

--- a/packages/ndla-ui/src/Layout/PageContainer.tsx
+++ b/packages/ndla-ui/src/Layout/PageContainer.tsx
@@ -6,30 +6,40 @@
  *
  */
 
-/** @jsxImportSource @emotion/react */
-import { ComponentPropsWithoutRef } from "react";
-import { css } from "@emotion/react";
-import styled from "@emotion/styled";
-import { colors, mq, breakpoints } from "@ndla/core";
+import { forwardRef } from "react";
+import { ark, type HTMLArkProps } from "@ark-ui/react";
+import { css, cva } from "@ndla/styled-system/css";
+import { styled } from "@ndla/styled-system/jsx";
+import { JsxStyleProps, RecipeVariantProps } from "@ndla/styled-system/types";
 
-interface Props extends ComponentPropsWithoutRef<"div"> {
-  backgroundWide?: boolean;
-}
+// TODO: Refactor this. It's a rewrite of our old layout.
+const pageContainerRecipe = cva({
+  base: {
+    minHeight: "100vh",
+    display: "flex",
+    flexDirection: "column",
+  },
+  variants: {
+    backgroundWide: {
+      true: {
+        tablet: {
+          backgroundColor: "#f8f8f8",
+        },
+      },
+      false: {},
+    },
+  },
+});
 
-const StyledPageContainer = styled.div`
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-`;
+const StyledPageContainer = styled(ark.div, {}, { baseComponent: true });
 
-const backgroundWideStyle = css`
-  ${mq.range({ from: breakpoints.tablet })} {
-    background-color: ${colors.brand.greyLightest};
-  }
-`;
+type PageContainerVariantProps = RecipeVariantProps<typeof pageContainerRecipe>;
 
-export const PageContainer = ({ backgroundWide = false, ...rest }: Props) => (
-  <StyledPageContainer css={backgroundWide ? backgroundWideStyle : undefined} {...rest} />
-);
+export const PageContainer = forwardRef<
+  HTMLDivElement,
+  HTMLArkProps<"div"> & JsxStyleProps & PageContainerVariantProps
+>(({ backgroundWide, css: cssProp, ...props }, ref) => (
+  <StyledPageContainer css={css.raw(pageContainerRecipe.raw({ backgroundWide }), cssProp)} {...props} ref={ref} />
+));
 
 export default PageContainer;

--- a/packages/ndla-ui/src/Layout/PageContainer.tsx
+++ b/packages/ndla-ui/src/Layout/PageContainer.tsx
@@ -6,18 +6,17 @@
  *
  */
 
-import { forwardRef } from "react";
-import { ark, type HTMLArkProps } from "@ark-ui/react";
-import { css, cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
-import { JsxStyleProps, RecipeVariantProps } from "@ndla/styled-system/types";
 
 // TODO: Refactor this. It's a rewrite of our old layout.
-const pageContainerRecipe = cva({
+export const PageContainer = styled("div", {
   base: {
     minHeight: "100vh",
     display: "flex",
     flexDirection: "column",
+  },
+  defaultVariants: {
+    backgroundWide: false,
   },
   variants: {
     backgroundWide: {
@@ -30,16 +29,5 @@ const pageContainerRecipe = cva({
     },
   },
 });
-
-const StyledPageContainer = styled(ark.div, {}, { baseComponent: true });
-
-type PageContainerVariantProps = RecipeVariantProps<typeof pageContainerRecipe>;
-
-export const PageContainer = forwardRef<
-  HTMLDivElement,
-  HTMLArkProps<"div"> & JsxStyleProps & PageContainerVariantProps
->(({ backgroundWide, css: cssProp, ...props }, ref) => (
-  <StyledPageContainer css={css.raw(pageContainerRecipe.raw({ backgroundWide }), cssProp)} {...props} ref={ref} />
-));
 
 export default PageContainer;


### PR DESCRIPTION
Begynner å gå veldig lei av at emotion ødelegger for panda. Dersom denne går inn er det kun to komponenter igjen som bruker emotion sin css-prop. Det klarer vi å fikse!