### PR TITLE
feat: restrict valid break parents

### DIFF
--- a/packages/editor/src/plugins/break/breakTypes.ts
+++ b/packages/editor/src/plugins/break/breakTypes.ts
@@ -6,8 +6,7 @@
  *
  */
 
-import type { Descendant } from "slate";
-import type { ElementType } from "../../types";
+import type { Descendant, ElementType } from "slate";
 
 export const BREAK_ELEMENT_TYPE = "br" as const;
 export const BREAK_PLUGIN = "break" as const;
@@ -22,6 +21,7 @@ export interface BreakElement {
 
 export interface BreakPluginOptions {
   validBreakElements?: ElementType[];
+  validBreakParents?: ElementType[];
 }
 
 export interface BreakSerializerOptions {

--- a/packages/editor/src/types/index.ts
+++ b/packages/editor/src/types/index.ts
@@ -50,5 +50,6 @@ export interface SlateEditor {
 declare module "slate" {
   export type BlockElement = ParagraphElement | HeadingElement;
   export type BlockElementType = BlockElement["type"];
+  export type ElementType = Element["type"];
   interface CustomTypes extends SlateEditor {}
 }


### PR DESCRIPTION
Begrenser hvor man har lov til å sette inn br-elementer basert på hva parenten er. Tipper dette kommer til å være section, uu-disclaimer, framed-content, details, og aside i ED.