### PR TITLE
chore: convert to exports field in package.json

### DIFF
--- a/packages/article-converter/package.json
+++ b/packages/article-converter/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@ndla/article-converter",
+  "type": "module",
   "version": "10.0.138-alpha.0",
   "description": "Transforms NDLA articles into extended html versions",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "sideEffects": false,
   "scripts": {
     "build": "tsdown",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,12 +1,15 @@
 {
   "name": "@ndla/core",
+  "type": "module",
   "version": "6.0.1-alpha.0",
   "description": "UI component library for NDLA.",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "sideEffects": false,
-  "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch ./src",

--- a/packages/editor-components/package.json
+++ b/packages/editor-components/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@ndla/editor-components",
+  "type": "module",
   "version": "0.0.43",
   "description": "Slate editor components for NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "sideEffects": false,
   "scripts": {
     "build": "tsdown",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@ndla/editor",
+  "type": "module",
   "version": "0.0.30",
   "description": "Slate editor plugins for NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "sideEffects": false,
   "scripts": {
     "build": "tsdown",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@ndla/hooks",
+  "type": "module",
   "version": "2.1.12",
   "description": "Collection of React hooks used by NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch ./src",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,12 +1,15 @@
 {
   "name": "@ndla/icons",
+  "type": "module",
   "version": "8.0.61-alpha.0",
   "description": "A package containing icons used in NDLA frontends",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "sideEffects": false,
-  "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch ./src",

--- a/packages/ndla-audio-search/package.json
+++ b/packages/ndla-audio-search/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@ndla/audio-search",
+  "type": "module",
   "version": "7.0.107-alpha.0",
   "description": "A simple library for searching for audio files from NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch ./src",

--- a/packages/ndla-error-reporter/package.json
+++ b/packages/ndla-error-reporter/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@ndla/error-reporter",
+  "type": "module",
   "version": "2.0.17",
   "description": "Error reporter for NDLA. Listens to window.onerror and sends client errors to Loggly.",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
+  "exports": {
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/NDLANO/frontend-packages.git/ndla-error-reporter/"

--- a/packages/ndla-image-search/package.json
+++ b/packages/ndla-image-search/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@ndla/image-search",
+  "type": "module",
   "version": "11.0.111-alpha.0",
   "description": "A simple library for searching images from NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch ./src",

--- a/packages/ndla-licenses/package.json
+++ b/packages/ndla-licenses/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@ndla/licenses",
+  "type": "module",
   "version": "9.0.5",
   "description": "A simple library for retrieving license information for NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch ./src",

--- a/packages/ndla-tracker/package.json
+++ b/packages/ndla-tracker/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@ndla/tracker",
+  "type": "module",
   "version": "5.0.23-alpha.0",
   "description": "A simple library for tracking NDLA applications.",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "sideEffects": false,
   "scripts": {
     "build": "tsdown",

--- a/packages/ndla-ui/package.json
+++ b/packages/ndla-ui/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@ndla/ui",
+  "type": "module",
   "version": "56.0.135-alpha.0",
   "description": "UI component library for NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "sideEffects": false,
   "scripts": {
     "build": "tsdown",

--- a/packages/ndla-video-search/package.json
+++ b/packages/ndla-video-search/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@ndla/video-search",
+  "type": "module",
   "version": "8.0.110-alpha.0",
   "description": "A simple library for searching NDLA videos",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch ./src",

--- a/packages/preset-panda/package.json
+++ b/packages/preset-panda/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@ndla/preset-panda",
+  "type": "module",
   "version": "0.0.56",
   "description": "Panda preset for NDLA.",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "sideEffects": false,
   "scripts": {
     "prepare": "panda codegen",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@ndla/primitives",
+  "type": "module",
   "version": "1.0.94-alpha.0",
   "description": "Primitive components for NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "sideEffects": false,
   "scripts": {
     "build": "tsdown",

--- a/packages/safelink/package.json
+++ b/packages/safelink/package.json
@@ -1,10 +1,14 @@
 {
   "name": "@ndla/safelink",
+  "type": "module",
   "version": "7.0.96-alpha.0",
   "description": "SafeLink component for NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "sideEffects": false,
   "scripts": {
     "build": "tsdown",

--- a/packages/styled-system/package.json
+++ b/packages/styled-system/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@ndla/styled-system",
+  "type": "module",
   "description": "Styled System for NDLA",
   "version": "0.0.35",
   "repository": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@ndla/util",
+  "type": "module",
   "version": "5.0.9-alpha.0",
   "description": "Collection of util functions used by NDLA",
   "license": "GPL-3.0",
-  "main": "lib/index.js",
-  "module": "es/index.js",
-  "types": "lib/index.d.ts",
+  "exports": {
+    "types": "./lib/index.d.ts",
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "sideEffects": false,
   "scripts": {
     "build": "tsdown",


### PR DESCRIPTION
Jeg har slått hodet i veggen med en bug som viste seg å være esm/cjs-interop. Tror det er på tide at vi går helt over til ESM nå, men har lagt til rette for at man fortsatt kan kjøre CJS ved behov. 

En kan anse dette som breaking, men vil tro de aller fleste semi-moderne kodebaser tåler det.