### PR TITLE
Gir tilbake liste markering på safari. Det er ikke noe E i safari

### DIFF
--- a/packages/primitives/src/ArticleLists.tsx
+++ b/packages/primitives/src/ArticleLists.tsx
@@ -16,6 +16,9 @@ const orderedListRecipe = cva({
   base: {
     "& li": {
       marginBlock: "small",
+      "& > p": {
+        display: "inline",
+      },
     },
   },
   defaultVariants: {
@@ -28,32 +31,37 @@ const orderedListRecipe = cva({
         "&[data-count='true']": {
           counterReset: "level1 var(--start, 0)",
         },
-        marginInline: "small",
         "& > li": {
           counterIncrement: "level1",
-          _marker: {
+          _before: {
             content: "counter(level1, decimal) '. '",
           },
+          "& > ol[data-variant='letters'] > li": {
+            paddingInlineStart: "medium",
+          },
           "& > ol:not([data-variant='letters'])": {
-            marginInlineStart: "xlarge",
             counterReset: "level2",
             "&[data-count='true']": {
               counterReset: "level2 var(--start, 0)",
             },
             "& > li": {
+              paddingInlineStart: "medium",
               counterIncrement: "level2",
-              _marker: {
+              _before: {
                 content: "counter(level1, decimal) '.' counter(level2, decimal) '. '",
               },
+              "& > ol[data-variant='letters'] > li": {
+                paddingInlineStart: "large",
+              },
               "& > ol:not([data-variant='letters'])": {
-                marginInlineStart: "xxlarge",
                 counterReset: "level3",
                 "&[data-count='true']": {
                   counterReset: "level3 var(--start, 0)",
                 },
                 "& > li": {
+                  paddingInlineStart: "large",
                   counterIncrement: "level3",
-                  _marker: {
+                  _before: {
                     content: "counter(level1, decimal) '.' counter(level2, decimal) '.' counter(level3, decimal) '. '",
                   },
                   "& > ol:not([data-variant='letters'])": {
@@ -62,8 +70,12 @@ const orderedListRecipe = cva({
                       counterReset: "level4 var(--start, 0)",
                     },
                     "& > li": {
+                      "& > ol[data-variant='letters'] > li": {
+                        paddingInlineStart: "xxlarge",
+                      },
+                      paddingInlineStart: "xxlarge",
                       counterIncrement: "level4",
-                      _marker: {
+                      _before: {
                         content:
                           "counter(level1, decimal) '.' counter(level2, decimal) '.' counter(level3, decimal) '.' counter(level4,  decimal) '. '",
                       },
@@ -80,23 +92,31 @@ const orderedListRecipe = cva({
         "&[data-count='true']": {
           counterReset: "level1 var(--start, 0)",
         },
-        paddingInlineStart: "medium",
         "& > li": {
           counterIncrement: "level1",
-          _marker: {
+          _before: {
             content: "counter(level1, upper-alpha) '. '",
           },
-          "& > ol[data-variant='letters']": {
-            paddingInlineStart: "small",
-            "& > li": {
-              _marker: {
-                content: "counter(level1, lower-alpha) '. '",
+          "& > ol > li": {
+            paddingInlineStart: "medium",
+          },
+          "& > ol[data-variant='letters'] > li": {
+            _before: {
+              content: "counter(level1, lower-alpha) '. '",
+            },
+            "& > ol[data-variant='letters'] > li": {
+              paddingInlineStart: "small",
+              _before: {
+                display: "inline-block",
+                width: "xsmall",
+                right: "small",
+                textAlign: "right",
+                content: "counter(level1, lower-roman) '. '",
+                marginRight: "4xsmall",
               },
-              "& > ol[data-variant='letters'] > li": {
-                _marker: {
-                  content: "counter(level1, lower-roman) '. '",
-                },
-              },
+            },
+            "& > ol:not([data-variant='letters']) > li": {
+              paddingInlineStart: "small",
             },
           },
         },

--- a/packages/primitives/src/ArticleLists.tsx
+++ b/packages/primitives/src/ArticleLists.tsx
@@ -26,8 +26,9 @@ const orderedListRecipe = cva({
         position: "absolute",
         transform: "translateX(-100%)",
         paddingInlineEnd: "3xsmall",
+        fontVariantNumeric: "tabular-nums",
       },
-      marginInlineStart: "medium",
+      marginInlineStart: "small",
     },
   },
   defaultVariants: {
@@ -54,7 +55,7 @@ const orderedListRecipe = cva({
               counterReset: "level2 var(--start, 0)",
             },
             [LIST_ITEM]: {
-              marginInlineStart: "large",
+              marginInlineStart: "xlarge",
               counterIncrement: "level2",
               _before: {
                 content: "counter(level1, decimal) '.' counter(level2, decimal) '. '",
@@ -65,7 +66,7 @@ const orderedListRecipe = cva({
                   counterReset: "level3 var(--start, 0)",
                 },
                 [LIST_ITEM]: {
-                  marginInlineStart: "xlarge",
+                  marginInlineStart: "xxlarge",
                   counterIncrement: "level3",
                   _before: {
                     content: "counter(level1, decimal) '.' counter(level2, decimal) '.' counter(level3, decimal) '. '",
@@ -76,7 +77,7 @@ const orderedListRecipe = cva({
                       counterReset: "level4 var(--start, 0)",
                     },
                     [LIST_ITEM]: {
-                      marginInlineStart: "xxlarge",
+                      marginInlineStart: "3xlarge",
                       counterIncrement: "level4",
                       _before: {
                         content:
@@ -101,10 +102,10 @@ const orderedListRecipe = cva({
             content: "counter(level1, upper-alpha) '. '",
           },
           [NUMBER_LIST_ITEM]: {
-            marginInlineStart: "small",
+            marginInlineStart: "medium",
           },
           [LETTER_LIST_ITEM]: {
-            marginInlineStart: "medium",
+            marginInlineStart: "small",
             _before: {
               content: "counter(level1, lower-alpha) '. '",
             },

--- a/packages/primitives/src/ArticleLists.tsx
+++ b/packages/primitives/src/ArticleLists.tsx
@@ -12,13 +12,22 @@ import { css, cva } from "@ndla/styled-system/css";
 import { styled } from "@ndla/styled-system/jsx";
 import { JsxStyleProps, RecipeVariantProps } from "@ndla/styled-system/types";
 
+const LIST_ITEM = "& > li";
+const LETTER_LIST = "& > ol[data-variant='letters']";
+const NUMBER_LIST = "& > ol:not([data-variant='letters'])";
+const LETTER_LIST_ITEM = `${LETTER_LIST} > li`;
+const NUMBER_LIST_ITEM = `${NUMBER_LIST} > li`;
+
 const orderedListRecipe = cva({
   base: {
-    "& li": {
+    [LIST_ITEM]: {
       marginBlock: "small",
-      "& > p": {
-        display: "inline",
+      _before: {
+        position: "absolute",
+        transform: "translateX(-100%)",
+        paddingInlineEnd: "3xsmall",
       },
+      marginInlineStart: "medium",
     },
   },
   defaultVariants: {
@@ -31,49 +40,43 @@ const orderedListRecipe = cva({
         "&[data-count='true']": {
           counterReset: "level1 var(--start, 0)",
         },
-        "& > li": {
+        [LIST_ITEM]: {
           counterIncrement: "level1",
           _before: {
             content: "counter(level1, decimal) '. '",
           },
-          "& > ol[data-variant='letters'] > li": {
-            paddingInlineStart: "medium",
+          [LETTER_LIST_ITEM]: {
+            marginInlineStart: "medium",
           },
-          "& > ol:not([data-variant='letters'])": {
+          [NUMBER_LIST]: {
             counterReset: "level2",
             "&[data-count='true']": {
               counterReset: "level2 var(--start, 0)",
             },
-            "& > li": {
-              paddingInlineStart: "medium",
+            [LIST_ITEM]: {
+              marginInlineStart: "large",
               counterIncrement: "level2",
               _before: {
                 content: "counter(level1, decimal) '.' counter(level2, decimal) '. '",
               },
-              "& > ol[data-variant='letters'] > li": {
-                paddingInlineStart: "large",
-              },
-              "& > ol:not([data-variant='letters'])": {
+              [NUMBER_LIST]: {
                 counterReset: "level3",
                 "&[data-count='true']": {
                   counterReset: "level3 var(--start, 0)",
                 },
-                "& > li": {
-                  paddingInlineStart: "large",
+                [LIST_ITEM]: {
+                  marginInlineStart: "xlarge",
                   counterIncrement: "level3",
                   _before: {
                     content: "counter(level1, decimal) '.' counter(level2, decimal) '.' counter(level3, decimal) '. '",
                   },
-                  "& > ol:not([data-variant='letters'])": {
+                  [NUMBER_LIST]: {
                     counterReset: "level4",
                     "&[data-count='true']": {
                       counterReset: "level4 var(--start, 0)",
                     },
-                    "& > li": {
-                      "& > ol[data-variant='letters'] > li": {
-                        paddingInlineStart: "xxlarge",
-                      },
-                      paddingInlineStart: "xxlarge",
+                    [LIST_ITEM]: {
+                      marginInlineStart: "xxlarge",
                       counterIncrement: "level4",
                       _before: {
                         content:
@@ -92,31 +95,27 @@ const orderedListRecipe = cva({
         "&[data-count='true']": {
           counterReset: "level1 var(--start, 0)",
         },
-        "& > li": {
+        [LIST_ITEM]: {
           counterIncrement: "level1",
           _before: {
             content: "counter(level1, upper-alpha) '. '",
           },
-          "& > ol > li": {
-            paddingInlineStart: "medium",
+          [NUMBER_LIST_ITEM]: {
+            marginInlineStart: "small",
           },
-          "& > ol[data-variant='letters'] > li": {
+          [LETTER_LIST_ITEM]: {
+            marginInlineStart: "medium",
             _before: {
               content: "counter(level1, lower-alpha) '. '",
             },
-            "& > ol[data-variant='letters'] > li": {
-              paddingInlineStart: "small",
+            [LETTER_LIST_ITEM]: {
+              marginInlineStart: "small",
               _before: {
-                display: "inline-block",
-                width: "xsmall",
-                right: "small",
-                textAlign: "right",
                 content: "counter(level1, lower-roman) '. '",
-                marginRight: "4xsmall",
               },
-            },
-            "& > ol:not([data-variant='letters']) > li": {
-              paddingInlineStart: "small",
+              [NUMBER_LIST_ITEM]: {
+                marginInlineStart: "medium",
+              },
             },
           },
         },

--- a/packages/primitives/src/ArticleOrderedList.stories.tsx
+++ b/packages/primitives/src/ArticleOrderedList.stories.tsx
@@ -206,7 +206,14 @@ export const StartingAtFive: StoryFn = () => (
                           <OrderedList>
                             <li>Listepunkt 1</li>
                             <li>Listepunkt 2</li>
-                            <li>Listepunkt 3</li>
+                            <li>
+                              Listepunkt 3
+                              <OrderedList variant="letters">
+                                <li>Listepunkt 1</li>
+                                <li>Listepunkt 2</li>
+                                <li>Listepunkt 3</li>
+                              </OrderedList>
+                            </li>
                           </OrderedList>
                         </li>
                       </OrderedList>


### PR DESCRIPTION
Added example with letter child after last number level. Changed from marker to before.

Baserer seg litt på det som har blitt gjort før panda.