### PR TITLE
chore!: drop i18next-browser-languagedetector

### DIFF
--- a/packages/ndla-ui/package.json
+++ b/packages/ndla-ui/package.json
@@ -39,8 +39,7 @@
     "@ndla/safelink": "^7.0.81-alpha.0",
     "@ndla/styled-system": "workspace:^",
     "@ndla/util": "^5.0.5-alpha.0",
-    "html-react-parser": "^5.1.19",
-    "i18next-browser-languagedetector": "^7.1.0"
+    "html-react-parser": "^5.1.19"
   },
   "peerDependencies": {
     "i18next": "^23.11.5",

--- a/packages/ndla-ui/src/i18n/i18n.ts
+++ b/packages/ndla-ui/src/i18n/i18n.ts
@@ -7,7 +7,6 @@
  */
 
 import i18n from "i18next";
-import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
 import messagesEN from "../locale/messages-en";
 import messagesNB from "../locale/messages-nb";
@@ -15,18 +14,11 @@ import messagesNN from "../locale/messages-nn";
 import messagesSE from "../locale/messages-se";
 import messagesSMA from "../locale/messages-sma";
 
-const DETECTION_OPTIONS = {
-  order: ["path", "localStorage", "htmlTag"],
-  caches: ["localStorage"],
-  lookupLocalStorage: "i18nextLng",
-};
-
 export const supportedTranslationLanguages = ["nb", "nn", "en", "se", "sma"] as const;
-const i18nInstance = i18n.use(initReactI18next).use(LanguageDetector);
+const i18nInstance = i18n.use(initReactI18next);
 
 i18nInstance.init({
   compatibilityJSON: "v3",
-  detection: DETECTION_OPTIONS,
   fallbackLng: "nb",
   supportedLngs: supportedTranslationLanguages,
   resources: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1306,7 +1306,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.19.4, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4":
   version: 7.26.0
   resolution: "@babel/runtime@npm:7.26.0"
   dependencies:
@@ -2541,7 +2541,6 @@ __metadata:
     "@ndla/util": "npm:^5.0.5-alpha.0"
     "@pandacss/dev": "npm:^0.52.0"
     html-react-parser: "npm:^5.1.19"
-    i18next-browser-languagedetector: "npm:^7.1.0"
   peerDependencies:
     i18next: ^23.11.5
     react: ">= 18"
@@ -10048,15 +10047,6 @@ __metadata:
   version: 2.1.0
   resolution: "human-signals@npm:2.1.0"
   checksum: 10c0/695edb3edfcfe9c8b52a76926cd31b36978782062c0ed9b1192b36bebc75c4c87c82e178dfcb0ed0fc27ca59d434198aac0bd0be18f5781ded775604db22304a
-  languageName: node
-  linkType: hard
-
-"i18next-browser-languagedetector@npm:^7.1.0":
-  version: 7.1.0
-  resolution: "i18next-browser-languagedetector@npm:7.1.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.19.4"
-  checksum: 10c0/d7cd0ea0ad6047e786de665d67b41cbb0940a2983eb2c53dd85a5d71f88e170550bba8de45728470a2b5f88060bed2c79f330aff9806dd50ef58ade0ec7b8ca3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Tror denne kan tas inn når vi endrer språkhåndtering i ndla-frontend