### PR TITLE
fix: always set xmlns on math elements

### DIFF
--- a/packages/article-converter/src/plugins/mathPlugin.tsx
+++ b/packages/article-converter/src/plugins/mathPlugin.tsx
@@ -10,6 +10,8 @@ import { attributesToProps } from "html-react-parser";
 import { PluginType } from "./types";
 export const mathPlugin: PluginType = (node) => {
   const { "data-math": mathContent, ...props } = attributesToProps(node.attribs);
-  // @ts-ignore
-  return <math {...props} dangerouslySetInnerHTML={{ __html: mathContent }} />;
+  return (
+    // @ts-ignore
+    <math xmlns="http://www.w3.org/1998/Math/MathML" {...props} dangerouslySetInnerHTML={{ __html: mathContent }} />
+  );
 };


### PR DESCRIPTION
Det er ikke alltid gitt at `xmlns` er satt på matte-elementet som kommer fra gql; Noen ganger har vi strippet bort det nøstede matte-elementet som inneholder attributten. 