### PR TITLE
Fix Figure padding on smaller screens for float-images + full width non float images

### DIFF
--- a/packages/ndla-ui/src/Embed/ImageEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/ImageEmbed.tsx
@@ -224,11 +224,13 @@ const ImageEmbed = ({ embed, previewAlt, lang, renderContext = "article", childr
 
   const licenseProps = licenseAttributes(data.copyright.license.license, lang, embedData.url);
 
+  const figureSize = figureProps?.float ? figureProps?.size ?? "medium" : "full";
+
   // TODO: Check how this works with `children`. Will only be important for ED
   return (
     <StyledFigure
       float={figureProps?.float}
-      size={imageSizes ? "full" : figureProps?.size ?? "medium"}
+      size={imageSizes ? "full" : figureSize}
       data-embed-type="image"
       {...licenseProps}
     >
@@ -245,7 +247,7 @@ const ImageEmbed = ({ embed, previewAlt, lang, renderContext = "article", childr
           onClick={figureProps?.float ? toggleImageSize : undefined}
           variant="rounded"
         />
-        {!!embedData.align && (
+        {(embedData.align === "right" || embedData.align === "left") && (
           <ExpandButton
             aria-label={t(`license.images.itemImage.zoom${imageSizes ? "Out" : ""}ImageButtonLabel`)}
             onClick={toggleImageSize}

--- a/packages/ndla-ui/src/Embed/ImageEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/ImageEmbed.tsx
@@ -183,6 +183,9 @@ const ExpandButton = styled(
         transitionDuration: "normal",
         transitionTimingFunction: "ease-out",
       },
+      tabletDown: {
+        display: "none",
+      },
     },
   },
   { defaultProps: { type: "button" } },

--- a/packages/primitives/src/Figure.tsx
+++ b/packages/primitives/src/Figure.tsx
@@ -85,6 +85,7 @@ const figureRecipe = cva({
       size: ["medium", "small", "xsmall"],
       css: {
         paddingInlineEnd: "medium",
+        tabletDown: { paddingInlineEnd: "0" },
       },
     },
     {
@@ -92,6 +93,7 @@ const figureRecipe = cva({
       size: ["medium", "small", "xsmall"],
       css: {
         paddingInlineStart: "medium",
+        tabletDown: { paddingInlineStart: "0" },
       },
     },
     {


### PR DESCRIPTION
fixes https://github.com/NDLANO/Issues/issues/4167 (https://trello.com/c/VDewZN14/58-un%C3%B8dvendig-pluss-knapp-i-mobilvisning)

fikser også: https://trello.com/c/QSAoheNI/69-feil-med-visning-av-noen-bilder

