### PR TITLE
Set full size on images given maxHeight limitation

### DIFF
--- a/packages/ndla-image-search/src/ImageSearchResult.tsx
+++ b/packages/ndla-image-search/src/ImageSearchResult.tsx
@@ -24,6 +24,8 @@ const StyledButton = styled(Button, {
 const StyledImage = styled(Image, {
   base: {
     maxHeight: "135px",
+    width: "100%",
+    height: "100%",
   },
 });
 


### PR DESCRIPTION
fikser https://trello.com/c/BGtwVU3O/1140-viser-ikke-svg-preview-i-bildes%C3%B8k-fra-artikkel