### PR TITLE
fix: constrain select and combobox height

### DIFF
--- a/packages/primitives/src/Combobox.tsx
+++ b/packages/primitives/src/Combobox.tsx
@@ -33,7 +33,7 @@ const comboboxRecipe = sva({
       zIndex: "dropdown",
       background: "surface.default",
       overflowY: "auto",
-      maxHeight: "surface.xsmall",
+      maxHeight: "min(token(spacing.surface.xsmall), 45vh)",
       _open: {
         animation: "fade-shift-in 0.25s ease-out",
         _motionReduce: {

--- a/packages/primitives/src/Select.tsx
+++ b/packages/primitives/src/Select.tsx
@@ -37,7 +37,7 @@ const selectRecipe = sva({
       boxShadow: "large",
       padding: "xsmall",
       overflowY: "auto",
-      maxHeight: "surface.xsmall",
+      maxHeight: "min(token(spacing.surface.xsmall), 45vh)",
       _focusVisible: {
         outlineOffset: "-1",
       },


### PR DESCRIPTION
Begrenser høyde på select og combobox så de alltid vil være synlige innenfor viewporten sin. 