### PR TITLE
fix: byline text and version

### DIFF
--- a/packages/ndla-licenses/src/getCopyString.ts
+++ b/packages/ndla-licenses/src/getCopyString.ts
@@ -177,7 +177,7 @@ export const getLicenseString = (license: string | undefined, locale: string) =>
   const licenseAbbreviation = license && getLicenseByAbbreviation(license, locale).abbreviation;
 
   if (licenseAbbreviation?.startsWith("CC ")) {
-    return `${licenseAbbreviation} 4.0`;
+    return `${licenseAbbreviation}`;
   }
 
   return licenseAbbreviation ?? "";

--- a/packages/ndla-licenses/src/licenseRights.ts
+++ b/packages/ndla-licenses/src/licenseRights.ts
@@ -18,6 +18,7 @@ export const CC0 = "cc0"; // Public Domain Dedication
 export const CC = "cc"; // Creative Commons
 export const COPYRIGHTED = "copyrighted"; // Copyrighted
 export const NA = "n/a"; // Not Applicable
+export const VERSION = "4.0"; //Current license version
 
 const by: RightType = {
   short: BY,

--- a/packages/ndla-licenses/src/licenses.ts
+++ b/packages/ndla-licenses/src/licenses.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import { BY, SA, NC, ND, PD, CC0, COPYRIGHTED, CC, NA } from "./licenseRights";
+import { BY, SA, NC, ND, PD, CC0, COPYRIGHTED, CC, NA, VERSION } from "./licenseRights";
 import { getLocaleOrDefault, LicenseType, LicenseLocaleType, Locale } from "./types";
 
 const freeUseNB = "Offentlig eie";
@@ -27,7 +27,7 @@ const naNB = "N/A - ikke relevant";
 const naNN = "N/A - ikkje relevant";
 const naEN = "N/A - not applicable";
 
-const byncndAbbrev = `${CC} ${BY}-${NC}-${ND}`.toUpperCase();
+const byncndAbbrev = `${CC} ${BY}-${NC}-${ND} ${VERSION}`.toUpperCase();
 
 const byncnd: LicenseType = {
   nn: {
@@ -64,7 +64,7 @@ const byncnd: LicenseType = {
   rights: [CC, BY, NC, ND],
 };
 
-const byncsaAbbrev = `${CC} ${BY}-${NC}-${SA}`.toUpperCase();
+const byncsaAbbrev = `${CC} ${BY}-${NC}-${SA} ${VERSION}`.toUpperCase();
 
 const byncsa: LicenseType = {
   nn: {
@@ -101,7 +101,7 @@ const byncsa: LicenseType = {
   rights: [CC, BY, NC, SA],
 };
 
-const byncAbbrev = `${CC} ${BY}-${NC}`.toUpperCase();
+const byncAbbrev = `${CC} ${BY}-${NC} ${VERSION}`.toUpperCase();
 
 const bync: LicenseType = {
   nn: {
@@ -138,7 +138,7 @@ const bync: LicenseType = {
   rights: [CC, BY, NC],
 };
 
-const byndAbbrev = `${CC} ${BY}-${ND}`.toUpperCase();
+const byndAbbrev = `${CC} ${BY}-${ND} ${VERSION}`.toUpperCase();
 
 const bynd: LicenseType = {
   nn: {
@@ -175,7 +175,7 @@ const bynd: LicenseType = {
   rights: [CC, BY, ND],
 };
 
-const bysaAbbrev = `${CC} ${BY}-${SA}`.toUpperCase();
+const bysaAbbrev = `${CC} ${BY}-${SA} ${VERSION}`.toUpperCase();
 
 const bysa: LicenseType = {
   nn: {
@@ -212,7 +212,7 @@ const bysa: LicenseType = {
   rights: [CC, BY, SA],
 };
 
-const byAbbrev = `${CC} ${BY}`.toUpperCase();
+const byAbbrev = `${CC} ${BY} ${VERSION}`.toUpperCase();
 
 const by: LicenseType = {
   nn: {

--- a/packages/ndla-ui/src/LicenseByline/EmbedByline.tsx
+++ b/packages/ndla-ui/src/LicenseByline/EmbedByline.tsx
@@ -78,6 +78,7 @@ const BylineWrapper = styled("figcaption", {
     paddingBlock: "xsmall",
     background: "surface.default",
     textStyle: "label.medium",
+    color: "text.subtle",
   },
 });
 

--- a/packages/ndla-ui/src/LicenseByline/LicenseLink.tsx
+++ b/packages/ndla-ui/src/LicenseByline/LicenseLink.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 const StyledSafeLink = styled(SafeLink, {
   base: {
-    color: "primary",
+    color: "text.link",
     textDecoration: "underline",
     whiteSpace: "nowrap",
     _hover: {


### PR DESCRIPTION
fikser [byline tekstfarge](https://trello.com/c/BV3cPn3h/40-byline-tekstfarge), [lisensversjon](https://trello.com/c/6rbpla56/42-alle-cc-lisenser-er-40-versjonstall-m%C3%A5-fremkomme-et-eller-alle-steder)