### PR TITLE
feat: add more badge variants

### DIFF
--- a/packages/primitives/src/Badge.stories.tsx
+++ b/packages/primitives/src/Badge.stories.tsx
@@ -45,3 +45,24 @@ export const Brand3: StoryObj<typeof Badge> = {
     children: "Læringssti",
   },
 };
+
+export const Success: StoryObj<typeof Badge> = {
+  args: {
+    colorTheme: "success",
+    children: "Endret",
+  },
+};
+
+export const Warning: StoryObj<typeof Badge> = {
+  args: {
+    colorTheme: "warning",
+    children: "Noe skurrer...",
+  },
+};
+
+export const Danger: StoryObj<typeof Badge> = {
+  args: {
+    colorTheme: "danger",
+    children: "Pass på!",
+  },
+};

--- a/packages/primitives/src/Badge.tsx
+++ b/packages/primitives/src/Badge.tsx
@@ -42,6 +42,18 @@ const badgeRecipe = cva({
         backgroundColor: "surface.infoSubtle",
         borderColor: "stroke.default",
       },
+      danger: {
+        backgroundColor: "surface.dangerSubtle",
+        borderColor: "surface.danger",
+      },
+      success: {
+        backgroundColor: "surface.successSubtle",
+        borderColor: "surface.success",
+      },
+      warning: {
+        backgroundColor: "surface.warningSubtle",
+        borderColor: "surface.warning",
+      },
     },
   },
 });


### PR DESCRIPTION
`warning`-varianten innfrir egentlig ikke kontrastkrav, men det vil endre seg når vi endrer på gulfargene vi bruker. Skal kun brukes i ED inntil videre uansett