### PR TITLE
feat: support `asChild` for both `ExpandableBox` and `ExpandableBoxSummary`

### DIFF
--- a/packages/preset-panda/src/globalCss.ts
+++ b/packages/preset-panda/src/globalCss.ts
@@ -70,7 +70,7 @@ export const globalCss = defineGlobalStyles({
     width: "100%",
 
     // Non-figure block elements that should have margin above and below.
-    '& details, :not(li) > blockquote, [data-embed-type="framed-content"], [data-embed-type="factbox"], table, [data-embed-type="related-content-list"], [data-embed-type="link-block-list"], [data-embed-type="blog-post"], [data-embed-type="campaign-block"], [data-embed-type="key-figure"], [data-embed-type="grid"], [data-embed-type="contact-block"], [data-embed-type="file-list"], [data-embed-type="uu-disclaimer"]':
+    '& details, :not(li) > blockquote, [data-embed-type="expandable-box"], [data-embed-type="framed-content"], [data-embed-type="factbox"], table, [data-embed-type="related-content-list"], [data-embed-type="link-block-list"], [data-embed-type="blog-post"], [data-embed-type="campaign-block"], [data-embed-type="key-figure"], [data-embed-type="grid"], [data-embed-type="contact-block"], [data-embed-type="file-list"], [data-embed-type="uu-disclaimer"]':
       {
         marginBlockStart: "xxlarge",
         marginBlockEnd: "xxlarge",
@@ -81,7 +81,7 @@ export const globalCss = defineGlobalStyles({
       },
 
     // Article content is usually wrapped in a section. The rest of the elements in this list contains other elements, and should add margin to them no matter where they are placed in the DOM.
-    '& section:not([class]), section:not([class]) > div:not([class]), [data-embed-type="framed-content"], [data-embed-type="grid"] > div, [data-embed-type="grid-parallax"] > div, [data-embed-type="factbox"] > div, [data-embed-type="copyright"] > [data-copyright-content], [data-embed-type="uu-disclaimer"] > [data-uu-content], [data-embed-wrapper], details, blockquote':
+    '& section:not([class]), section:not([class]) > div:not([class]), [data-embed-type="framed-content"], [data-embed-type="grid"] > div, [data-embed-type="grid-parallax"] > div, [data-embed-type="factbox"] > div, [data-embed-type="copyright"] > [data-copyright-content], [data-embed-type="uu-disclaimer"] > [data-uu-content], [data-embed-wrapper], details, [data-embed-type="expandable-box"] blockquote':
       {
         '& > :is(h2, [data-embed-type="copy-heading"])': {
           marginBlockStart: "xlarge",

--- a/packages/primitives/src/ExpandableBox.tsx
+++ b/packages/primitives/src/ExpandableBox.tsx
@@ -6,34 +6,43 @@
  *
  */
 
+import { forwardRef } from "react";
 import { HTMLArkProps, ark } from "@ark-ui/react";
 import { styled } from "@ndla/styled-system/jsx";
 import { JsxStyleProps } from "@ndla/styled-system/types";
 
 export type ExpandableBoxProps = HTMLArkProps<"details"> & JsxStyleProps;
 
-export const ExpandableBox = styled("details", {
-  base: {
-    transitionDuration: "fast",
-    width: "100%",
-    position: "relative",
-    border: "1px solid",
-    borderRadius: "xsmall",
-    borderColor: "stroke.subtle",
-    padding: "medium",
-    clear: "both",
-    _open: {
+const StyledExpandableBox = styled(
+  ark.details,
+  {
+    base: {
+      transitionDuration: "fast",
+      width: "100%",
+      position: "relative",
+      border: "1px solid",
+      borderRadius: "xsmall",
+      borderColor: "stroke.subtle",
       padding: "medium",
-      "& summary": {
-        marginBlockEnd: "-xxsmall",
+      clear: "both",
+      _open: {
+        padding: "medium",
+        "& summary, [data-embed-type='expandable-box-summary']": {
+          marginBlockEnd: "-xxsmall",
+        },
       },
     },
   },
-});
+  { baseComponent: true },
+);
+
+export const ExpandableBox = forwardRef<HTMLDetailsElement, ExpandableBoxProps>((props, ref) => (
+  <StyledExpandableBox {...props} data-embed-type="expandable-box" ref={ref} />
+));
 
 export type ExpandableBoxSummaryProps = HTMLArkProps<"summary"> & JsxStyleProps;
 
-export const ExpandableBoxSummary = styled(
+const StyledExpandableBoxSummary = styled(
   ark.summary,
   {
     base: {
@@ -52,3 +61,7 @@ export const ExpandableBoxSummary = styled(
   },
   { baseComponent: true },
 );
+
+export const ExpandableBoxSummary = forwardRef<HTMLElement, ExpandableBoxSummaryProps>((props, ref) => (
+  <StyledExpandableBoxSummary {...props} data-embed-type="expandable-box-summary" ref={ref} />
+));


### PR DESCRIPTION
Stilen skal anvendes likt uavhengig av hva vi faktisk rendrer.