### PR TITLE
fix: make `useEditorPopover` less greedy when the Enter key is pressed

### DIFF
--- a/packages/editor-components/src/hooks/useEditorPopover.ts
+++ b/packages/editor-components/src/hooks/useEditorPopover.ts
@@ -7,16 +7,17 @@
  */
 
 import { type UsePopoverProps } from "@ark-ui/react";
-import { useEffect } from "react";
+import { useEffect, type RefObject } from "react";
 import { Range } from "slate";
 import { useFocused, useSelected, useSlate } from "slate-react";
 import { usePopover } from "@ndla/primitives";
 
 interface UseEditorPopover extends UsePopoverProps {
   openOnEnter?: boolean;
+  triggerRef: RefObject<HTMLElement | null>;
 }
 
-export const useEditorPopover = (opts: UseEditorPopover = {}) => {
+export const useEditorPopover = ({ triggerRef, ...opts }: UseEditorPopover) => {
   const editor = useSlate();
   const isActive = useSelected();
   const isFocused = useFocused();
@@ -28,7 +29,11 @@ export const useEditorPopover = (opts: UseEditorPopover = {}) => {
     const handleKeyDown = (event: KeyboardEvent) => {
       const { selection } = editor;
       if (event.key !== "Enter" || !isActive || !isFocused || !selection) return;
-      if (Range.isCollapsed(selection) && !editor.isEdge(selection.anchor, selection.anchor.path)) {
+      if (
+        Range.isCollapsed(selection) &&
+        !editor.isEdge(selection.anchor, selection.anchor.path) &&
+        document.activeElement?.contains(triggerRef.current)
+      ) {
         event.preventDefault();
         popover.setOpen(!popover.open);
       }

--- a/packages/editor/src/playground.stories.tsx
+++ b/packages/editor/src/playground.stories.tsx
@@ -162,13 +162,15 @@ interface LinkProps extends RenderElementProps {
 const NewLink = ({ element, attributes, children }: LinkProps) => {
   const editor = useSlate();
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const popover = useEditorPopover({
     initialFocusEl: () => ref.current,
+    triggerRef,
   });
 
   return (
     <PopoverRootProvider value={popover} onExitComplete={() => DOMEditor.focus(editor)}>
-      <PopoverTrigger asChild consumeCss>
+      <PopoverTrigger asChild consumeCss ref={triggerRef}>
         <a {...attributes} href={element.data.href} target={element.data.target} tabIndex={0}>
           {children}
         </a>


### PR DESCRIPTION
Litt vanskelig å få til interop mellom Slate og alt utenfor slate. Dette fikser et problem som oppsto når man brukte tastatur i richtext-toolbaren.