### PR TITLE
chore: migrate to react-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ yarn link
 In repo using the package (ie. ndla-frontend). Forces usage of the same react versions as in frontend-packages.
 
 ```js
-yarn link @ndla/[package-name] react react-dom react-router react-router-dom
+yarn link @ndla/[package-name] react react-dom react-router
 yarn
 ```
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-i18next": "^15.7.2",
-    "react-router-dom": "^7.0.0",
+    "react-router": "^7.0.0",
     "serve": "^14.2.4",
     "slate": "^0.118.1",
     "slate-dom": "^0.118.1",

--- a/packages/article-converter/package.json
+++ b/packages/article-converter/package.json
@@ -45,7 +45,7 @@
     "react": ">= 16.8.0",
     "react-dom": ">= 16.8.0",
     "react-i18next": "^15.4.1",
-    "react-router-dom": ">= 6.0.0"
+    "react-router": ">= 7.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ndla-tracker/package.json
+++ b/packages/ndla-tracker/package.json
@@ -33,7 +33,7 @@
   ],
   "peerDependencies": {
     "react": ">= 19.0.0",
-    "react-router-dom": ">= 6.0.0"
+    "react-router": ">= 7.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ndla-tracker/src/useTracker.ts
+++ b/packages/ndla-tracker/src/useTracker.ts
@@ -7,7 +7,7 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 import { usePrevious } from "@ndla/util";
 
 interface TrackPageViewProps {

--- a/packages/ndla-ui/package.json
+++ b/packages/ndla-ui/package.json
@@ -51,7 +51,7 @@
     "react": ">= 18",
     "react-dom": ">= 18",
     "react-i18next": "^15.4.1",
-    "react-router-dom": ">= 6.0.0"
+    "react-router": ">= 7.0.0"
   },
   "devDependencies": {
     "@ndla/preset-panda": "workspace:^",

--- a/packages/ndla-ui/src/Article/ArticleByline.tsx
+++ b/packages/ndla-ui/src/Article/ArticleByline.tsx
@@ -8,7 +8,7 @@
 
 import { type ReactNode, forwardRef, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 import { ArrowDownShortLine } from "@ndla/icons";
 import {
   AccordionItem,

--- a/packages/safelink/package.json
+++ b/packages/safelink/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "react": ">= 18",
     "react-dom": ">= 18",
-    "react-router-dom": ">= 6.0.0"
+    "react-router": ">= 7.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/safelink/src/SafeLink.tsx
+++ b/packages/safelink/src/SafeLink.tsx
@@ -7,7 +7,7 @@
  */
 
 import { forwardRef, type HTMLAttributes, type MutableRefObject, type ReactNode, useContext } from "react";
-import { Link, type LinkProps } from "react-router-dom";
+import { Link, type LinkProps } from "react-router";
 import { styled } from "@ndla/styled-system/jsx";
 import type { JsxStyleProps } from "@ndla/styled-system/types";
 import { MissingRouterContext } from "./MissingRouterContext";

--- a/packages/safelink/src/__tests__/SafeLink-test.tsx
+++ b/packages/safelink/src/__tests__/SafeLink-test.tsx
@@ -7,7 +7,7 @@
  */
 
 import type { ReactNode } from "react";
-import { StaticRouter } from "react-router-dom";
+import { StaticRouter } from "react-router";
 import { render } from "@testing-library/react";
 import { MissingRouterContext } from "../MissingRouterContext";
 import { SafeLink, isOldNdlaLink } from "../SafeLink";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,7 +1129,7 @@ __metadata:
     react: ">= 16.8.0"
     react-dom: ">= 16.8.0"
     react-i18next: ^15.4.1
-    react-router-dom: ">= 6.0.0"
+    react-router: ">= 7.0.0"
   languageName: unknown
   linkType: soft
 
@@ -1292,7 +1292,7 @@ __metadata:
   peerDependencies:
     react: ">= 18"
     react-dom: ">= 18"
-    react-router-dom: ">= 6.0.0"
+    react-router: ">= 7.0.0"
   languageName: unknown
   linkType: soft
 
@@ -1330,7 +1330,7 @@ __metadata:
     tiny-warning: "npm:^1.0.3"
   peerDependencies:
     react: ">= 19.0.0"
-    react-router-dom: ">= 6.0.0"
+    react-router: ">= 7.0.0"
   languageName: unknown
   linkType: soft
 
@@ -1379,7 +1379,7 @@ __metadata:
     react: ">= 18"
     react-dom: ">= 18"
     react-i18next: ^15.4.1
-    react-router-dom: ">= 6.0.0"
+    react-router: ">= 7.0.0"
   languageName: unknown
   linkType: soft
 
@@ -7876,7 +7876,7 @@ __metadata:
     react: "npm:^19.1.0"
     react-dom: "npm:^19.1.0"
     react-i18next: "npm:^15.7.2"
-    react-router-dom: "npm:^7.0.0"
+    react-router: "npm:^7.0.0"
     serve: "npm:^14.2.4"
     slate: "npm:^0.118.1"
     slate-dom: "npm:^0.118.1"
@@ -12064,21 +12064,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^7.0.0":
-  version: 7.6.1
-  resolution: "react-router-dom@npm:7.6.1"
-  dependencies:
-    react-router: "npm:7.6.1"
-  peerDependencies:
-    react: ">=18"
-    react-dom: ">=18"
-  checksum: 10c0/9d448d82d73c18475c8e3e2f93cf9dd16ca0488379e295f5a949aa849aaf770eb6257d48f2aef2c62ac1635e8ccddd0fa53173c2479525305eb656936f330812
-  languageName: node
-  linkType: hard
-
-"react-router@npm:7.6.1":
-  version: 7.6.1
-  resolution: "react-router@npm:7.6.1"
+"react-router@npm:^7.0.0":
+  version: 7.8.2
+  resolution: "react-router@npm:7.8.2"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -12088,7 +12076,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10c0/9968dcccc6695671cb216a74a756d717f47d5b8613869be72764966c2dc252ce12aa91a5f74838776b78d65a2297d7d5455c26a3ed78a380897905383b30c7d8
+  checksum: 10c0/e3122c2949bcad5e9c990cfb88e9cbd139e5a2a5c1d29664732623907a488634c0ddbf673d07af8f113d418f66270c174f014de8b885996722f431d09f5734be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
react-router-dom er egentlig deprecated. Dette er ganske breaking.