### PR TITLE
Show colored variant when variant is colored and contentType does not exist

### DIFF
--- a/packages/ndla-ui/src/ContentTypeBlockQuote/ContentTypeBlockQuote.tsx
+++ b/packages/ndla-ui/src/ContentTypeBlockQuote/ContentTypeBlockQuote.tsx
@@ -26,11 +26,7 @@ interface Props extends Omit<BlockQuoteProps, "variant"> {
 }
 
 export const ContentTypeBlockQuote = forwardRef<HTMLQuoteElement, Props>(({ variant, contentType, ...props }, ref) => {
-  return (
-    <BlockQuote
-      {...props}
-      variant={variant === "colored" && contentType ? contentTypeToVariantMapping[contentType] : undefined}
-      ref={ref}
-    />
-  );
+  const color = contentType ? (contentTypeToVariantMapping[contentType] ?? "brand1") : "brand1";
+  const variantColor = variant === "colored" ? color : undefined;
+  return <BlockQuote {...props} variant={variantColor} ref={ref} />;
 });

--- a/packages/ndla-ui/src/ContentTypeFramedContent/ContentTypeFramedContent.tsx
+++ b/packages/ndla-ui/src/ContentTypeFramedContent/ContentTypeFramedContent.tsx
@@ -27,12 +27,8 @@ interface Props extends FramedContentProps {
 
 export const ContentTypeFramedContent = forwardRef<HTMLDivElement, Props>(
   ({ variant = "neutral", contentType, ...props }, ref) => {
-    return (
-      <FramedContent
-        {...props}
-        colorTheme={variant === "colored" && contentType ? contentTypeToVariantMapping[contentType] : undefined}
-        ref={ref}
-      />
-    );
+    const color = contentType ? (contentTypeToVariantMapping[contentType] ?? "brand1") : "brand1";
+    const variantColor = variant === "colored" ? color : undefined;
+    return <FramedContent {...props} colorTheme={variantColor} ref={ref} />;
   },
 );


### PR DESCRIPTION
https://trello.com/c/XrulHWyQ/1238-forh%C3%A5ndsvisning-i-ed-viser-ikke-farge-p%C3%A5-tekstboks-hvis-denne-er-satt

Jeg syntes det gir mening at vi viser en default-farge når variant er satt til colored og ingen contentType eksisterer 🤔 