### PR TITLE
fix: only show intense background on hover

### DIFF
--- a/packages/primitives/src/Card/Card.tsx
+++ b/packages/primitives/src/Card/Card.tsx
@@ -58,7 +58,9 @@ const cardRecipe = sva({
       subtle: {},
       intense: {
         root: {
-          background: "surface.actionSubtle.hover",
+          _hover: {
+            background: "surface.actionSubtle.hover",
+          },
         },
       },
     },


### PR DESCRIPTION
Surr