### PR TITLE
Remove form wrapper on search input

### DIFF
--- a/packages/ndla-audio-search/src/AudioSearch.tsx
+++ b/packages/ndla-audio-search/src/AudioSearch.tsx
@@ -102,6 +102,7 @@ const AudioSearch = ({
   const [queryObject, setQueryObject] = useState<QueryObject>(query);
   const [searching, setSearching] = useState(false);
   const [searchResult, setSearchResult] = useState<IAudioSummarySearchResult | undefined>();
+  const noResultsFound = !searching && searchResult?.results.length === 0;
 
   const { locale } = queryObject ?? {};
 
@@ -166,6 +167,7 @@ const AudioSearch = ({
         translations={translations.paginationTranslations}
         count={searchResult?.totalCount ?? 0}
         pageSize={searchResult?.pageSize}
+        hidden={noResultsFound}
       >
         <PaginationPrevTrigger asChild>
           <StyledButton

--- a/packages/ndla-audio-search/src/AudioSearch.tsx
+++ b/packages/ndla-audio-search/src/AudioSearch.tsx
@@ -21,7 +21,7 @@ import {
 } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
 import { IAudioMetaInformation, IAudioSummary, IAudioSummarySearchResult } from "@ndla/types-backend/audio-api";
-import AudioSearchForm from "./AudioSearchForm";
+import AudioSearchInput from "./AudioSearchInput";
 import AudioSearchList from "./AudioSearchList";
 
 const AudioSearchWrapper = styled("div", {
@@ -144,7 +144,7 @@ const AudioSearch = ({
 
   return (
     <AudioSearchWrapper>
-      <AudioSearchForm
+      <AudioSearchInput
         onSearchQuerySubmit={submitAudioSearchQuery}
         queryObject={queryObject}
         searching={searching}

--- a/packages/ndla-audio-search/src/AudioSearchForm.tsx
+++ b/packages/ndla-audio-search/src/AudioSearchForm.tsx
@@ -6,13 +6,13 @@
  *
  */
 
-import { ChangeEvent, FormEvent, KeyboardEvent, useState } from "react";
+import { ChangeEvent, useState } from "react";
 import { SearchLine } from "@ndla/icons/common";
 import { IconButton, Input } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
 import { QueryObject } from "./AudioSearch";
 
-const StyledForm = styled("form", {
+const InputWrapper = styled("div", {
   base: {
     display: "flex",
     gap: "xsmall",
@@ -39,29 +39,29 @@ const AudioSearchForm = ({ queryObject: query, translations, searching, onSearch
     }));
   };
 
-  const handleSubmit = (e: KeyboardEvent<HTMLInputElement> | FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-    onSearchQuerySubmit(queryObject);
-  };
-
   return (
-    <StyledForm onSubmit={handleSubmit}>
+    <InputWrapper role="search">
       <Input
         type="search"
         placeholder={translations.searchPlaceholder}
         value={queryObject?.query}
         onChange={handleQueryChange}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            onSearchQuerySubmit(queryObject);
+          }
+        }}
       />
       <IconButton
         variant="primary"
         type="submit"
         aria-label={translations.searchButtonTitle}
         title={translations.searchButtonTitle}
+        onClick={() => onSearchQuerySubmit(queryObject)}
       >
         <SearchLine />
       </IconButton>
-    </StyledForm>
+    </InputWrapper>
   );
 };
 

--- a/packages/ndla-audio-search/src/AudioSearchInput.tsx
+++ b/packages/ndla-audio-search/src/AudioSearchInput.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, KeyboardEvent, useState } from "react";
 import { SearchLine } from "@ndla/icons/common";
 import { IconButton, Input } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
@@ -29,7 +29,7 @@ interface Props {
   onSearchQuerySubmit: (query: QueryObject) => void;
 }
 
-const AudioSearchForm = ({ queryObject: query, translations, searching, onSearchQuerySubmit }: Props) => {
+const AudioSearchInput = ({ queryObject: query, translations, onSearchQuerySubmit }: Props) => {
   const [queryObject, setQueryObject] = useState(query);
 
   const handleQueryChange = ({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
@@ -39,6 +39,12 @@ const AudioSearchForm = ({ queryObject: query, translations, searching, onSearch
     }));
   };
 
+  const onEnter = (e: KeyboardEvent<HTMLInputElement> | KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "Enter") {
+      onSearchQuerySubmit(queryObject);
+    }
+  };
+
   return (
     <InputWrapper role="search">
       <Input
@@ -46,17 +52,14 @@ const AudioSearchForm = ({ queryObject: query, translations, searching, onSearch
         placeholder={translations.searchPlaceholder}
         value={queryObject?.query}
         onChange={handleQueryChange}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            onSearchQuerySubmit(queryObject);
-          }
-        }}
+        onKeyDown={onEnter}
       />
       <IconButton
         variant="primary"
         type="submit"
         aria-label={translations.searchButtonTitle}
         title={translations.searchButtonTitle}
+        onKeyDown={onEnter}
         onClick={() => onSearchQuerySubmit(queryObject)}
       >
         <SearchLine />
@@ -65,4 +68,4 @@ const AudioSearchForm = ({ queryObject: query, translations, searching, onSearch
   );
 };
 
-export default AudioSearchForm;
+export default AudioSearchInput;

--- a/packages/ndla-audio-search/src/AudioSearchInput.tsx
+++ b/packages/ndla-audio-search/src/AudioSearchInput.tsx
@@ -39,7 +39,7 @@ const AudioSearchInput = ({ queryObject: query, translations, onSearchQuerySubmi
     }));
   };
 
-  const onEnter = (e: KeyboardEvent<HTMLInputElement> | KeyboardEvent<HTMLButtonElement>) => {
+  const onEnter = (e: KeyboardEvent<HTMLInputElement | HTMLButtonElement>) => {
     if (e.key === "Enter") {
       onSearchQuerySubmit(queryObject);
     }

--- a/packages/ndla-image-search/src/ImageSearch.tsx
+++ b/packages/ndla-image-search/src/ImageSearch.tsx
@@ -180,12 +180,6 @@ const ImageSearch = ({
     }));
   };
 
-  const handleSubmit = (e?: KeyboardEvent<HTMLInputElement>) => {
-    e?.preventDefault();
-    e?.stopPropagation();
-    searchImages(queryObject);
-  };
-
   useEffect(() => {
     searchImages(queryObject);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -199,12 +193,17 @@ const ImageSearch = ({
           placeholder={translations.searchPlaceholder}
           value={queryObject?.query}
           onChange={handleQueryChange}
+          onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
+            if (e.key === "Enter") {
+              searchImages(queryObject);
+            }
+          }}
         />
         <IconButton
           variant="primary"
           aria-label={translations.searchButtonTitle}
           title={translations.searchButtonTitle}
-          onClick={() => handleSubmit()}
+          onClick={() => searchImages(queryObject)}
         >
           <SearchLine />
         </IconButton>

--- a/packages/ndla-image-search/src/ImageSearch.tsx
+++ b/packages/ndla-image-search/src/ImageSearch.tsx
@@ -180,7 +180,7 @@ const ImageSearch = ({
     }));
   };
 
-  const onEnter = (e: KeyboardEvent<HTMLInputElement> | KeyboardEvent<HTMLButtonElement>) => {
+  const onEnter = (e: KeyboardEvent<HTMLInputElement | HTMLButtonElement>) => {
     if (e.key === "Enter") {
       searchImages(queryObject);
     }
@@ -232,6 +232,7 @@ const ImageSearch = ({
         translations={translations.paginationTranslations}
         count={searchResult?.totalCount ?? 0}
         pageSize={searchResult?.pageSize}
+        hidden={noResultsFound}
       >
         <PaginationPrevTrigger asChild>
           <StyledButton

--- a/packages/ndla-image-search/src/ImageSearch.tsx
+++ b/packages/ndla-image-search/src/ImageSearch.tsx
@@ -180,6 +180,12 @@ const ImageSearch = ({
     }));
   };
 
+  const onEnter = (e: KeyboardEvent<HTMLInputElement> | KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "Enter") {
+      searchImages(queryObject);
+    }
+  };
+
   useEffect(() => {
     searchImages(queryObject);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -193,16 +199,13 @@ const ImageSearch = ({
           placeholder={translations.searchPlaceholder}
           value={queryObject?.query}
           onChange={handleQueryChange}
-          onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
-            if (e.key === "Enter") {
-              searchImages(queryObject);
-            }
-          }}
+          onKeyDown={onEnter}
         />
         <IconButton
           variant="primary"
           aria-label={translations.searchButtonTitle}
           title={translations.searchButtonTitle}
+          onKeyDown={onEnter}
           onClick={() => searchImages(queryObject)}
         >
           <SearchLine />

--- a/packages/ndla-image-search/src/ImageSearch.tsx
+++ b/packages/ndla-image-search/src/ImageSearch.tsx
@@ -42,7 +42,7 @@ const StyledSearchResults = styled("div", {
   },
 });
 
-const StyledForm = styled("form", {
+const InputWrapper = styled("div", {
   base: {
     display: "flex",
     gap: "xsmall",
@@ -180,9 +180,9 @@ const ImageSearch = ({
     }));
   };
 
-  const handleSubmit = (e: KeyboardEvent<HTMLInputElement> | FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
+  const handleSubmit = (e?: KeyboardEvent<HTMLInputElement>) => {
+    e?.preventDefault();
+    e?.stopPropagation();
     searchImages(queryObject);
   };
 
@@ -193,7 +193,7 @@ const ImageSearch = ({
 
   return (
     <ImageSearchWrapper>
-      <StyledForm onSubmit={handleSubmit}>
+      <InputWrapper role="search">
         <Input
           type="search"
           placeholder={translations.searchPlaceholder}
@@ -202,13 +202,13 @@ const ImageSearch = ({
         />
         <IconButton
           variant="primary"
-          type="submit"
           aria-label={translations.searchButtonTitle}
           title={translations.searchButtonTitle}
+          onClick={() => handleSubmit()}
         >
           <SearchLine />
         </IconButton>
-      </StyledForm>
+      </InputWrapper>
       {noResultsFound && noResults}
       <StyledSearchResults>
         {searchResult?.results.map((image) => (

--- a/packages/ndla-video-search/src/VideoResultList.tsx
+++ b/packages/ndla-video-search/src/VideoResultList.tsx
@@ -66,7 +66,7 @@ export const VideoResultList = ({ videos, isLoading, translations, locale, onVid
           <Spinner />
         </SpinnerWrapper>
       )}
-      {!!videos.length && <Button onClick={onShowMore}>{translations.loadMoreVideos}</Button>}
+      {videos.length === 10 && <Button onClick={onShowMore}>{translations.loadMoreVideos}</Button>}
     </StyledVideoResultWrapper>
   );
 };

--- a/packages/ndla-video-search/src/VideoResultList.tsx
+++ b/packages/ndla-video-search/src/VideoResultList.tsx
@@ -36,6 +36,7 @@ const StyledVideoResultWrapper = styled("div", {
 
 interface Props {
   videos: BrightcoveApiType[];
+  existsMoreVideos: boolean;
   isLoading: boolean;
   translations: VideoTranslations;
   locale: string;
@@ -43,7 +44,15 @@ interface Props {
   onShowMore: () => void;
 }
 
-export const VideoResultList = ({ videos, isLoading, translations, locale, onVideoSelect, onShowMore }: Props) => {
+export const VideoResultList = ({
+  videos,
+  existsMoreVideos,
+  isLoading,
+  translations,
+  locale,
+  onVideoSelect,
+  onShowMore,
+}: Props) => {
   return (
     <StyledVideoResultWrapper>
       {!videos.length && !isLoading ? (
@@ -66,7 +75,7 @@ export const VideoResultList = ({ videos, isLoading, translations, locale, onVid
           <Spinner />
         </SpinnerWrapper>
       )}
-      {videos.length === 10 && <Button onClick={onShowMore}>{translations.loadMoreVideos}</Button>}
+      {existsMoreVideos && <Button onClick={onShowMore}>{translations.loadMoreVideos}</Button>}
     </StyledVideoResultWrapper>
   );
 };

--- a/packages/ndla-video-search/src/VideoSearch.tsx
+++ b/packages/ndla-video-search/src/VideoSearch.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { ChangeEvent, FormEvent, useCallback, useEffect, useState } from "react";
+import { ChangeEvent, useCallback, useEffect, useState } from "react";
 import { SearchLine } from "@ndla/icons/common";
 import { IconButton, Input } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
@@ -47,7 +47,7 @@ const VideoSearchWrapper = styled("div", {
   },
 });
 
-const StyledForm = styled("form", {
+const InputWrapper = styled("div", {
   base: {
     display: "flex",
     gap: "xsmall",
@@ -85,15 +85,10 @@ export const VideoSearch = ({ onVideoSelect, searchVideos, onError, translations
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const onSubmit = useCallback(
-    (e: FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
-      e.stopPropagation();
-      setOffset(0);
-      fetchVideos(query, offset);
-    },
-    [fetchVideos, offset, query],
-  );
+  const onSearch = useCallback(() => {
+    setOffset(0);
+    fetchVideos(query, offset);
+  }, [fetchVideos, offset, query]);
 
   const onShowMore = useCallback(() => {
     const newOffset = offset + 10;
@@ -107,17 +102,28 @@ export const VideoSearch = ({ onVideoSelect, searchVideos, onError, translations
 
   return (
     <VideoSearchWrapper>
-      <StyledForm onSubmit={onSubmit}>
-        <Input type="search" placeholder={translations.searchPlaceholder} value={query} onChange={onQueryChange} />
+      <InputWrapper role="search">
+        <Input
+          type="search"
+          placeholder={translations.searchPlaceholder}
+          value={query}
+          onChange={onQueryChange}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              onSearch();
+            }
+          }}
+        />
         <IconButton
           variant="primary"
           type="submit"
           aria-label={translations.searchButtonTitle}
           title={translations.searchButtonTitle}
+          onClick={onSearch}
         >
           <SearchLine />
         </IconButton>
-      </StyledForm>
+      </InputWrapper>
       <VideoResultList
         videos={videos}
         isLoading={isLoading}

--- a/packages/ndla-video-search/src/VideoSearch.tsx
+++ b/packages/ndla-video-search/src/VideoSearch.tsx
@@ -61,10 +61,9 @@ export const VideoSearch = ({ onVideoSelect, searchVideos, onError, translations
   const [offset, setOffset] = useState(0);
   const [videos, setVideos] = useState<BrightcoveApiType[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const previousQuery = usePrevious(query);
 
   const fetchVideos = useCallback(
-    async (query: string, offset: number) => {
+    async (query: string, offset: number, isAppending?: boolean) => {
       setIsLoading(true);
       try {
         const results = await searchVideos({
@@ -72,14 +71,13 @@ export const VideoSearch = ({ onVideoSelect, searchVideos, onError, translations
           offset: offset,
           limit: VIDEO_FETCH_LIMIT,
         });
-        const isAppending = query === previousQuery && offset !== 0;
         setVideos((prev) => (isAppending ? prev.concat(results) : results));
       } catch (e) {
         onError(e);
       }
       setIsLoading(false);
     },
-    [searchVideos, previousQuery, onError],
+    [searchVideos, onError],
   );
 
   useEffect(() => {
@@ -89,13 +87,13 @@ export const VideoSearch = ({ onVideoSelect, searchVideos, onError, translations
 
   const onSearch = useCallback(() => {
     setOffset(0);
-    fetchVideos(query, offset);
-  }, [fetchVideos, offset, query]);
+    fetchVideos(query, 0);
+  }, [fetchVideos, query]);
 
   const onShowMore = useCallback(() => {
-    const newOffset = offset + 10;
+    const newOffset = offset + VIDEO_FETCH_LIMIT;
     setOffset(newOffset);
-    fetchVideos(query, newOffset);
+    fetchVideos(query, newOffset, true);
   }, [fetchVideos, offset, query]);
 
   const onQueryChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
@@ -136,6 +134,7 @@ export const VideoSearch = ({ onVideoSelect, searchVideos, onError, translations
         locale={locale}
         onVideoSelect={onVideoSelect}
         onShowMore={onShowMore}
+        existsMoreVideos={videos.length === offset + VIDEO_FETCH_LIMIT}
       />
     </VideoSearchWrapper>
   );

--- a/packages/ndla-video-search/src/VideoSearch.tsx
+++ b/packages/ndla-video-search/src/VideoSearch.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { ChangeEvent, useCallback, useEffect, useState } from "react";
+import { ChangeEvent, useCallback, useEffect, useState, KeyboardEvent } from "react";
 import { SearchLine } from "@ndla/icons/common";
 import { IconButton, Input } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
@@ -54,6 +54,8 @@ const InputWrapper = styled("div", {
   },
 });
 
+const VIDEO_FETCH_LIMIT = 10;
+
 export const VideoSearch = ({ onVideoSelect, searchVideos, onError, translations, locale }: Props) => {
   const [query, setQuery] = useState("");
   const [offset, setOffset] = useState(0);
@@ -65,12 +67,12 @@ export const VideoSearch = ({ onVideoSelect, searchVideos, onError, translations
     async (query: string, offset: number) => {
       setIsLoading(true);
       try {
-        const isAppending = query === previousQuery;
         const results = await searchVideos({
           query,
           offset: offset,
-          limit: 10,
+          limit: VIDEO_FETCH_LIMIT,
         });
+        const isAppending = query === previousQuery && offset !== 0;
         setVideos((prev) => (isAppending ? prev.concat(results) : results));
       } catch (e) {
         onError(e);
@@ -100,6 +102,12 @@ export const VideoSearch = ({ onVideoSelect, searchVideos, onError, translations
     setQuery(e.target.value);
   }, []);
 
+  const onEnter = (e: KeyboardEvent<HTMLInputElement> | KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "Enter") {
+      onSearch();
+    }
+  };
+
   return (
     <VideoSearchWrapper>
       <InputWrapper role="search">
@@ -108,17 +116,14 @@ export const VideoSearch = ({ onVideoSelect, searchVideos, onError, translations
           placeholder={translations.searchPlaceholder}
           value={query}
           onChange={onQueryChange}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              onSearch();
-            }
-          }}
+          onKeyDown={onEnter}
         />
         <IconButton
           variant="primary"
           type="submit"
           aria-label={translations.searchButtonTitle}
           title={translations.searchButtonTitle}
+          onKeyDown={onEnter}
           onClick={onSearch}
         >
           <SearchLine />

--- a/packages/ndla-video-search/src/VideoSearch.tsx
+++ b/packages/ndla-video-search/src/VideoSearch.tsx
@@ -100,7 +100,7 @@ export const VideoSearch = ({ onVideoSelect, searchVideos, onError, translations
     setQuery(e.target.value);
   }, []);
 
-  const onEnter = (e: KeyboardEvent<HTMLInputElement> | KeyboardEvent<HTMLButtonElement>) => {
+  const onEnter = (e: KeyboardEvent<HTMLInputElement | HTMLButtonElement>) => {
     if (e.key === "Enter") {
       onSearch();
     }


### PR DESCRIPTION
fikser at artikkelredigerings sidene refreshes når man klikker søk i editoren hvor komponenten er brukt, EG. kampanjeblokk.

Når den blir brukt i andre forms så vil search knappen sin submit sende submit til parent form også. 

Form rundt et søke input trengs vell strengt tatt ikke så lenge man har riktig aria roler? 🤔 