### PR TITLE
feat: add isEntryOfType

### DIFF
--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -114,5 +114,5 @@ export { toggleBlock } from "./transforms/toggleBlock";
 
 export type { SlateEditor, CustomEditor, ElementType } from "./types";
 
-export { isElementOfType } from "./utils/isElementType";
+export { isElementOfType, isEntryOfType } from "./utils/isElementType";
 export { isEmptyTextNode } from "./utils/isEmptyTextNode";

--- a/packages/editor/src/utils/isElementType.ts
+++ b/packages/editor/src/utils/isElementType.ts
@@ -6,13 +6,26 @@
  *
  */
 
-import { Element, Node } from "slate";
+import { Element, Node, type NodeEntry } from "slate";
 import type { ElementType } from "../types";
 
 export const isElementOfType = <TType extends ElementType>(
   node: Node | undefined,
   type: TType | TType[] | undefined,
 ): node is TType extends any[] ? Extract<Element, { type: TType[number] }>[] : Extract<Element, { type: TType }> => {
+  if (!Element.isElement(node)) {
+    return false;
+  }
+  return Array.isArray(type) ? type.includes(node.type as TType) : node.type === type;
+};
+
+export const isEntryOfType = <TType extends ElementType>(
+  entry: NodeEntry | undefined,
+  type: TType | TType[] | undefined,
+): entry is NodeEntry<
+  TType extends any[] ? Extract<Element, { type: TType[number] }>[] : Extract<Element, { type: TType }>
+> => {
+  const node = entry?.[0];
   if (!Element.isElement(node)) {
     return false;
   }


### PR DESCRIPTION
TypeScript er dessverre ikke smart nok til å skjønne at `isElementOfType(entry[0], PARAGRAPH_ELEMENT_TYPE)` burde caste `Node` til `ParagraphElement`, så lager en ny util-funksjon. Fungerer i all hovedsak som en helper-funksjon for gamle ED-plugins.