### PR TITLE
Makes strong text in header same weight as header

### DIFF
--- a/packages/preset-panda/src/globalCss.ts
+++ b/packages/preset-panda/src/globalCss.ts
@@ -21,6 +21,9 @@ export const globalCss = defineGlobalStyles({
     // this is included in the css reset we use. We don't want it.
     "& h1, h2, h3, h4, h5, h6": {
       textWrap: "unset",
+      "& b, strong": {
+        fontWeight: "bold",
+      },
     },
   },
   body: {


### PR DESCRIPTION
`strong` vises som `bolder` i generert css. Dette tvinger strong i header til å være berre bold. På ingen måte gitt at dette er den beste måten å gjøre det på.

https://trello.com/c/j3weZTYZ/264-fet-overskrift-skal-ikke-vises

Kan sjekkes på http://localhost:3000/article/38557 etter å ha linka inn i ndla-frontend.