### PR TITLE
feat: trim leading and trailing whitespace in paragraphs

### DIFF
--- a/packages/editor/src/plugins/paragraph/__tests__/paragraphNormalizer-test.ts
+++ b/packages/editor/src/plugins/paragraph/__tests__/paragraphNormalizer-test.ts
@@ -12,8 +12,10 @@ import { sectionPlugin } from "../../section/sectionPlugin";
 import { paragraphPlugin } from "../paragraphPlugin";
 import { SECTION_ELEMENT_TYPE } from "../../section/sectionTypes";
 import { PARAGRAPH_ELEMENT_TYPE } from "../paragraphTypes";
+import { spanPlugin } from "../../span/spanPlugin";
+import { SPAN_ELEMENT_TYPE } from "../../span/spanTypes";
 
-const editor = createSlate({ plugins: [sectionPlugin, paragraphPlugin] });
+const editor = createSlate({ plugins: [sectionPlugin, paragraphPlugin, spanPlugin] });
 
 describe("paragraph normalizer tests", () => {
   test("Remove serializeAsText from paragraph that is not placed in list-item", () => {
@@ -44,6 +46,130 @@ describe("paragraph normalizer tests", () => {
 
     editor.children = editorValue;
     editor.normalize({ force: true });
+    expect(editor.children).toEqual(expectedValue);
+  });
+  test("Remove leading whitespace from paragraph", () => {
+    const editorValue: Descendant[] = [
+      {
+        type: SECTION_ELEMENT_TYPE,
+        children: [
+          {
+            type: PARAGRAPH_ELEMENT_TYPE,
+            serializeAsText: true,
+            children: [{ text: " This is a paragraph" }],
+          },
+        ],
+      },
+    ];
+
+    const expectedValue: Descendant[] = [
+      {
+        type: SECTION_ELEMENT_TYPE,
+        children: [
+          {
+            type: PARAGRAPH_ELEMENT_TYPE,
+            children: [{ text: "This is a paragraph" }],
+          },
+        ],
+      },
+    ];
+    editor.reinitialize({ value: editorValue, shouldNormalize: true });
+    expect(editor.children).toEqual(expectedValue);
+  });
+  test("Remove trailing whitespace from paragraph", () => {
+    const editorValue: Descendant[] = [
+      {
+        type: SECTION_ELEMENT_TYPE,
+        children: [
+          {
+            type: PARAGRAPH_ELEMENT_TYPE,
+            serializeAsText: true,
+            children: [{ text: "This is a paragraph " }],
+          },
+        ],
+      },
+    ];
+
+    const expectedValue: Descendant[] = [
+      {
+        type: SECTION_ELEMENT_TYPE,
+        children: [
+          {
+            type: PARAGRAPH_ELEMENT_TYPE,
+            children: [{ text: "This is a paragraph" }],
+          },
+        ],
+      },
+    ];
+    editor.reinitialize({ value: editorValue, shouldNormalize: true });
+    expect(editor.children).toEqual(expectedValue);
+  });
+  test("Remove leading whitespace from nested element in paragraph", () => {
+    const editorValue: Descendant[] = [
+      {
+        type: SECTION_ELEMENT_TYPE,
+        children: [
+          {
+            type: PARAGRAPH_ELEMENT_TYPE,
+            children: [
+              { text: "" },
+              { type: SPAN_ELEMENT_TYPE, data: {}, children: [{ text: " This is a paragraph" }] },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const expectedValue: Descendant[] = [
+      {
+        type: SECTION_ELEMENT_TYPE,
+        children: [
+          {
+            type: PARAGRAPH_ELEMENT_TYPE,
+            children: [
+              { text: "" },
+              { type: SPAN_ELEMENT_TYPE, data: {}, children: [{ text: "This is a paragraph" }] },
+              { text: "" },
+            ],
+          },
+        ],
+      },
+    ];
+    editor.reinitialize({ value: editorValue, shouldNormalize: true });
+    expect(editor.children).toEqual(expectedValue);
+  });
+  test("Remove trailing whitespace from nested element in paragraph", () => {
+    const editorValue: Descendant[] = [
+      {
+        type: SECTION_ELEMENT_TYPE,
+        children: [
+          {
+            type: PARAGRAPH_ELEMENT_TYPE,
+            children: [
+              { type: SPAN_ELEMENT_TYPE, data: {}, children: [{ text: "This is a paragraph " }] },
+              { text: "" },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const expectedValue: Descendant[] = [
+      {
+        type: SECTION_ELEMENT_TYPE,
+        children: [
+          {
+            type: PARAGRAPH_ELEMENT_TYPE,
+            children: [
+              { text: "" },
+              { type: SPAN_ELEMENT_TYPE, data: {}, children: [{ text: "This is a paragraph" }] },
+              { text: "" },
+            ],
+          },
+        ],
+      },
+    ];
+    editor.reinitialize({ value: editorValue, shouldNormalize: true });
     expect(editor.children).toEqual(expectedValue);
   });
 });


### PR DESCRIPTION
Fixes https://trello.com/c/fnSZ5s7J/1233-autoslette-whitespace-i-bakkant-og-forkant-av-avsnitt-n%C3%A5r-man-lagrer-artikkel-i-ed

Litt usikker på hvor fornøyd jeg er med dette. I all hovedsak fører det til at man får opp "artikkelen er endret"-varselen etter at man har lagret en artikkel, da det ikke er så kult å disable whitespace på slutten av en setning mens man skriver den. Man kan eventuelt gjøre dette under deserialisering, men det blir nok en del mer komplekst. Hva tenker folket? 

Et annet alternativ vi kan utforske er å normalisere før vi lagrer. Da kunne vi hatt normaliseringsregler som kun ble kjørt når en artikkel ble lastet inn  og lagret, for eksempel. 

Kan testes ved å linke inn i ED.