### PR TITLE
refactor: move code block css to global css.

### DIFF
--- a/packages/ndla-ui/src/CodeBlock/CodeBlock.tsx
+++ b/packages/ndla-ui/src/CodeBlock/CodeBlock.tsx
@@ -16,97 +16,21 @@ interface Props extends JsxStyleProps, ComponentPropsWithRef<"pre"> {
   format: string;
 }
 
-const Pre = styled("pre", {
-  base: {
-    border: "1px solid",
-    borderColor: "stroke.subtle",
-    borderLeft: "4px solid",
-    borderLeftColor: "stroke.default",
-    borderRadius: "xsmall",
-    boxSizing: "border-box",
-    overflowX: "auto",
-    textStyle: "label.medium",
-    fontFamily: "code",
-    display: "block",
-    whiteSpace: "pre",
-    "& .linenumber": {
-      display: "inline-block",
-      paddingBlock: "0",
-      paddingInline: "small",
-      borderRight: "1px solid",
-      borderColor: "stroke.subtle",
-      width: "xxlarge",
-      textAlign: "right",
-      marginInlineEnd: "xsmall",
-    },
-    "& .linenumber[data-first]": {
-      paddingBlockStart: "xsmall",
-    },
-    "& .linenumber[data-last]": {
-      paddingBlockEnd: "xsmall",
-    },
-    // The remaining css is copied from the coy theme in prismjs. A lot of css is omitted due to styling clashes
-    "& .token.comment, .token.block-comment, .token.prolog, .token.doctype, .token.cdata": {
-      color: "#7d8b99",
-    },
-    "& .token.punctuation": {
-      color: "#5f6364",
-    },
-    "& .token.property, .token.tag, .token.boolean, .token.number, .token.function-name, .token.constant, .token.symbol, .token.deleted":
-      {
-        color: "#c92c2c",
-      },
-    "& .token.selector, .token.attr-name, .token.string, .token.char, .token.function, .token.builtin, .token.inserted":
-      {
-        color: "#2f9c0a",
-      },
-    "& .token.operator, .token.entity, .token.url, .token.variable": {
-      color: "#a67f59",
-      background: "rgba(255, 255, 255, 0.5)",
-    },
-    "& .token.atrule, .token.attr-value, .token.keyword, .token.class-name": {
-      color: "#1990b8",
-    },
-    "& .token.regex, .token.important": {
-      color: "#e90",
-    },
-    "& .language-css .token.string, .style .token.string": {
-      color: "#a67f59",
-      background: "rgba(255, 255, 255, 0.5)",
-    },
-    "& .token.important": {
-      fontWeight: "normal",
-    },
-    "& .token.bold": {
-      fontWeight: "bold",
-    },
-    "& .token.italic": {
-      fontStyle: "italic",
-    },
-    "& .token.entity": {
-      cursor: "help",
-    },
-    "& .token.namespace": {
-      opacity: "0.7",
-    },
-  },
-});
+const Pre = styled("pre", {});
 
 export const Codeblock = forwardRef<HTMLPreElement, Props>(({ highlightedCode, format, className, ...props }, ref) => {
   const codeWithLineNumbers = useMemo(() => {
     return highlightedCode
       .split("\n")
-      .map((line, i, arr) => {
-        return `<span><span class="linenumber" ${i === 0 ? 'data-first=""' : ""} ${
-          i === arr.length - 1 ? 'data-last=""' : ""
-        }>${i + 1}</span>${line}</span>`;
+      .map((line, i) => {
+        return `<span class="linenumber">${i + 1}</span>${line}`;
       })
       .join("\n");
   }, [highlightedCode]);
 
   return (
     <Pre
-      className={cx(`language-${format}`, className)}
+      className={cx("codeblock", `language-${format}`, className)}
       {...props}
       dangerouslySetInnerHTML={{ __html: codeWithLineNumbers }}
       ref={ref}

--- a/packages/preset-panda/src/globalCss.ts
+++ b/packages/preset-panda/src/globalCss.ts
@@ -147,4 +147,77 @@ export const globalCss = defineGlobalStyles({
       color: "text.linkVisited",
     },
   },
+  ".codeblock": {
+    border: "1px solid",
+    borderColor: "stroke.subtle",
+    borderLeft: "4px solid",
+    borderLeftColor: "stroke.default",
+    borderRadius: "xsmall",
+    boxSizing: "border-box",
+    overflowX: "auto",
+    textStyle: "label.medium",
+    fontFamily: "code",
+    display: "block",
+    whiteSpace: "pre",
+    "& .linenumber": {
+      display: "inline-block",
+      paddingBlock: "0",
+      paddingInline: "small",
+      borderRight: "1px solid",
+      borderColor: "stroke.subtle",
+      width: "xxlarge",
+      textAlign: "right",
+      marginInlineEnd: "xsmall",
+    },
+    "& :nth-child(1 of .linenumber)": {
+      paddingBlockStart: "xsmall",
+    },
+    "& :nth-last-child(1 of .linenumber)": {
+      paddingBlockEnd: "xsmall",
+    },
+    // The remaining css is copied from the coy theme in prismjs. A lot of css is omitted due to styling clashes
+    "& .token.comment, .token.block-comment, .token.prolog, .token.doctype, .token.cdata": {
+      color: "#7d8b99",
+    },
+    "& .token.punctuation": {
+      color: "#5f6364",
+    },
+    "& .token.property, .token.tag, .token.boolean, .token.number, .token.function-name, .token.constant, .token.symbol, .token.deleted":
+      {
+        color: "#c92c2c",
+      },
+    "& .token.selector, .token.attr-name, .token.string, .token.char, .token.function, .token.builtin, .token.inserted":
+      {
+        color: "#2f9c0a",
+      },
+    "& .token.operator, .token.entity, .token.url, .token.variable": {
+      color: "#a67f59",
+      background: "rgba(255, 255, 255, 0.5)",
+    },
+    "& .token.atrule, .token.attr-value, .token.keyword, .token.class-name": {
+      color: "#1990b8",
+    },
+    "& .token.regex, .token.important": {
+      color: "#e90",
+    },
+    "& .language-css .token.string, .style .token.string": {
+      color: "#a67f59",
+      background: "rgba(255, 255, 255, 0.5)",
+    },
+    "& .token.important": {
+      fontWeight: "normal",
+    },
+    "& .token.bold": {
+      fontWeight: "bold",
+    },
+    "& .token.italic": {
+      fontStyle: "italic",
+    },
+    "& .token.entity": {
+      cursor: "help",
+    },
+    "& .token.namespace": {
+      opacity: "0.7",
+    },
+  },
 });


### PR DESCRIPTION
This allows us to more easily reuse the styling in ED. 

Kan testes med https://github.com/NDLANO/editorial-frontend/pull/2471