### PR TITLE
feat: add possibility of normalizing initial editor value before slate has mounted

### DIFF
--- a/packages/editor/src/__tests__/createSlate-test.ts
+++ b/packages/editor/src/__tests__/createSlate-test.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type { Descendant } from "slate";
+import { createSlate } from "../editor/createSlate";
+import { createPlugin } from "../core/createPlugin";
+
+describe("createSlate", () => {
+  describe("normalizeInitialValue", () => {
+    it("does not crash if a plugin is just a regular function", () => {
+      const editor = createSlate({
+        plugins: [(editor) => editor],
+      });
+      expect(editor).toBeTruthy();
+    });
+    it("does not run normalizeInitialValue if the editor has no initial value", () => {
+      const updatedValue: Descendant[] = [
+        { type: "section", children: [{ type: "paragraph", children: [{ text: "Hello" }] }] },
+      ] as const;
+      const editor = createSlate({
+        plugins: [
+          createPlugin({
+            name: "test",
+            normalizeInitialValue: (editor) => {
+              editor.children = updatedValue;
+              return true;
+            },
+          }),
+        ],
+      });
+      expect(editor.children).toEqual([]);
+    });
+    it("runs if the editor has an initial value", () => {
+      const value: Descendant[] = [
+        { type: "section", children: [{ type: "paragraph", children: [{ text: "Hello" }] }] },
+      ] as const;
+
+      const expected: Descendant[] = [
+        { type: "section", children: [{ type: "paragraph", children: [{ text: "Updated" }] }] },
+      ] as const;
+
+      const editor = createSlate({
+        value: value,
+        plugins: [
+          (editor) => editor,
+          createPlugin({
+            name: "test",
+            normalizeInitialValue: (editor) => {
+              editor.children = expected;
+              return true;
+            },
+          }),
+        ],
+      });
+      expect(editor.children).toEqual(expected);
+    });
+    it("can be overriden with configure", () => {
+      const value: Descendant[] = [
+        { type: "section", children: [{ type: "paragraph", children: [{ text: "Hello" }] }] },
+      ] as const;
+
+      const expected: Descendant[] = [
+        { type: "section", children: [{ type: "paragraph", children: [{ text: "Updated" }] }] },
+      ] as const;
+
+      const testPlugin = createPlugin({ name: "test" });
+      const editor = createSlate({
+        value: value,
+        plugins: [
+          (editor) => editor,
+          testPlugin.configure({
+            normalizeInitialValue: (editor) => {
+              editor.children = expected;
+              return true;
+            },
+          }),
+        ],
+      });
+      expect(editor.children).toEqual(expected);
+    });
+  });
+});

--- a/packages/editor/src/core/createPlugin.ts
+++ b/packages/editor/src/core/createPlugin.ts
@@ -106,8 +106,14 @@ export const createPlugin = <TType extends ElementType, TOptions extends object 
   const plugin = new Proxy(pluginFn, {
     get(_, prop) {
       if (prop === "configure") {
-        return (configuration: PluginConfiguration<TType, TOptions>) =>
-          createPlugin({ ...params, configuration } as PluginConfiguration<TType, TOptions>);
+        return (configuration: PluginConfiguration<TType, TOptions>) => {
+          if (configuration.normalizeInitialValue) {
+            params.normalizeInitialValue = configuration.normalizeInitialValue;
+          }
+          return createPlugin({ ...params, configuration } as PluginConfiguration<TType, TOptions>);
+        };
+      } else if (prop === "normalizeInitialValue") {
+        return params.normalizeInitialValue;
       }
       return undefined; // Only expose `.configure`
     },

--- a/packages/editor/src/core/index.ts
+++ b/packages/editor/src/core/index.ts
@@ -71,6 +71,7 @@ export interface PluginConfiguration<TType extends ElementType, TOptions = undef
    * For instance, use it to define valid blocks another block/inline can be nested in
    */
   options?: TOptions;
+  normalizeInitialValue?: (editor: Editor) => void;
 }
 
 export interface ConfigurationOption<T> {
@@ -114,6 +115,7 @@ export type PluginReturnType<TType extends ElementType, TOptions = undefined> = 
       options?: MappedConfigurationOption<Partial<TOptions>>;
     },
   ) => SlatePlugin;
+  normalizeInitialValue: (editor: Editor) => void;
   options: TOptions;
 };
 

--- a/packages/editor/src/editor/createSlate.ts
+++ b/packages/editor/src/editor/createSlate.ts
@@ -6,15 +6,15 @@
  *
  */
 
-import { createEditor, Element, type Editor } from "slate";
-import type { ElementRenderer, LeafRenderer, SlatePlugin, SlateRenderer } from "../core";
+import { createEditor, Element, type Descendant, type Editor } from "slate";
+import type { ElementRenderer, LeafRenderer, PluginReturnType, SlatePlugin, SlateRenderer } from "../core";
 import { LoggerManager } from "../editor/logger/Logger";
 import { withHistory } from "slate-history";
 import { withReact } from "slate-react";
 import { withLogger } from "../editor/logger/withLogger";
 import { createElementRenderer, createLeafRenderer } from "../core/createRenderer";
 
-export const withPlugins = (editor: Editor, plugins?: SlatePlugin[]) => {
+export const withPlugins = (editor: Editor, plugins?: (SlatePlugin | PluginReturnType<any, any>)[]) => {
   if (plugins) {
     editor.getPluginOptions = <T>(pluginName: string) => editor.pluginOptions.get(pluginName) as T | undefined;
     return plugins.reduce((editor, plugin) => plugin(editor), editor);
@@ -32,10 +32,11 @@ export const withRenderers = (editor: Editor, renderers?: SlateRenderer[]) => {
 };
 
 interface CreateSlate {
-  plugins?: SlatePlugin[];
+  plugins?: (SlatePlugin | PluginReturnType<any, any>)[];
   logger?: LoggerManager;
   elementRenderers?: ElementRenderer[];
   leafRenderers?: LeafRenderer[];
+  value?: Descendant[];
 }
 
 export const createSlate = ({
@@ -43,6 +44,7 @@ export const createSlate = ({
   elementRenderers,
   leafRenderers,
   logger = new LoggerManager({ debug: false }),
+  value,
 }: CreateSlate): Editor => {
   const editor = withRenderers(
     withRenderers(
@@ -51,6 +53,18 @@ export const createSlate = ({
     ),
     leafRenderers?.map(createLeafRenderer),
   );
+
+  if (value) {
+    editor.children = value;
+  }
+
+  if (editor.children.length) {
+    plugins?.forEach((plugin) => {
+      // plugins are either functions or a proxy wrapping a function. If the plugin is a function, this call will return undefined.
+      // If the plugin is a proxy, it will run the function if it exists.
+      (plugin as PluginReturnType<any, any>).normalizeInitialValue?.(editor);
+    });
+  }
 
   editor.hasVoids = (element) => element.children.some((n) => Element.isElement(n) && editor.isVoid(n));
 

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -22,6 +22,7 @@ export type {
   LeafRenderer,
   CreateSlateElementRenderer,
   CreateSlateLeafRenderer,
+  PluginReturnType,
 } from "./core";
 export { mergeOptions } from "./core/mergeOptions";
 


### PR DESCRIPTION
Sitter og funderer på om det er lurt å ta dette enda litt videre, og tillate vanlig normaliseringslogikk også. Dette kommer til å brukes i ED til å sette ID'er på alle blokknoder uten at vi trenger å lagre ID'ene på server.