### PR TITLE
Initial pass at new Error message primitive

### DIFF
--- a/packages/primitives/src/ErrorMessage/ErrorMessage.stories.tsx
+++ b/packages/primitives/src/ErrorMessage/ErrorMessage.stories.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Meta, StoryObj } from "@storybook/react";
+import { LoginBoxLine, PresentationLine } from "@ndla/icons/common";
+import { SafeLink } from "@ndla/safelink";
+import {
+  ErrorMessageActions,
+  ErrorMessageContent,
+  ErrorMessageDescription,
+  ErrorMessageRoot,
+  ErrorMessageTitle,
+} from "./ErrorMessage";
+//@ts-ignore
+import Oops from "../../../../images/oops.gif";
+import { Button } from "../Button";
+
+export default {
+  title: "Primitives/ErrorMessage",
+  component: ErrorMessageRoot,
+  tags: ["autodocs"],
+  parameters: {
+    inlineStories: true,
+  },
+  render: (args) => (
+    <ErrorMessageRoot {...args}>
+      <img src={Oops} alt="Systemfeil" />
+      <ErrorMessageContent>
+        <ErrorMessageTitle>Oisann, her gikk noe galt</ErrorMessageTitle>
+        <ErrorMessageDescription>En kort beskrivelse av feilen som oppsto.</ErrorMessageDescription>
+      </ErrorMessageContent>
+      <ErrorMessageActions>
+        <Button variant="link" onClick={() => window.history.back()}>
+          Gå tilbake
+        </Button>
+        <SafeLink to="/">Gå til forsiden</SafeLink>
+      </ErrorMessageActions>
+    </ErrorMessageRoot>
+  ),
+} satisfies Meta<typeof ErrorMessageRoot>;
+
+export const Default: StoryObj<typeof ErrorMessageRoot> = {};
+
+export const AccessDenied: StoryObj<typeof ErrorMessageRoot> = {
+  render: (args) => (
+    <ErrorMessageRoot {...args}>
+      <PresentationLine css={{ width: "surface.xsmall", height: "surface.xsmall" }} />
+      <ErrorMessageContent>
+        <ErrorMessageTitle>Vi beklager, men denne ressursen er bare for lærere innlogget med Feide.</ErrorMessageTitle>
+      </ErrorMessageContent>
+      <ErrorMessageActions>
+        <Button>
+          Logg inn med Feide
+          <LoginBoxLine />
+        </Button>
+        <Button variant="link" onClick={() => window.history.back()}>
+          Gå tilbake
+        </Button>
+        <SafeLink to="/">Gå til forsiden</SafeLink>
+      </ErrorMessageActions>
+    </ErrorMessageRoot>
+  ),
+};

--- a/packages/primitives/src/ErrorMessage/ErrorMessage.tsx
+++ b/packages/primitives/src/ErrorMessage/ErrorMessage.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2024-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { forwardRef } from "react";
+import { HTMLArkProps, ark } from "@ark-ui/react";
+import { sva } from "@ndla/styled-system/css";
+import { JsxStyleProps } from "@ndla/styled-system/types";
+import { createStyleContext } from "../createStyleContext";
+import { Heading, Text, TextProps } from "../Text";
+
+const errorMessageRecipe = sva({
+  slots: ["root", "content", "actions", "title", "description"],
+  base: {
+    root: {
+      display: "flex",
+      flexDirection: "column",
+      gap: "xxlarge",
+      alignItems: "center",
+    },
+    content: {
+      display: "flex",
+      flexDirection: "column",
+      gap: "medium",
+      alignItems: "center",
+    },
+    actions: {
+      display: "flex",
+      flexDirection: "column",
+      gap: "xsmall",
+      alignItems: "center",
+    },
+    title: {
+      textAlign: "center",
+    },
+    description: {
+      textAlign: "center",
+    },
+  },
+});
+
+const { withProvider, withContext } = createStyleContext(errorMessageRecipe);
+
+export const ErrorMessageRoot = withProvider<HTMLElement, HTMLArkProps<"article"> & JsxStyleProps>(
+  ark.article,
+  "root",
+  { baseComponent: true },
+);
+
+export const ErrorMessageContent = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(
+  ark.div,
+  "content",
+  { baseComponent: true },
+);
+
+export const ErrorMessageActions = withContext<HTMLDivElement, HTMLArkProps<"div"> & JsxStyleProps>(
+  ark.div,
+  "actions",
+  { baseComponent: true },
+);
+
+const InternalErrorMessageTitle = forwardRef<HTMLHeadingElement, HTMLArkProps<"h1"> & JsxStyleProps & TextProps>(
+  ({ textStyle = "heading.small", ...props }, ref) => <Heading textStyle={textStyle} {...props} ref={ref} />,
+);
+
+export const ErrorMessageTitle = withContext<HTMLHeadingElement, HTMLArkProps<"h1"> & JsxStyleProps & TextProps>(
+  InternalErrorMessageTitle,
+  "title",
+);
+
+const InternalErrorMessageDescription = forwardRef<HTMLParagraphElement, HTMLArkProps<"p"> & JsxStyleProps & TextProps>(
+  ({ textStyle = "body.xlarge", ...props }, ref) => <Text textStyle={textStyle} {...props} ref={ref} />,
+);
+
+export const ErrorMessageDescription = withContext<HTMLParagraphElement, HTMLArkProps<"p"> & JsxStyleProps & TextProps>(
+  InternalErrorMessageDescription,
+  "description",
+);


### PR DESCRIPTION
Går vekk fra vår gamle margin-baserte feilmelding. Dropper også alt av implementasjonsdetaljer, så vi heller kan styre dette fra frontendene våre. Jeg mener dette er mer forståelig enn det gamle `messages`-systemet.