### PR TITLE
Use actual button for inline concept embeds

### DIFF
--- a/packages/ndla-ui/src/Embed/ConceptEmbed.stories.tsx
+++ b/packages/ndla-ui/src/Embed/ConceptEmbed.stories.tsx
@@ -192,6 +192,15 @@ export const Inline: StoryObj<typeof ConceptEmbed> = {
       data: blockMetaData,
     },
   },
+  render: (args) => (
+    <p>
+      Vi kan si at organisasjonene i arbeidslivet er spesielt viktige. Arbeidstakere og arbeidsgivere har ikke alltid de
+      samme interessene og har derfor forskjellig syn <ConceptEmbed {...args} /> på hva som er problemer, og hvordan
+      problemer skal løses. I stedet for at hver enkelt arbeidstaker stadig skal forhandle for seg selv med
+      arbeidsgiveren sin, blir mange problemer løst gjennom organisasjonene som representerer arbeidstakerne og
+      arbeidsgiverne.
+    </p>
+  ),
 };
 
 export const InlineFailed: StoryObj<typeof ConceptEmbed> = {

--- a/packages/ndla-ui/src/Embed/ConceptEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/ConceptEmbed.tsx
@@ -82,9 +82,10 @@ export interface InlineConceptProps extends ConceptProps, BaseProps {
   linkText?: string;
 }
 
-export const InlineConcept = forwardRef<HTMLSpanElement, InlineConceptProps>(
+export const InlineConcept = forwardRef<HTMLButtonElement, InlineConceptProps>(
   ({ linkText, copyright, visualElement, lang, children, title, ...rest }, ref) => (
-    <PopoverRoot>
+    // eslint-disable-next-line jsx-a11y/no-autofocus
+    <PopoverRoot autoFocus={false}>
       <PopoverTrigger asChild>
         <InlineTriggerButton {...rest} ref={ref}>
           {linkText}

--- a/packages/ndla-ui/src/Embed/InlineTriggerButton.tsx
+++ b/packages/ndla-ui/src/Embed/InlineTriggerButton.tsx
@@ -6,11 +6,10 @@
  *
  */
 
-import { ComponentPropsWithRef, KeyboardEvent, forwardRef, useCallback, useRef } from "react";
+import { ComponentPropsWithRef, forwardRef } from "react";
 import { styled } from "@ndla/styled-system/jsx";
-import { composeRefs } from "@ndla/util";
 
-const StyledSpan = styled("span", {
+const StyledButton = styled("button", {
   base: {
     position: "relative",
     overflow: "visible",
@@ -18,7 +17,6 @@ const StyledSpan = styled("span", {
     borderStyle: "dashed",
     borderColor: "stroke.hover",
     paddingBlock: "4xsmall",
-    paddingInline: "4xsmall",
     width: "fit-content",
     cursor: "pointer",
     _hover: {
@@ -47,26 +45,6 @@ const StyledSpan = styled("span", {
   },
 });
 
-export const InlineTriggerButton = forwardRef<HTMLSpanElement, ComponentPropsWithRef<"span">>(
-  ({ onClick, ...props }, ref) => {
-    const spanRef = useRef<HTMLSpanElement>(null);
-
-    // Emulate a button click when pressing Enter or Space
-    const onKeyboardEvent = useCallback((event: KeyboardEvent<HTMLSpanElement>) => {
-      if (event.key === "Enter" || event.key === " ") {
-        spanRef.current?.click();
-      }
-    }, []);
-
-    return (
-      <StyledSpan
-        ref={composeRefs(spanRef, ref)}
-        onKeyUp={onKeyboardEvent}
-        onClick={onClick}
-        role="button"
-        tabIndex={0}
-        {...props}
-      />
-    );
-  },
-);
+export const InlineTriggerButton = forwardRef<HTMLButtonElement, ComponentPropsWithRef<"button">>((props, ref) => {
+  return <StyledButton {...props} ref={ref} />;
+});


### PR DESCRIPTION
Støtt på et problem der lukking av popover ikke fungerer ordentlig på alle skjermstørrelser. Ser ut som at det er på grunn av vår bruk av spans. Dette er strengt tatt en mer UU-vennlig løsning uansett. Det vi taper på dette er at elementet ikke lenger vil wrappe på samme måte, men det går kanskje greit? Dette er måten NRK gjør det på f.eks.