### PR TITLE
move visually interpreted button

### DIFF
--- a/packages/ndla-ui/src/Embed/BrightcoveEmbed.tsx
+++ b/packages/ndla-ui/src/Embed/BrightcoveEmbed.tsx
@@ -25,7 +25,7 @@ interface Props {
 
 const LinkedVideoButton = styled(Button, {
   base: {
-    marginInlineStart: "xsmall",
+    marginBlockStart: "3xsmall",
   },
 });
 
@@ -117,11 +117,13 @@ const BrightcoveEmbed = ({ embed, renderContext = "article", lang }: Props) => {
         />
       </div>
       <EmbedByline type="video" copyright={data.copyright!} description={parsedDescription}>
-        {!!linkedVideoId && (
-          <LinkedVideoButton size="small" variant="secondary" onClick={() => setShowOriginalVideo((p) => !p)}>
-            {t(`figure.button.${!showOriginalVideo ? "original" : "alternative"}`)}
-          </LinkedVideoButton>
-        )}
+        <div>
+          {!!linkedVideoId && (
+            <LinkedVideoButton size="small" variant="secondary" onClick={() => setShowOriginalVideo((p) => !p)}>
+              {t(`figure.button.${!showOriginalVideo ? "original" : "alternative"}`)}
+            </LinkedVideoButton>
+          )}
+        </div>
       </EmbedByline>
     </Figure>
   );


### PR DESCRIPTION
Problemet oppstår når byline går over 2 linjer og det er ikke nok plass til knappen. Flytter knappen under byline-teksten og la til litt margin (visuelt godkjent av Hedvig)

[trello](https://trello.com/c/b0DxBgUA/304-synstolketknappen-ser-litt-tilfeldig-plassert-ut)