### PR TITLE
let byline have transparent background

### DIFF
--- a/packages/ndla-ui/src/LicenseByline/EmbedByline.tsx
+++ b/packages/ndla-ui/src/LicenseByline/EmbedByline.tsx
@@ -78,7 +78,6 @@ const BylineWrapper = styled("figcaption", {
     display: "flex",
     flexDirection: "column",
     paddingBlock: "xsmall",
-    background: "surface.default",
     textStyle: "label.medium",
     color: "text.subtle",
   },


### PR DESCRIPTION
fant denne på forsiden. ser ikke helt bra ut, men breaker det et annet sted at byline ikke har hvitt bakgrunn?
![image](https://github.com/user-attachments/assets/142cad9e-5ba0-4ea8-862d-bbde9fcad645)
