### PR TITLE
fix: allow edges when using `useEditorPopover`

### DIFF
--- a/packages/editor-components/src/hooks/useEditorPopover.ts
+++ b/packages/editor-components/src/hooks/useEditorPopover.ts
@@ -29,11 +29,7 @@ export const useEditorPopover = ({ triggerRef, ...opts }: UseEditorPopover) => {
     const handleKeyDown = (event: KeyboardEvent) => {
       const { selection } = editor;
       if (event.key !== "Enter" || !isActive || !isFocused || !selection) return;
-      if (
-        Range.isCollapsed(selection) &&
-        !editor.isEdge(selection.anchor, selection.anchor.path) &&
-        document.activeElement?.contains(triggerRef.current)
-      ) {
+      if (Range.isCollapsed(selection) && document.activeElement?.contains(triggerRef.current)) {
         event.preventDefault();
         popover.setOpen(!popover.open);
       }

--- a/packages/editor/src/playground.stories.tsx
+++ b/packages/editor/src/playground.stories.tsx
@@ -48,6 +48,7 @@ import { breakPlugin } from "./plugins/break/breakPlugin";
 import { softBreakPlugin } from "./plugins/break/softBreakPlugin";
 import { headingPlugin } from "./plugins/heading/headingPlugin";
 import { toggleHeading } from "./plugins/heading/transforms/toggleHeading";
+import { inlineNavigationPlugin } from "./plugins/inlineNavigation/inlineNavigationPlugin";
 import { linkPlugin } from "./plugins/link/linkPlugin";
 import { type LinkElement } from "./plugins/link/linkTypes";
 import { listPlugin } from "./plugins/list/listPlugin";
@@ -240,6 +241,7 @@ export const EditorPlayground: StoryFn = () => {
   const [editor] = useState(() =>
     createSlate({
       plugins: [
+        inlineNavigationPlugin,
         sectionPlugin,
         headingPlugin,
         configuredMarkPlugin,


### PR DESCRIPTION
I og med at man kan steppe inn og ut av inline-elementer er det ingen grunn til å ignorere kanter. Kunne eventuelt vært en option?