### PR TITLE
Fix FactBox transition

### DIFF
--- a/packages/ndla-ui/src/FactBox/FactBox.tsx
+++ b/packages/ndla-ui/src/FactBox/FactBox.tsx
@@ -21,27 +21,30 @@ interface Props extends ComponentProps<"aside"> {
 
 const StyledAside = styled("aside", {
   base: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
     position: "relative",
     padding: "medium",
-    transitionProperty: "max-height",
+    display: "grid",
+    gridTemplateRows: "0fr",
+    transitionProperty: "grid-template-rows",
     transitionDuration: "slow",
     transitionTimingFunction: "ease-in-out",
+    justifyItems: "center",
     border: "1px solid",
     borderColor: "stroke.default",
     borderRadius: "xsmall",
-    maxHeight: "surface.xxsmall",
     clear: "both",
+    _open: {
+      gridTemplateRows: "1fr",
+    },
     _closed: {
       _print: {
         overflow: "visible",
         maxHeight: "500vh",
       },
     },
-    _open: {
-      maxHeight: "500vh",
+    "& > div": {
+      minHeight: "surface.3xsmall",
+      overflow: "hidden",
     },
   },
 });


### PR DESCRIPTION
fikser: https://trello.com/c/wk6zNMh6/36-animasjon-factbox

Fikser opp i lukke-transition i FactBox. Problemet var at max-høyde var veldig mye større enn faktisk høyde på elementet, som gjorde at transition oppleves litt forsinket. Løst ved å ta i bruk grid-triks herfra: https://dev.to/francescovetere/css-trick-transition-from-height-0-to-auto-21de
