### PR TITLE
Use `CET` when rendering date instead of `UTC`

### DIFF
--- a/packages/ndla-ui/src/LinkBlock/LinkBlock.tsx
+++ b/packages/ndla-ui/src/LinkBlock/LinkBlock.tsx
@@ -78,7 +78,7 @@ const LinkBlock = ({ title, articleLanguage, date, url, path }: Props) => {
   const formattedDate = useMemo(() => {
     if (!date) return null;
     return new Intl.DateTimeFormat(articleLanguage, {
-      timeZone: "UTC",
+      timeZone: "CET",
       day: "2-digit",
       month: "long",
       year: "numeric",


### PR DESCRIPTION
Vi har vel mye større sjanse for å få brukere fra norge enn fra andre plasser.

Ideelt sett så burde vi sikkert droppet serverside rendering for alle datoer, men kanskje litt for mye hassle?