### PR TITLE
feat: add an editor function that asserts whether the editor supports a specific type

### DIFF
--- a/packages/editor/src/__tests__/createSlate-test.ts
+++ b/packages/editor/src/__tests__/createSlate-test.ts
@@ -125,4 +125,21 @@ describe("createSlate", () => {
       expect(editor.children).toEqual(expected);
     });
   });
+  describe("supportsElement", () => {
+    it("returns false if no plugins are registered", () => {
+      const editor = createSlate({});
+      const result = editor.supportsElement({ type: "paragraph", children: [{ text: "" }] });
+      expect(result).toBe(false);
+    });
+    it("returns true if a plugin supports the element", () => {
+      const editor = createSlate({ plugins: [createPlugin({ name: "test", type: "paragraph" })] });
+      const result = editor.supportsElement({ type: "paragraph", children: [{ text: "" }] });
+      expect(result).toBe(true);
+    });
+    it("returns false if a plugin does not support the element", () => {
+      const editor = createSlate({ plugins: [createPlugin({ name: "test", type: "section" })] });
+      const result = editor.supportsElement({ type: "paragraph", children: [{ text: "" }] });
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/packages/editor/src/core/createPlugin.ts
+++ b/packages/editor/src/core/createPlugin.ts
@@ -33,6 +33,16 @@ export const createPlugin = <TType extends ElementType, TOptions extends object 
     }
     editor.pluginOptions.set(name, pluginOptions);
 
+    if (type) {
+      const { supportsElement } = editor;
+      editor.supportsElement = (element) => {
+        if (element.type === type) {
+          return true;
+        }
+        return supportsElement(element);
+      };
+    }
+
     if (isInlineParam != null) {
       const { isInline } = editor;
       editor.isInline = (element) => {

--- a/packages/editor/src/editor/createSlate.ts
+++ b/packages/editor/src/editor/createSlate.ts
@@ -15,8 +15,12 @@ import { withLogger } from "../editor/logger/withLogger";
 import { createElementRenderer, createLeafRenderer } from "../core/createRenderer";
 
 export const withPlugins = (editor: Editor, plugins?: (SlatePlugin | PluginReturnType<any, any>)[]) => {
+  // base case
+  editor.supportsElement = (_) => {
+    return false;
+  };
+  editor.getPluginOptions = <T>(pluginName: string) => editor.pluginOptions.get(pluginName) as T | undefined;
   if (plugins) {
-    editor.getPluginOptions = <T>(pluginName: string) => editor.pluginOptions.get(pluginName) as T | undefined;
     return plugins.reduce((editor, plugin) => plugin(editor), editor);
   }
 

--- a/packages/editor/src/types/index.ts
+++ b/packages/editor/src/types/index.ts
@@ -32,6 +32,7 @@ export interface CustomEditor {
   renderElement?: (props: RenderElementProps) => JSX.Element | undefined;
   renderLeaf?: (props: RenderLeafProps) => JSX.Element | undefined;
   reinitialize: (options: ReinitializeOptions) => void;
+  supportsElement: (element: Element) => boolean;
 }
 
 export interface SlateEditor {


### PR DESCRIPTION
Skal brukes til å lete etter elementer som ikke støttes av editoren. Må komme på noe annet lurt for manglende renderers.