### PR TITLE
feat: getClosestEditor

### DIFF
--- a/packages/editor-components/src/index.ts
+++ b/packages/editor-components/src/index.ts
@@ -14,3 +14,4 @@ export { useListToolbarButton, useListToolbarButtonState } from "./hooks/useList
 export { useMarkToolbarButton, useMarkToolbarButtonState } from "./hooks/useMarkToolbarButton";
 
 export { platformSpecificTooltip } from "./utils/platformSpecificTooltip";
+export { getClosestEditor } from "./utils/getClosestEditor";

--- a/packages/editor-components/src/utils/getClosestEditor.ts
+++ b/packages/editor-components/src/utils/getClosestEditor.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export const getClosestEditor = (el: HTMLElement | null): HTMLElement | null => {
+  return el?.closest("[data-slate-editor]") as HTMLElement | null;
+};


### PR DESCRIPTION
LinkPlugin i ED møter på et problem dersom en side har flere slate-editors. Hvis man bruker `document.querySelector` vil man automatisk plukke den første editoren en møter på, ikke den man nødvendigvis står i nå.