### PR TITLE
Allow scrolling in iframe

### DIFF
--- a/packages/ndla-ui/src/Embed/IframeEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/IframeEmbed.tsx
@@ -21,6 +21,7 @@ interface Props {
 const StyledIframe = styled("iframe", {
   base: {
     width: "100%",
+    border: 0,
   },
 });
 
@@ -76,11 +77,7 @@ const IframeEmbed = ({ embed }: Props) => {
         src={url}
         width={strippedWidth}
         height={strippedHeight}
-        // eslint-disable-next-line react/no-unknown-property
-        allowFullScreen
-        allow="encrypted-media"
-        scrolling="no"
-        frameBorder="0"
+        allow="fullscreen; encrypted-media"
         loading="lazy"
       />
     </Figure>


### PR DESCRIPTION
BM sjekker om vi kan gjøre dette. :heavy_check_mark: 

Dette gjør at alt av iframes kan scrolles ved behov. Klarert av Sverre, Johannes og Hedvig.