### PR TITLE
Forcing the lists in articles to follow specific style build up

### DIFF
--- a/packages/primitives/src/ArticleLists.tsx
+++ b/packages/primitives/src/ArticleLists.tsx
@@ -153,7 +153,7 @@ export const UnOrderedList = styled("ul", {
     listStyle: "revert",
     marginInlineStart: "medium",
     paddingInlineStart: "small",
-    "&  ul": {
+    "& ul": {
       marginInlineStart: "0",
     },
     "& li": {
@@ -161,6 +161,14 @@ export const UnOrderedList = styled("ul", {
       paddingInlineStart: "small",
       _marker: {
         color: "icon.strong",
+      },
+    },
+
+    listStyleType: "disc",
+    "& > li > ul": {
+      listStyleType: "square",
+      "& > li > ul": {
+        listStyleType: "circle",
       },
     },
   },

--- a/packages/primitives/src/ArticleLists.tsx
+++ b/packages/primitives/src/ArticleLists.tsx
@@ -22,6 +22,9 @@ const orderedListRecipe = cva({
     marginInlineStart: "small",
     paddingInlineStart: "small",
     [LIST_ITEM]: {
+      "& > ul": {
+        marginInlineStart: "0 !important",
+      },
       _before: {
         position: "absolute",
         transform: "translateX(calc(-100% + (token(spacing.small) * -1)))",
@@ -161,6 +164,10 @@ export const UnOrderedList = styled("ul", {
       paddingInlineStart: "small",
       _marker: {
         color: "icon.strong",
+      },
+
+      "& > ol": {
+        marginInlineStart: "0 !important",
       },
     },
 

--- a/packages/primitives/src/ArticleLists.tsx
+++ b/packages/primitives/src/ArticleLists.tsx
@@ -166,9 +166,9 @@ export const UnOrderedList = styled("ul", {
 
     listStyleType: "disc",
     "& > li > ul": {
-      listStyleType: "square",
+      listStyleType: "circle",
       "& > li > ul": {
-        listStyleType: "circle",
+        listStyleType: "square",
       },
     },
   },

--- a/packages/primitives/src/ArticleOrderedList.stories.tsx
+++ b/packages/primitives/src/ArticleOrderedList.stories.tsx
@@ -8,7 +8,7 @@
 
 import type { Meta, StoryFn, StoryObj } from "@storybook/react";
 import { ArticleContent, ArticleWrapper } from "@ndla/ui";
-import { OrderedList } from "./ArticleLists";
+import { OrderedList, UnOrderedList } from "./ArticleLists";
 import { BlockQuote } from "./BlockQuote";
 import { PageContent } from "./Layout/PageContent";
 
@@ -322,4 +322,27 @@ export const ListsBelowEachOther: StoryFn = () => (
       <li>Listepunkt 3</li>
     </OrderedList>
   </>
+);
+
+export const WithNestedUnOrderedList: StoryFn = () => (
+  <OrderedList>
+    <li>
+      Listepunkt 1
+      <OrderedList>
+        <li>Listepunkt 2</li>
+      </OrderedList>
+    </li>
+    <li>Listepunkt 3</li>
+    <li>
+      Listepunkt 4
+      <UnOrderedList>
+        <li>
+          Listepunkt 5
+          <UnOrderedList>
+            <li>Listepunkt 6</li>
+          </UnOrderedList>
+        </li>
+      </UnOrderedList>
+    </li>
+  </OrderedList>
 );

--- a/packages/primitives/src/ArticleUnorderedList.stories.tsx
+++ b/packages/primitives/src/ArticleUnorderedList.stories.tsx
@@ -8,7 +8,7 @@
 
 import type { Meta, StoryFn } from "@storybook/react";
 import { ArticleContent, ArticleWrapper } from "@ndla/ui";
-import { UnOrderedList } from "./ArticleLists";
+import { OrderedList, UnOrderedList } from "./ArticleLists";
 import { BlockQuote } from "./BlockQuote";
 import { PageContent } from "./Layout/PageContent";
 
@@ -120,6 +120,29 @@ export const WithParagraphs: StoryFn = () => (
     </li>
     <li>
       <p>Listepunkt 3</p>
+    </li>
+  </UnOrderedList>
+);
+
+export const WithNestedOrderedList: StoryFn = () => (
+  <UnOrderedList>
+    <li>
+      Listpunkt 1
+      <UnOrderedList>
+        <li>Listpunkt 2</li>
+      </UnOrderedList>
+    </li>
+    <li>Listpunkt 3</li>
+    <li>
+      Listepunkt 4
+      <OrderedList>
+        <li>
+          Listepunkt 5
+          <OrderedList>
+            <li>Listepunkt 6</li>
+          </OrderedList>
+        </li>
+      </OrderedList>
     </li>
   </UnOrderedList>
 );


### PR DESCRIPTION
Ikke veldig fan av måten å gjøre dette på, men tror vi kanskje må force stylingen for at vi ikke skal overskrides av et liste element høyere i dom'en. 

Det her tatt utgangspunkt i hvordan vi gjorde det tidligere før nytt design system.  Jeg kan flette sammen logikken om det er ønskelig men jeg synes det var mer ryddig å ha det utenfor.