### PR TITLE
fix: ensure that re-styled complex components that are aschilded onto a non-complex component still consumes its css prop.

### DIFF
--- a/packages/preset-panda/src/plugins/__tests__/forwardCssProp-test.tsx
+++ b/packages/preset-panda/src/plugins/__tests__/forwardCssProp-test.tsx
@@ -365,6 +365,54 @@ describe("CSS prop forwarding", () => {
     `);
   });
 
+  test("converts itself to a class name when re-styled and asChilded onto a regular component", () => {
+    const StyledContainer = styled(
+      ark.div,
+      {
+        base: {
+          display: "flex",
+        },
+      },
+      { baseComponent: true },
+    );
+
+    const StyledStyledContainer = styled(StyledContainer, {
+      base: {
+        display: "block",
+      },
+    });
+
+    const StyledStyledStyledContainer = styled(StyledStyledContainer, {
+      base: {
+        display: "inline",
+      },
+    });
+
+    const { container } = render(
+      <StyledStyledStyledContainer asChild consumeCss>
+        <span>Hello</span>
+      </StyledStyledStyledContainer>,
+    );
+
+    const notAsChildedResult = render(<StyledStyledStyledContainer>Hello</StyledStyledStyledContainer>);
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <span
+        class="d_inline"
+      >
+        Hello
+      </span>
+    `);
+
+    expect(notAsChildedResult.container.firstChild).toMatchInlineSnapshot(`
+      <div
+        class="d_inline"
+      >
+        Hello
+      </div>
+    `);
+  });
+
   test("should automatically merge complex components wrapped in styled and asChilded to a non-complex component", () => {
     const StyledBase = styled(
       ark.div,

--- a/packages/preset-panda/src/plugins/forwardCssPropPlugin.ts
+++ b/packages/preset-panda/src/plugins/forwardCssPropPlugin.ts
@@ -56,7 +56,7 @@ export const transformStyledFn = (args: CodegenPrepareHookArgs) => {
     `const { as: Element = __base__, consumeCss, children, ...restProps } = props
 
     const consume = props.asChild
-      ? consumeCss && options.baseComponent
+      ? consumeCss && (options.baseComponent || Dynamic.__baseComponent__)
       : consumeCss ?? contextConsume`,
   );
 
@@ -73,6 +73,14 @@ export const transformStyledFn = (args: CodegenPrepareHookArgs) => {
   factoryJs.code = factoryJs.code.replace(
     "className: classes()",
     `...(consume ? { className: classes() } : { css: classes(), consumeCss } )`,
+  );
+
+  const styledComponentForwardPropDeclaration = `StyledComponent.__shouldForwardProps__ = shouldForwardProp`;
+
+  factoryJs.code = factoryJs.code.replace(
+    styledComponentForwardPropDeclaration,
+    `${styledComponentForwardPropDeclaration}
+  StyledComponent.__baseComponent__ = options.baseComponent ?? Dynamic.__baseComponent__`,
   );
 
   const shouldForwardPropCode = "shouldForwardProp?(prop: string, variantKeys: string[]): boolean";

--- a/packages/styled-system/src/jsx/factory.js
+++ b/packages/styled-system/src/jsx/factory.js
@@ -24,7 +24,7 @@ function styledFn(Dynamic, configOrCva = {}, options = {}) {
     const { as: Element = __base__, consumeCss, children, ...restProps } = props
 
     const consume = props.asChild
-      ? consumeCss && options.baseComponent
+      ? consumeCss && (options.baseComponent || Dynamic.__baseComponent__)
       : consumeCss ?? contextConsume
 
     const combinedProps = useMemo(() => Object.assign({}, defaultProps, restProps), [restProps])
@@ -65,6 +65,7 @@ function styledFn(Dynamic, configOrCva = {}, options = {}) {
   StyledComponent.__cva__ = __cvaFn__
   StyledComponent.__base__ = __base__
   StyledComponent.__shouldForwardProps__ = shouldForwardProp
+  StyledComponent.__baseComponent__ = options.baseComponent ?? Dynamic.__baseComponent__
 
   return StyledComponent
 }


### PR DESCRIPTION
Testen som er lagt til ville feilet før denne endringen ble gjort. Har kjent på dette to ganger i ED, og aldri i ndla-frontend. Fortsatt fint å fikse.