### PR TITLE
new scaling for campaign block

### DIFF
--- a/packages/ndla-ui/src/CampaignBlock/CampaignBlock.tsx
+++ b/packages/ndla-ui/src/CampaignBlock/CampaignBlock.tsx
@@ -46,12 +46,23 @@ const Container = styled("div", {
     boxShadow: "full",
     marginBlockEnd: "4xsmall",
     overflow: "hidden",
-    tabletWide: {
-      gridTemplateColumns: "auto minmax(230px, 455px)", //required for campaign block in myNdla
-      "&[data-img-left='true']": {
-        gridTemplateColumns: "minmax(230px, 455px) auto", //required for campaign block in myNdla
+  },
+  variants: {
+    imageSide: {
+      left: {
+        tabletWide: {
+          gridTemplateColumns: "minmax(230px, 455px) auto", //required for campaign block in myNdla
+        },
+      },
+      right: {
+        tabletWide: {
+          gridTemplateColumns: "auto minmax(230px, 455px)", //required for campaign block in myNdla
+        },
       },
     },
+  },
+  defaultVariants: {
+    imageSide: "left",
   },
 });
 
@@ -148,7 +159,7 @@ const CampaignBlock = ({
   const imageComponent = image && <StyledImg src={`${image.src}?width=455`} height={340} width={455} alt={image.alt} />;
   const HeaderComponent = url?.url ? LinkHeader : Text;
   return (
-    <Container className={className} data-embed-type="campaign-block" data-img-left={imageSide === "left"}>
+    <Container className={className} data-embed-type="campaign-block" imageSide={imageSide}>
       {imageSide === "left" && imageComponent}
       <ContentWrapper>
         <MaybeLinkText url={url?.url} path={path}>

--- a/packages/ndla-ui/src/CampaignBlock/CampaignBlock.tsx
+++ b/packages/ndla-ui/src/CampaignBlock/CampaignBlock.tsx
@@ -36,10 +36,9 @@ interface Props {
 
 const Container = styled("div", {
   base: {
-    width: "100%",
-    display: "flex",
+    display: "grid",
+    gridTemplateColumns: "1fr",
     gap: "medium",
-    flexDirection: "column",
     border: "1px solid",
     borderColor: "stroke.default",
     backgroundColor: "background.default",
@@ -48,7 +47,10 @@ const Container = styled("div", {
     marginBlockEnd: "4xsmall",
     overflow: "hidden",
     tabletWide: {
-      flexDirection: "row",
+      gridTemplateColumns: "auto minmax(230px, 455px)", //required for campaign block in myNdla
+      "&[data-img-left='true']": {
+        gridTemplateColumns: "minmax(230px, 455px) auto", //required for campaign block in myNdla
+      },
     },
   },
 });
@@ -78,15 +80,14 @@ const LinkHeader = styled(Text, {
 
 const StyledImg = styled("img", {
   base: {
-    alignSelf: "center",
     objectFit: "cover",
     width: "100%",
     height: "215px",
-    mobileWide: {
-      height: "340px",
+    tablet: {
+      height: "265px",
     },
     tabletWide: {
-      width: "auto",
+      height: "340px",
     },
   },
 });
@@ -94,7 +95,6 @@ const StyledImg = styled("img", {
 const ContentWrapper = styled("div", {
   base: {
     width: "100%",
-    position: "relative",
     display: "flex",
     flexDirection: "column",
     gap: "medium",
@@ -102,6 +102,7 @@ const ContentWrapper = styled("div", {
     justifyContent: "center",
     paddingBlock: "medium",
     paddingInline: "medium",
+    minWidth: "270px", //required for campaign block in myNdla
   },
 });
 
@@ -147,7 +148,7 @@ const CampaignBlock = ({
   const imageComponent = image && <StyledImg src={`${image.src}?width=455`} height={340} width={455} alt={image.alt} />;
   const HeaderComponent = url?.url ? LinkHeader : Text;
   return (
-    <Container className={className} data-embed-type="campaign-block">
+    <Container className={className} data-embed-type="campaign-block" data-img-left={imageSide === "left"}>
       {imageSide === "left" && imageComponent}
       <ContentWrapper>
         <MaybeLinkText url={url?.url} path={path}>


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/4148
Problemet med skalering av kampanjeblokk er at det ble designet med tanke på bruk i vanlig side-layout og med ett bilde format. Når vi da bruker den i minNdla der vi har mindre plass pga menyen til venstre, og bildeformatet er varierende, så blir det litt vanskelig å skalere den og samtidig oppfylle designkrav. Jeg har prøvd å trikse litt og Hedvig er enig med at dette er innafor til vi har innført strengere bildekrav i ED. 

Om noen har bedre grid skills så er jeg åpen for forslag på hvordan dette kunne bli løst bedre/enklere 🙏
