### PR TITLE
fix: remove inline padding on InlineTriggerButton, avoiding double spacing

### DIFF
--- a/packages/ndla-ui/src/Embed/InlineTriggerButton.tsx
+++ b/packages/ndla-ui/src/Embed/InlineTriggerButton.tsx
@@ -18,7 +18,6 @@ const StyledSpan = styled("span", {
     borderStyle: "dashed",
     borderColor: "stroke.hover",
     paddingBlockStart: "5xsmall",
-    paddingInline: "4xsmall",
     width: "fit-content",
     cursor: "pointer",
     _hover: {


### PR DESCRIPTION
Fixes https://trello.com/c/QuvOfwmT/262-dobble-mellomrom-mellom-forklaringer-og-ordene-rundt