### PR TITLE
Make box-shadow be a part of element width for embeds

### DIFF
--- a/packages/ndla-ui/src/AudioPlayer/AudioPlayer.tsx
+++ b/packages/ndla-ui/src/AudioPlayer/AudioPlayer.tsx
@@ -24,6 +24,8 @@ const AudioPlayerWrapper = styled("div", {
     boxShadow: "full",
     marginBlockEnd: "4xsmall",
     overflow: "hidden",
+    // Include box-shadow in element size
+    width: "calc(100% - 4px)",
   },
 });
 

--- a/packages/ndla-ui/src/CampaignBlock/CampaignBlock.tsx
+++ b/packages/ndla-ui/src/CampaignBlock/CampaignBlock.tsx
@@ -48,6 +48,8 @@ const Container = styled("div", {
     tabletWide: {
       flexDirection: "row",
     },
+    // Include box-shadow in element size
+    width: "calc(100% - 4px)",
   },
 });
 

--- a/packages/ndla-ui/src/ContactBlock/ContactBlock.tsx
+++ b/packages/ndla-ui/src/ContactBlock/ContactBlock.tsx
@@ -44,6 +44,8 @@ const StyledWrapper = styled("div", {
       alignItems: "unset",
       flexDirection: "row",
     },
+    // Include box-shadow in element size
+    width: "calc(100% - 4px)",
   },
 });
 

--- a/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
+++ b/packages/ndla-ui/src/ResourceBox/ResourceBox.tsx
@@ -30,6 +30,8 @@ const Container = styled("div", {
       gap: "0",
       padding: "0",
     },
+    // Include box-shadow in element size
+    width: "calc(100% - 4px)",
   },
 });
 


### PR DESCRIPTION
Dette er en fiks for å tvinge boxShadow: "full" til å ta opp faktisk plass i embeds.

Hentet inspirasjon herfra: https://stackoverflow.com/a/14367262

Syntes dette ser ut til å fungere, prøvde å gjøre tilsvarende for height, men det hadde ingen effekt, som jeg syntes var litt rart ...

Eventuelt er en mulig løsning å lage en wrapper som setter padding tilsvarende plassen box-shadow opptar. Prøvde meg også litt frem med pseudo-element, men det vil ikke fungere med padding utenfra, som er litt av poenget her 😅 