### PR TITLE
Fix: only apply inline navigation plugin on inline borders

### DIFF
--- a/packages/editor/src/core/createPlugin.ts
+++ b/packages/editor/src/core/createPlugin.ts
@@ -90,14 +90,18 @@ export const createPlugin = <TType extends ElementType, TOptions extends object 
     if (shortcutEntries.length) {
       const { onKeyDown } = editor;
       editor.onKeyDown = (event) => {
-        for (const [key, { handler, keyCondition }] of shortcutEntries) {
+        for (const [key, { handler, keyCondition, ignoreSkipLogging, ignoreConsumeLogging }] of shortcutEntries) {
           const keyConditions = Array.isArray(keyCondition) ? keyCondition : [keyCondition];
           if (keyConditions.some((condition) => condition(event))) {
             if (handler(editor, event, logger, pluginOptions)) {
-              logger.log(`Shortcut "${key}" consumed keyDown event. Ignoring further handlers.`);
+              if (!ignoreConsumeLogging) {
+                logger.log(`Shortcut "${key}" consumed keyDown event. Ignoring further handlers.`);
+              }
               return;
             } else {
-              logger.log(`Shortcut "${key}" triggered, but did not consume the keyDown event.`);
+              if (!ignoreSkipLogging) {
+                logger.log(`Shortcut "${key}" triggered, but did not consume the keyDown event.`);
+              }
             }
           }
         }

--- a/packages/editor/src/core/index.ts
+++ b/packages/editor/src/core/index.ts
@@ -31,6 +31,8 @@ export interface Shortcut<TOptions = undefined> {
    * A key condition that must be met for the handler to be called
    */
   keyCondition: KeyConditionFn | KeyConditionFn[];
+  ignoreSkipLogging?: boolean;
+  ignoreConsumeLogging?: boolean;
 }
 
 export interface PluginConfiguration<TType extends ElementType, TOptions = undefined> {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -49,6 +49,9 @@ export { HEADING_ELEMENT_TYPE, HEADING_PLUGIN } from "./plugins/heading/headingT
 export { isHeadingElement } from "./plugins/heading/queries/headingQueries";
 export { toggleHeading } from "./plugins/heading/transforms/toggleHeading";
 
+export { focusPlugin } from "./plugins/focus/focusPlugin";
+export { FOCUS_PLUGIN } from "./plugins/focus/focusTypes";
+
 export { inlineNavigationPlugin } from "./plugins/inlineNavigation/inlineNavigationPlugin";
 export { INLINE_NAVIGATION_PLUGIN } from "./plugins/inlineNavigation/inlineNavigationTypes";
 

--- a/packages/editor/src/playground.stories.tsx
+++ b/packages/editor/src/playground.stories.tsx
@@ -46,6 +46,7 @@ import { useCreateSlate } from "./editor/createSlate";
 import { LoggerManager } from "./editor/logger/Logger";
 import { breakPlugin } from "./plugins/break/breakPlugin";
 import { softBreakPlugin } from "./plugins/break/softBreakPlugin";
+import { focusPlugin } from "./plugins/focus/focusPlugin";
 import { headingPlugin } from "./plugins/heading/headingPlugin";
 import { toggleHeading } from "./plugins/heading/transforms/toggleHeading";
 import { inlineNavigationPlugin } from "./plugins/inlineNavigation/inlineNavigationPlugin";
@@ -240,6 +241,7 @@ const ToolbarButtons = () => {
 export const EditorPlayground: StoryFn = () => {
   const editor = useCreateSlate({
     plugins: [
+      focusPlugin,
       inlineNavigationPlugin,
       sectionPlugin,
       headingPlugin,

--- a/packages/editor/src/plugins/focus/focusPlugin.ts
+++ b/packages/editor/src/plugins/focus/focusPlugin.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { ReactEditor } from "slate-react";
+import { createPlugin } from "../../core/createPlugin";
+import { FOCUS_PLUGIN } from "./focusTypes";
+
+export const focusPlugin = createPlugin({
+  name: FOCUS_PLUGIN,
+  transform: (editor) => {
+    editor.focus = () => ReactEditor.focus(editor);
+    return editor;
+  },
+});

--- a/packages/editor/src/plugins/focus/focusTypes.ts
+++ b/packages/editor/src/plugins/focus/focusTypes.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) 2026-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export const FOCUS_PLUGIN = "focus" as const;

--- a/packages/editor/src/plugins/inlineNavigation/inlineNavigationPlugin.ts
+++ b/packages/editor/src/plugins/inlineNavigation/inlineNavigationPlugin.ts
@@ -21,6 +21,7 @@ const moveAroundInline = (editor: Editor, event: { preventDefault(): void }, rev
     const [, inlinePath] = inlineMatch;
     if (!atBoundary(inlinePath)) return false;
     event.preventDefault();
+    editor.focus?.();
     Transforms.move(editor, { unit: "offset", reverse });
     return true;
   }
@@ -31,6 +32,7 @@ const moveAroundInline = (editor: Editor, event: { preventDefault(): void }, rev
   const sibling = parentNode.children[childIndex + (reverse ? -1 : 1)];
   if (Element.isElement(sibling) && editor.isInline(sibling)) {
     event.preventDefault();
+    editor.focus?.();
     Transforms.move(editor, { unit: "offset", reverse });
     return true;
   }

--- a/packages/editor/src/plugins/inlineNavigation/inlineNavigationPlugin.ts
+++ b/packages/editor/src/plugins/inlineNavigation/inlineNavigationPlugin.ts
@@ -7,37 +7,53 @@
  */
 
 import { isKeyHotkey } from "is-hotkey";
-import { Range, Transforms } from "slate";
+import { Element, Range, Transforms, type Editor, type Location } from "slate";
 import { createPlugin } from "../../core/createPlugin";
 
+const moveAroundInline = (editor: Editor, event: { preventDefault(): void }, reverse: boolean): boolean => {
+  if (!editor.selection || !Range.isCollapsed(editor.selection)) return false;
+
+  const { anchor } = editor.selection;
+  const atBoundary = (at: Location) => (reverse ? editor.isStart(anchor, at) : editor.isEnd(anchor, at));
+
+  const [inlineMatch] = editor.nodes({ match: (n) => Element.isElement(n) && editor.isInline(n), reverse: true });
+  if (inlineMatch) {
+    const [, inlinePath] = inlineMatch;
+    if (!atBoundary(inlinePath)) return false;
+    event.preventDefault();
+    Transforms.move(editor, { unit: "offset", reverse });
+    return true;
+  }
+
+  if (!atBoundary(anchor.path)) return false;
+  const [parentNode] = editor.parent(anchor.path);
+  const childIndex = anchor.path.at(-1)!;
+  const sibling = parentNode.children[childIndex + (reverse ? -1 : 1)];
+  if (Element.isElement(sibling) && editor.isInline(sibling)) {
+    event.preventDefault();
+    Transforms.move(editor, { unit: "offset", reverse });
+    return true;
+  }
+
+  return false;
+};
+
 /**
- * By default, Slate does not allow the user to navigate out of inline elements using the arrow keys. They are stuck inside the inline element.
- * This plugin fixes that issue by adding two new keyboard shortcuts: "inline-left" and "inline-right".
+ * By default, Slate does not allow the user to navigate into or out of inline elements using the arrow keys.
+ * This plugin fixes that by intercepting arrow keys at inline boundaries (both entering and exiting).
  */
 export const inlineNavigationPlugin = createPlugin({
   name: "inline-plugin",
   shortcuts: {
     "inline-left": {
       keyCondition: isKeyHotkey("left"),
-      handler: (editor, event) => {
-        if (editor.selection && Range.isCollapsed(editor.selection)) {
-          event.preventDefault();
-          Transforms.move(editor, { unit: "offset", reverse: true });
-          return true;
-        }
-        return false;
-      },
+      handler: (editor, event) => moveAroundInline(editor, event, true),
+      ignoreSkipLogging: true,
     },
     "inline-right": {
       keyCondition: isKeyHotkey("right"),
-      handler: (editor, event) => {
-        if (editor.selection && Range.isCollapsed(editor.selection)) {
-          event.preventDefault();
-          Transforms.move(editor, { unit: "offset" });
-          return true;
-        }
-        return false;
-      },
+      handler: (editor, event) => moveAroundInline(editor, event, false),
+      ignoreSkipLogging: true,
     },
   },
 });

--- a/packages/editor/src/types/index.ts
+++ b/packages/editor/src/types/index.ts
@@ -32,6 +32,7 @@ export interface CustomEditor {
   renderElement?: (props: RenderElementProps) => JSX.Element | undefined;
   renderLeaf?: (props: RenderLeafProps) => JSX.Element | undefined;
   reinitialize: (options: ReinitializeOptions) => void;
+  focus?: () => void;
   supportsElement: (element: Element) => boolean;
   supportsMark: (mark: MarkType | MarkType[]) => boolean;
 }


### PR DESCRIPTION
Dette har irritert meg i en stund. Inline-pluginen vår har egentlig bare overstyrt alt av piltast-navigering. Denne PR'en sørger for at den kun overstyrer vanlig navigering når man enten er i kanten av en inline, eller på vei inn i en inline. Tror dette skal gjøre unicode-støtten vår ordentlig. Du kan for eksempel teste dette ved å lime inn 👋🏽 i editoren før og etter denne luringen lander.

La også til støtte for å skru av noen av shortcut-loggene. De kan bråke litt vel mye til tider.