### PR TITLE
feat: add validChildren option to headingPlugin

### DIFF
--- a/packages/editor/src/plugins/heading/__tests__/headingNormalizer-test.ts
+++ b/packages/editor/src/plugins/heading/__tests__/headingNormalizer-test.ts
@@ -171,3 +171,50 @@ test("remove bold marker on header", () => {
   editor.normalize({ force: true });
   expect(editor.children).toEqual(expectedValue);
 });
+
+test("removes invalid elements from heading children", () => {
+  const editorValue: Descendant[] = [
+    {
+      type: SECTION_ELEMENT_TYPE,
+      children: [
+        {
+          type: PARAGRAPH_ELEMENT_TYPE,
+          children: [{ text: "" }],
+        },
+        {
+          type: HEADING_ELEMENT_TYPE,
+          level: 2,
+          children: [{ text: "Test" }, { text: "Paragraf" }, { text: "Test 2" }],
+        },
+        {
+          type: PARAGRAPH_ELEMENT_TYPE,
+          children: [{ text: "" }],
+        },
+      ],
+    },
+  ];
+
+  const expectedValue: Descendant[] = [
+    {
+      type: SECTION_ELEMENT_TYPE,
+      children: [
+        {
+          type: PARAGRAPH_ELEMENT_TYPE,
+          children: [{ text: "" }],
+        },
+        {
+          type: HEADING_ELEMENT_TYPE,
+          level: 2,
+          children: [{ text: "TestParagrafTest 2" }],
+        },
+        {
+          type: PARAGRAPH_ELEMENT_TYPE,
+          children: [{ text: "" }],
+        },
+      ],
+    },
+  ];
+  editor.children = editorValue;
+  editor.normalize({ force: true });
+  expect(editor.children).toEqual(expectedValue);
+});

--- a/packages/editor/src/plugins/heading/headingPlugin.ts
+++ b/packages/editor/src/plugins/heading/headingPlugin.ts
@@ -37,15 +37,21 @@ export const headingPlugin = createPlugin({
       return true;
     }
 
-    const boldEntries = Array.from(editor.nodes({ match: (n) => Text.isText(n) && !!n.bold }), (n) => n);
-    if (boldEntries.length) {
-      logger.log("Removing bold from nodes within heading.");
-      editor.withoutNormalizing(() => {
-        boldEntries.forEach(([_, path]) => {
-          Transforms.setNodes(editor, { bold: undefined }, { at: path });
-        });
+    for (const [index, child] of node.children.entries()) {
+      if (Text.isText(child)) {
+        if (child.bold) {
+          logger.log("Removing bold from text within heading");
+          Transforms.setNodes(editor, { bold: undefined }, { at: path.concat(index) });
+          return true;
+        }
+        continue;
+      }
+
+      if (!editor.isInline(child)) {
+        logger.log("Heading contains block element, unwrapping.");
+        Transforms.unwrapNodes(editor, { at: path.concat(index) });
         return true;
-      });
+      }
     }
 
     return false;


### PR DESCRIPTION
Relatert til https://github.com/ndlano/issues/issues/4353

Lar oss kontrollere hva en har lov til å ha inne i en heading. Tenker vi bare kan unwrappe alt av paragrafer.