### PR TITLE
add placeholder color

### DIFF
--- a/packages/primitives/src/Input.stories.tsx
+++ b/packages/primitives/src/Input.stories.tsx
@@ -30,7 +30,7 @@ export const Default: StoryFn<typeof Input> = () => <Input />;
 export const WithLeftDecorative: StoryFn<typeof Input> = () => (
   <InputContainer>
     <SearchLine />
-    <Input />
+    <Input placeholder="Placeholder" />
   </InputContainer>
 );
 

--- a/packages/primitives/src/Input.tsx
+++ b/packages/primitives/src/Input.tsx
@@ -99,6 +99,9 @@ const baseInputCss = css.raw({
   _focus: {
     appearance: "none",
   },
+  _placeholder: {
+    color: "text.subtle",
+  },
 });
 
 const baseTextAreaCss = css.raw({


### PR DESCRIPTION
funker på firefox men ikke chrome.. noen forslag? chrome reagerer på `font-weight`, `background-color` og `font-size` endringer men ikke `color` 🤔

"fikser": https://trello.com/c/B5akWzcI/126-for-lav-kontrast-p%C3%A5-hjelpetekst