### PR TITLE
fix: ensure that the slate editor does not focus the Factbox button

### DIFF
--- a/packages/ndla-ui/src/FactBox/FactBox.tsx
+++ b/packages/ndla-ui/src/FactBox/FactBox.tsx
@@ -149,6 +149,7 @@ const FactBox = forwardRef<HTMLElement, Props>(
         <StyledIconButton
           data-state={state}
           onClick={onClick}
+          contentEditable={false}
           aria-expanded={state === "open"}
           aria-controls={contentId}
           aria-label={t(`factbox.${state === "open" ? "close" : "open"}`)}


### PR DESCRIPTION
Litt uheldig men ingen vei rundt