### PR TITLE
fix: apply overflow: "hidden" to framed content to ensure floated content remains inside

### DIFF
--- a/packages/primitives/src/FramedContent.tsx
+++ b/packages/primitives/src/FramedContent.tsx
@@ -18,6 +18,7 @@ const framedContentRecipe = cva({
     border: "1px solid",
     borderRadius: "small",
     clear: "both",
+    overflow: "hidden",
   },
   variants: {
     colorTheme: {


### PR DESCRIPTION
Fixes https://trello.com/c/Z6BGV4nJ/261-et-bilde-i-tekstboksen-faller-utenfor-tekstboksen