### PR TITLE
fix: make `override` option work properly when using `configure`. Support overriding `normalizeInitialValue`

### DIFF
--- a/packages/editor/src/__tests__/createSlate-test.ts
+++ b/packages/editor/src/__tests__/createSlate-test.ts
@@ -68,14 +68,55 @@ describe("createSlate", () => {
         { type: "section", children: [{ type: "paragraph", children: [{ text: "Updated" }] }] },
       ] as const;
 
-      const testPlugin = createPlugin({ name: "test" });
+      const testPlugin = createPlugin({
+        name: "test",
+        normalizeInitialValue: (editor) => {
+          editor.children.push({ type: "section", children: [{ type: "paragraph", children: [{ text: "Add" }] }] });
+          return true;
+        },
+      });
       const editor = createSlate({
         value: value,
         plugins: [
           (editor) => editor,
           testPlugin.configure({
             normalizeInitialValue: (editor) => {
-              editor.children = expected;
+              //@ts-expect-error - this is a test
+              editor.children[0].children[0].children[0].text = "Updated";
+              return true;
+            },
+            override: {
+              normalizeInitialValue: true,
+            },
+          }),
+        ],
+      });
+      expect(editor.children).toEqual(expected);
+    });
+    it("can run both the original and the `configure` normalizeInitialValue", () => {
+      const value: Descendant[] = [
+        { type: "section", children: [{ type: "paragraph", children: [{ text: "Hello" }] }] },
+      ] as const;
+
+      const expected: Descendant[] = [
+        { type: "section", children: [{ type: "paragraph", children: [{ text: "Updated" }] }] },
+        { type: "section", children: [{ type: "paragraph", children: [{ text: "Add" }] }] },
+      ] as const;
+      const testPlugin = createPlugin({
+        name: "test",
+        normalizeInitialValue: (editor) => {
+          editor.children.push({ type: "section", children: [{ type: "paragraph", children: [{ text: "Add" }] }] });
+          return true;
+        },
+      });
+      const editor = createSlate({
+        value: value,
+        plugins: [
+          (editor) => editor,
+          testPlugin.configure({
+            normalizeInitialValue: (editor) => {
+              //@ts-expect-error - this is a test
+              editor.children[0].children[0].children[0].text = "Updated";
               return true;
             },
           }),

--- a/packages/editor/src/core/index.ts
+++ b/packages/editor/src/core/index.ts
@@ -87,11 +87,9 @@ export type MappedConfigurationOption<T> = {
       : T[K];
 };
 
-export interface PluginConfigurationWithConfiguration<TType extends ElementType, TOptions>
-  extends PluginConfiguration<TType, TOptions> {
-  configuration?: Omit<Partial<PluginConfiguration<TType, TOptions>>, "options"> & {
-    options?: MappedConfigurationOption<TOptions>;
-  };
+export interface PluginConfigurationConfigurationType<TType extends ElementType, TOptions>
+  extends Omit<Partial<PluginConfiguration<TType, TOptions>>, "options"> {
+  options?: MappedConfigurationOption<TOptions>;
   /**
    * Specify whether the new configuration should entirely replace the existing configuration, or if it should be merged with the existing configuration.
    * By default, the new configuration will be merged with the existing configuration.
@@ -99,6 +97,7 @@ export interface PluginConfigurationWithConfiguration<TType extends ElementType,
   override?: {
     shortcuts?: boolean;
     normalize?: boolean;
+    normalizeInitialValue?: boolean;
     transform?: boolean;
   };
 }
@@ -110,11 +109,7 @@ export type PluginReturnType<TType extends ElementType, TOptions = undefined> = 
    * Allows consumers of plugins to further modify most aspects of the plugin.
    * Usually just used to modify the options passed into the plugin.
    */
-  configure: (
-    configuration: Omit<Partial<PluginConfiguration<TType, TOptions>>, "options"> & {
-      options?: MappedConfigurationOption<Partial<TOptions>>;
-    },
-  ) => SlatePlugin;
+  configure: (configuration: PluginConfigurationConfigurationType<TType, TOptions>) => SlatePlugin;
   normalizeInitialValue: (editor: Editor) => void;
   options: TOptions;
 };


### PR DESCRIPTION
Ser ut som at jeg har bommet på typene for `override`, så det var aldri mulig å sende det inn. Dette legger til støtte for det, og også støtte for å override `normalizeInitialValue`