### PR TITLE
fix: only show Checkbox focus-ring when focus-visible is true

### DIFF
--- a/packages/primitives/src/Checkbox.tsx
+++ b/packages/primitives/src/Checkbox.tsx
@@ -66,7 +66,7 @@ const checkboxRecipe = sva({
           _hover: {
             color: "text.action",
           },
-          _focus: {
+          _focusVisible: {
             outline: "2px solid",
             outlineOffset: "4xsmall",
             outlineColor: "stroke.default",


### PR DESCRIPTION
Ønske fra Hedvig. 