### PR TITLE
Adds story to display standard marks

### DIFF
--- a/packages/preset-panda/src/typography.stories.tsx
+++ b/packages/preset-panda/src/typography.stories.tsx
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React from "react";
+import type { Meta, StoryFn } from "@storybook/react";
+import { css } from "@ndla/styled-system/css";
+import { styled } from "@ndla/styled-system/jsx";
+
+const TextContainer = styled("div", {
+  base: {
+    display: "flex",
+    flexDirection: "column",
+    flexWrap: "wrap",
+    gap: "small",
+  },
+});
+
+interface Props {
+  mark: string;
+}
+
+const TextItem = ({ mark }: Props) => {
+  const tag = React.createElement(mark, {}, mark);
+  return (
+    <div className={css({ display: "flex", flexDirection: "column", alignItems: "center" })}>
+      <p>Her er et avsnitt med {tag} text!</p>
+    </div>
+  );
+};
+
+export default {
+  title: "Preset/Typography",
+  tags: ["autodocs"],
+  component: TextItem,
+  parameters: {
+    inlineStories: true,
+  },
+} as Meta<typeof TextItem>;
+
+export const Marks: StoryFn = () => (
+  <TextContainer>
+    {["strong", "em", "code", "sub", "sup", "u"].map((mark) => (
+      <TextItem key={mark} mark={mark} />
+    ))}
+  </TextContainer>
+);


### PR DESCRIPTION
Savna en plass der code-taggen blei vist så laga en liten story

![image](https://github.com/user-attachments/assets/16b2e8a4-4013-40a3-b6a0-be2eb1736ba3)
