### PR TITLE
Make Skeleton accessible

### DIFF
--- a/packages/primitives/src/Skeleton.tsx
+++ b/packages/primitives/src/Skeleton.tsx
@@ -6,9 +6,59 @@
  *
  */
 
+import { forwardRef } from "react";
 import { HTMLArkProps, ark } from "@ark-ui/react";
 import { styled } from "@ndla/styled-system/jsx";
 import { JsxStyleProps } from "@ndla/styled-system/types";
+
+const StyledField = styled(
+  ark.div,
+  {
+    base: {
+      animation: "skeleton-pulse",
+      backgroundColor: "surface.disabled",
+      backgroundClip: "padding-box",
+      borderRadius: "xsmall",
+      color: "transparent",
+      cursor: "default",
+      pointerEvents: "none",
+      userSelect: "none",
+      "&::before, &::after, *": {
+        visibility: "hidden",
+      },
+      _motionReduce: {
+        animation: "none",
+      },
+    },
+  },
+  { baseComponent: true },
+);
+
+export type SkeletonProps = HTMLArkProps<"div"> &
+  JsxStyleProps & {
+    "aria-label": string;
+    fallbackStructure: React.ReactNode;
+    loading: Boolean;
+  };
+
+type SkeletonFieldProps = HTMLArkProps<"div"> &
+  JsxStyleProps & {
+    children?: React.ReactNode;
+  };
+
+export const SkeletonField = forwardRef<HTMLDivElement, SkeletonFieldProps & JsxStyleProps>(
+  ({ children, ...rest }, ref) => (
+    <StyledField aria-hidden="true" {...rest} ref={ref}>
+      {children}
+    </StyledField>
+  ),
+);
+
+export const SkeletonWrapper = ({ children, fallbackStructure, loading, ...rest }: SkeletonProps) => (
+  <ark.div aria-busy={!!loading} {...rest}>
+    {loading ? fallbackStructure : children}
+  </ark.div>
+);
 
 export const Skeleton = styled(
   ark.div,
@@ -32,5 +82,3 @@ export const Skeleton = styled(
   },
   { baseComponent: true },
 );
-
-export interface SkeletonProps extends HTMLArkProps<"div">, JsxStyleProps {}

--- a/packages/primitives/src/index.ts
+++ b/packages/primitives/src/index.ts
@@ -203,7 +203,7 @@ export {
 } from "./Select";
 
 export type { SkeletonProps } from "./Skeleton";
-export { Skeleton } from "./Skeleton";
+export { Skeleton, SkeletonField, SkeletonWrapper } from "./Skeleton";
 
 export type { SliderRootProps } from "./Slider";
 export {


### PR DESCRIPTION
Forsøk på å sette opp en Skeleton component slik jeg ønsker meg den, for å komme https://github.com/NDLANO/Issues/issues/4126 til livs. Så får vi se hvor bra det går. Tanken er at SkeletonWrapper renderer det ferdige treet hvis man er ferdig lasta, eller en fallback som man passer inn (gjerne definert rett før som en `const fallback` e.l.). Så tar komponenten seg av resten.
Skeleton-komponenten slik den står før denne endringa ligger fortsatt inne, men er ønsket fjernet ("erstattes" av SkeletonField som vil være mer beskrivende gitt dette oppsettet) dersom denne skulle gå inn.