### PR TITLE
feat: skip non-accessible content

### DIFF
--- a/packages/locales/src/messages-en.ts
+++ b/packages/locales/src/messages-en.ts
@@ -327,7 +327,11 @@ const messages = {
       disclaimer: "Accessibility warning",
     },
   },
-  uuDisclaimer: { title: "Accessibility" },
+  uuDisclaimer: {
+    title: "Accessibility",
+    skipContent: "Skip non-accessible content",
+    contentCompleted: "End of non-accessible content.",
+  },
   gloss: {
     examples: "Examples",
     showExamples: "Show examples",

--- a/packages/locales/src/messages-nb.ts
+++ b/packages/locales/src/messages-nb.ts
@@ -328,7 +328,11 @@ const messages = {
       disclaimer: "UU-advarsel",
     },
   },
-  uuDisclaimer: { title: "Tilgjengelighet" },
+  uuDisclaimer: {
+    title: "Tilgjengelighet",
+    skipContent: "Hopp over ikke-tilgjengelig innhold",
+    contentCompleted: "Slutt på ikke-tilgjengelig innhold.",
+  },
   gloss: {
     examples: "Eksempler",
     showExamples: "Vis eksempler",

--- a/packages/locales/src/messages-nn.ts
+++ b/packages/locales/src/messages-nn.ts
@@ -328,7 +328,11 @@ const messages = {
       disclaimer: "UU-advarsel",
     },
   },
-  uuDisclaimer: { title: "Tilgjengelighet" },
+  uuDisclaimer: {
+    title: "Tilgjengelighet",
+    skipContent: "Hopp over ikkje-tilgjengeleg innhald",
+    contentCompleted: "Slutt på ikkje-tilgjengeleg innhald.",
+  },
   gloss: {
     examples: "Eksempler",
     showExamples: "Vis eksempler",

--- a/packages/locales/src/messages-se.ts
+++ b/packages/locales/src/messages-se.ts
@@ -329,7 +329,11 @@ const messages = {
       disclaimer: "UU-advarsel",
     },
   },
-  uuDisclaimer: { title: "Tilgjengelighet" },
+  uuDisclaimer: {
+    title: "Tilgjengelighet",
+    skipContent: "Hopp over ikke-tilgjengelig innhold",
+    contentCompleted: "Slutt på ikke-tilgjengelig innhold.",
+  },
   gloss: {
     examples: "Ovdamearkkat",
     showExamples: "Vis eksempler",

--- a/packages/ui/src/Embed/UuDisclaimerEmbed.stories.tsx
+++ b/packages/ui/src/Embed/UuDisclaimerEmbed.stories.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { ExpandableBox, ExpandableBoxSummary, FramedContent, PageContent } from "@ndla/primitives";
+import { ExpandableBox, ExpandableBoxSummary, FramedContent, PageContent, Button } from "@ndla/primitives";
 import type { UUDisclaimerData, UuDisclaimerEmbedData } from "@ndla/types-embed";
 import type { Meta, StoryObj } from "@storybook/react";
 import { AnchorHeading } from "../AnchorHeading/AnchorHeading";
@@ -198,4 +198,31 @@ export const Error: StoryObj<typeof UuDisclaimerEmbed> = {
       </AnchorHeading>
     ),
   },
+};
+export const SkipContent: StoryObj<typeof UuDisclaimerEmbed> = {
+  args: {
+    embed: {
+      resource: "uu-disclaimer",
+      status: "success",
+      embedData,
+      data,
+    },
+    children: (
+      <div>
+        <h2>Dette er noe ugyldig innhold</h2>
+        <Button>Denne kan hoppes over!</Button>
+        <p>
+          Innholdet kan enkelt hoppes over ved å bruke knappen skip-knappen som dukker opp når du bruker
+          tastaturnavigering inne i popoveren.
+        </p>
+      </div>
+    ),
+  },
+  render: (args) => (
+    <>
+      <UuDisclaimerEmbed {...args} />
+      <h2>Dette er noe gyldig innhold</h2>
+      <Button>Denne vil ikke hoppes over</Button>
+    </>
+  ),
 };

--- a/packages/ui/src/Embed/UuDisclaimerEmbed.tsx
+++ b/packages/ui/src/Embed/UuDisclaimerEmbed.tsx
@@ -8,10 +8,11 @@
 
 import { Portal } from "@ark-ui/react";
 import { AccessibilityFill, ErrorWarningFill } from "@ndla/icons";
-import { IconButton, PopoverContent, PopoverRoot, PopoverTrigger } from "@ndla/primitives";
+import { Button, IconButton, PopoverContent, PopoverRoot, PopoverTrigger } from "@ndla/primitives";
 import { styled } from "@ndla/styled-system/jsx";
+import { visuallyHidden } from "@ndla/styled-system/patterns";
 import type { UuDisclaimerMetaData } from "@ndla/types-embed";
-import { type ReactNode } from "react";
+import { useRef, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 interface Props {
@@ -44,14 +45,35 @@ const StyledErrorWarningFill = styled(ErrorWarningFill, {
 
 const StyledPopoverContent = styled(PopoverContent, {
   base: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "xsmall",
     width: "surface.xlarge",
     maxHeight: "50vh",
     overflowY: "auto",
   },
 });
 
+const HiddenButton = styled(Button, {
+  base: {
+    "&:not(:focus)": {
+      position: "absolute",
+      width: "1px",
+      height: "1px",
+      padding: "0",
+      margin: "-1px",
+      overflow: "hidden",
+      clip: "rect(0,0,0,0)",
+      whiteSpace: "nowrap",
+      borderWidth: "0",
+    },
+  },
+});
+
 export const UuDisclaimerEmbed = ({ embed, transformedDisclaimer, children }: Props) => {
   const { t } = useTranslation();
+  const skipRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   if (embed.status === "error") {
     return (
       <DisclaimerWrapper>
@@ -67,7 +89,7 @@ export const UuDisclaimerEmbed = ({ embed, transformedDisclaimer, children }: Pr
   return (
     // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role
     <DisclaimerWrapper role="region" data-embed-type="uu-disclaimer">
-      <PopoverRoot>
+      <PopoverRoot initialFocusEl={() => contentRef.current}>
         <PopoverTrigger asChild>
           <StyledIconButton
             size="small"
@@ -79,12 +101,16 @@ export const UuDisclaimerEmbed = ({ embed, transformedDisclaimer, children }: Pr
           </StyledIconButton>
         </PopoverTrigger>
         <Portal>
-          <StyledPopoverContent>
+          <StyledPopoverContent ref={contentRef}>
             <div>{transformedDisclaimer}</div>
+            <HiddenButton onClick={() => skipRef.current?.focus()}>{t("uuDisclaimer.skipContent")}</HiddenButton>
           </StyledPopoverContent>
         </Portal>
       </PopoverRoot>
       <div data-uu-content="">{children}</div>
+      <div className={visuallyHidden()} tabIndex={-1} ref={skipRef}>
+        {t("uuDisclaimer.contentCompleted")}
+      </div>
     </DisclaimerWrapper>
   );
 };


### PR DESCRIPTION
Fixes https://trello.com/c/Vqbzkhxm/1454-skip-knapp-i-uu-varsel

Går for en ganske drastisk forenkling av den originale oppgaven her: Skip-knappen er alltid tilgjengelig for uu-disclaimers. Den dukker bare opp dersom man tabber til knappen.