### PR TITLE
Fix default image size on floating images

### DIFF
--- a/packages/primitives/src/Figure.tsx
+++ b/packages/primitives/src/Figure.tsx
@@ -111,6 +111,8 @@ export type FigureProps = HTMLArkProps<"figure"> & JsxStyleProps & FigureVariant
 
 const StyledFigure = styled(ark.figure, {}, { baseComponent: true });
 
-export const Figure = forwardRef<HTMLElement, FigureProps>(({ size, float, css: cssProp, ...props }, ref) => (
-  <StyledFigure css={css.raw(figureRecipe.raw({ size, float }), cssProp)} {...props} ref={ref} />
-));
+export const Figure = forwardRef<HTMLElement, FigureProps>(
+  ({ size = "medium", float, css: cssProp, ...props }, ref) => {
+    return <StyledFigure css={css.raw(figureRecipe.raw({ size, float }), cssProp)} {...props} ref={ref} />;
+  },
+);


### PR DESCRIPTION
Nest siste punkt her: https://github.com/NDLANO/Issues/issues/4097

Fikses default størrelse på Figure når float er definert og ikke size