### PR TITLE
chore: revert to react-router-dom to allow linking packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-docgen": "^8.0.0",
     "react-dom": "^19.1.0",
     "react-i18next": "^15.4.1",
-    "react-router": "^7.0.0",
+    "react-router-dom": "^7.0.0",
     "serve": "^14.2.4",
     "slate": "^0.112.0",
     "slate-dom": "^0.112.2",

--- a/packages/article-converter/package.json
+++ b/packages/article-converter/package.json
@@ -40,7 +40,7 @@
     "react": ">= 16.8.0",
     "react-dom": ">= 16.8.0",
     "react-i18next": "^15.4.1",
-    "react-router": ">= 6.0.0"
+    "react-router-dom": ">= 6.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ndla-tracker/package.json
+++ b/packages/ndla-tracker/package.json
@@ -29,7 +29,7 @@
   ],
   "peerDependencies": {
     "react": ">= 19.0.0",
-    "react-router": ">= 6.0.0"
+    "react-router-dom": ">= 6.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ndla-tracker/src/useTracker.ts
+++ b/packages/ndla-tracker/src/useTracker.ts
@@ -7,7 +7,7 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { useLocation } from "react-router";
+import { useLocation } from "react-router-dom";
 import { usePrevious } from "@ndla/util";
 
 interface TrackPageViewProps {

--- a/packages/ndla-ui/package.json
+++ b/packages/ndla-ui/package.json
@@ -46,7 +46,7 @@
     "react": ">= 18",
     "react-dom": ">= 18",
     "react-i18next": "^15.4.1",
-    "react-router": ">= 6.0.0"
+    "react-router-dom": ">= 6.0.0"
   },
   "devDependencies": {
     "@ndla/preset-panda": "workspace:^",

--- a/packages/ndla-ui/src/Article/ArticleByline.tsx
+++ b/packages/ndla-ui/src/Article/ArticleByline.tsx
@@ -9,7 +9,7 @@
 import type { TFunction } from "i18next";
 import { type ReactNode, forwardRef, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useLocation } from "react-router";
+import { useLocation } from "react-router-dom";
 import { ArrowDownShortLine } from "@ndla/icons";
 import {
   AccordionItem,

--- a/packages/safelink/package.json
+++ b/packages/safelink/package.json
@@ -37,7 +37,7 @@
   "peerDependencies": {
     "react": ">= 18",
     "react-dom": ">= 18",
-    "react-router": ">= 6.0.0"
+    "react-router-dom": ">= 6.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/safelink/src/SafeLink.tsx
+++ b/packages/safelink/src/SafeLink.tsx
@@ -7,7 +7,7 @@
  */
 
 import { forwardRef, type HTMLAttributes, type MutableRefObject, type ReactNode, useContext } from "react";
-import { Link, type LinkProps } from "react-router";
+import { Link, type LinkProps } from "react-router-dom";
 import { styled } from "@ndla/styled-system/jsx";
 import type { JsxStyleProps } from "@ndla/styled-system/types";
 import { MissingRouterContext } from "./MissingRouterContext";

--- a/packages/safelink/src/__tests__/SafeLink-test.tsx
+++ b/packages/safelink/src/__tests__/SafeLink-test.tsx
@@ -7,7 +7,7 @@
  */
 
 import type { ReactNode } from "react";
-import { StaticRouter } from "react-router";
+import { StaticRouter } from "react-router-dom";
 import { render } from "@testing-library/react";
 import { MissingRouterContext } from "../MissingRouterContext";
 import { SafeLink, isOldNdlaLink } from "../SafeLink";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,7 +2153,7 @@ __metadata:
     react: ">= 16.8.0"
     react-dom: ">= 16.8.0"
     react-i18next: ^15.4.1
-    react-router: ">= 6.0.0"
+    react-router-dom: ">= 6.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2313,7 +2313,7 @@ __metadata:
   peerDependencies:
     react: ">= 18"
     react-dom: ">= 18"
-    react-router: ">= 6.0.0"
+    react-router-dom: ">= 6.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2351,7 +2351,7 @@ __metadata:
     tiny-warning: "npm:^1.0.3"
   peerDependencies:
     react: ">= 19.0.0"
-    react-router: ">= 6.0.0"
+    react-router-dom: ">= 6.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2399,7 +2399,7 @@ __metadata:
     react: ">= 18"
     react-dom: ">= 18"
     react-i18next: ^15.4.1
-    react-router: ">= 6.0.0"
+    react-router-dom: ">= 6.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4129,13 +4129,6 @@ __metadata:
   dependencies:
     "@babel/types": "npm:^7.20.7"
   checksum: 10c0/e76cb4974c7740fd61311152dc497e7b05c1c46ba554aab875544ab0a7457f343cafcad34ba8fb2ff543ab0e012ef2d3fa0c13f1a4e9a4cd9c4c703c7a2a8d62
-  languageName: node
-  linkType: hard
-
-"@types/cookie@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@types/cookie@npm:0.6.0"
-  checksum: 10c0/5b326bd0188120fb32c0be086b141b1481fec9941b76ad537f9110e10d61ee2636beac145463319c71e4be67a17e85b81ca9e13ceb6e3bb63b93d16824d6c149
   languageName: node
   linkType: hard
 
@@ -9240,7 +9233,7 @@ __metadata:
     react-docgen: "npm:^8.0.0"
     react-dom: "npm:^19.1.0"
     react-i18next: "npm:^15.4.1"
-    react-router: "npm:^7.0.0"
+    react-router-dom: "npm:^7.0.0"
     serve: "npm:^14.2.4"
     slate: "npm:^0.112.0"
     slate-dom: "npm:^0.112.2"
@@ -13566,21 +13559,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:^7.0.0":
-  version: 7.4.0
-  resolution: "react-router@npm:7.4.0"
+"react-router-dom@npm:^7.0.0":
+  version: 7.6.1
+  resolution: "react-router-dom@npm:7.6.1"
   dependencies:
-    "@types/cookie": "npm:^0.6.0"
+    react-router: "npm:7.6.1"
+  peerDependencies:
+    react: ">=18"
+    react-dom: ">=18"
+  checksum: 10c0/9d448d82d73c18475c8e3e2f93cf9dd16ca0488379e295f5a949aa849aaf770eb6257d48f2aef2c62ac1635e8ccddd0fa53173c2479525305eb656936f330812
+  languageName: node
+  linkType: hard
+
+"react-router@npm:7.6.1":
+  version: 7.6.1
+  resolution: "react-router@npm:7.6.1"
+  dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
-    turbo-stream: "npm:2.4.0"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10c0/9cf943d7854e1e4d068162efa9a61e2d06a5c679cf3272a867046cc97a6cc65c9744490f54e8fd77bbe2d114610a5cb285ceb3d3941b9b19ac6f63385ac0a89d
+  checksum: 10c0/9968dcccc6695671cb216a74a756d717f47d5b8613869be72764966c2dc252ce12aa91a5f74838776b78d65a2297d7d5455c26a3ed78a380897905383b30c7d8
   languageName: node
   linkType: hard
 
@@ -15507,13 +15510,6 @@ __metadata:
     debug: "npm:^4.3.4"
     make-fetch-happen: "npm:^13.0.1"
   checksum: 10c0/7c17b097571f001730d7be0aeaec6bec46ed2f25bf73990b1133c383d511a1ce65f831e5d6d78770940a85b67664576ff0e4c98e5421bab6d33ff36e4be500c8
-  languageName: node
-  linkType: hard
-
-"turbo-stream@npm:2.4.0":
-  version: 2.4.0
-  resolution: "turbo-stream@npm:2.4.0"
-  checksum: 10c0/e68b2569f1f16e6e9633d090c6024b2ae9f0e97bfeacb572451ca3732e120ebbb546f3bc4afc717c46cb57b5aea6104e04ef497f9912eef6a7641e809518e98a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Vi fikk utrolig mye tyn ved linking. Jeg tror det kommer til å ta litt tid å gå helt over til `react-router`, så vi kan like så godt reverte tilbake til `react-router-dom` inntil videre.