### PR TITLE
fix: do not define `to` as a string in SafeLink buttons

### DIFF
--- a/packages/safelink/src/SafeLinkButton.tsx
+++ b/packages/safelink/src/SafeLinkButton.tsx
@@ -13,7 +13,6 @@ import { SafeLink, SafeLinkProps } from "./SafeLink";
 
 export interface SafeLinkButtonProps extends SafeLinkProps, ButtonVariantProps {
   children: ReactNode;
-  to: string;
 }
 
 export const SafeLinkButton = forwardRef<HTMLAnchorElement, SafeLinkButtonProps>(

--- a/packages/safelink/src/SafeLinkIconButton.tsx
+++ b/packages/safelink/src/SafeLinkIconButton.tsx
@@ -13,7 +13,6 @@ import { SafeLink, SafeLinkProps } from "./SafeLink";
 
 export interface SafeLinkIconButtonProps extends SafeLinkProps, IconButtonVariantProps {
   children: ReactNode;
-  to: string;
 }
 
 export const SafeLinkIconButton = forwardRef<HTMLAnchorElement, SafeLinkIconButtonProps>(


### PR DESCRIPTION
Fører til en typefeil i ndla-frontend, men det kan vi nok rydde opp i. Dette er mer riktig.