### PR TITLE
feat: keep safelink base styling when extending it with styled

### DIFF
--- a/packages/safelink/src/SafeLink.stories.tsx
+++ b/packages/safelink/src/SafeLink.stories.tsx
@@ -8,7 +8,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 import { MissingRouterContext } from "./MissingRouterContext";
-import { SafeLink } from "./SafeLink";
+import { SafeLink, UnstyledSafeLink } from "./SafeLink";
 
 /**
  * Lenker på [ndla.no](https://ndla.no) bruker den vanlige konvensjonen med underlinje. Lenker skal i hovedsak åpne seg i samme vindu (det vil si at vi bruker `target="_self"` eller ingen target-attributt). Unntaket er hvis lenken inngår i et skjema eller læringssammenhengen gjør det unødvendig at brukerne beholder vinduet eller fanen de står i. Når lenker går til et annet nettsted (eksterne lenker) skal disse alltids åpnes i ny fane.
@@ -55,4 +55,8 @@ export const WithMissingRouterContext: StoryObj<typeof SafeLink> = {
     ),
   ],
   args: { to: "https://example.com", target: "_blank" },
+};
+
+export const Unstyled: StoryObj<typeof SafeLink> = {
+  render: (args) => <UnstyledSafeLink {...args} />,
 };

--- a/packages/safelink/src/SafeLink.tsx
+++ b/packages/safelink/src/SafeLink.tsx
@@ -20,53 +20,69 @@ const isExternalLink = (to?: LinkProps["to"]) =>
 
 export const isOldNdlaLink = (to?: LinkProps["to"]) => typeof to === "string" && to.match(oldNdlaRegex) !== null;
 
-export interface SafeLinkProps extends LinkProps, StyledProps {
+export interface UnstyledSafeLinkProps extends LinkProps {
   ref?: RefObject<HTMLAnchorElement | null>;
   asAnchor?: boolean;
   disabled?: boolean;
-  unstyled?: boolean;
 }
 
-const StyledLink = styled(Link, {}, { baseComponent: true });
+export interface SafeLinkProps extends UnstyledSafeLinkProps, StyledProps {}
 
 // Fallback to normal link if app is missing RouterContext, link is external or is old ndla link
-
-export const SafeLink = forwardRef<HTMLAnchorElement, SafeLinkProps>(
-  ({ to, replace, state, disabled, unstyled, children, tabIndex, asAnchor, reloadDocument, ...rest }, ref) => {
+export const UnstyledSafeLink = forwardRef<HTMLAnchorElement, UnstyledSafeLinkProps>(
+  ({ to, replace, state, disabled, children, tabIndex, asAnchor, reloadDocument, ...rest }, ref) => {
     const isMissingRouterContext = useContext(MissingRouterContext);
-    const unstyledProps = unstyled ? { "data-unstyled": "" } : {};
 
     if (isMissingRouterContext || isExternalLink(to) || isOldNdlaLink(to) || asAnchor || disabled) {
       const href = typeof to === "string" ? to : "#";
       return (
-        <styled.a
+        <a
           href={disabled ? undefined : href}
           role={disabled ? "link" : undefined}
           aria-disabled={disabled}
           ref={ref}
           tabIndex={tabIndex}
-          {...unstyledProps}
+          data-unstyled={rest.className?.length ? undefined : ""}
           {...rest}
         >
           {children}
-        </styled.a>
+        </a>
       );
     }
 
     return (
       // RR6 link immediately fails if to is somehow undefined, so we provide an empty fallback to recover.
-      <StyledLink
+      <Link
         ref={ref}
         tabIndex={tabIndex ?? 0}
         to={to ?? ""}
         state={state}
         reloadDocument={reloadDocument}
         replace={replace}
-        {...unstyledProps}
+        data-unstyled={rest.className?.length ? undefined : ""}
         {...rest}
       >
         {children}
-      </StyledLink>
+      </Link>
     );
   },
+);
+
+export const SafeLink = styled(
+  UnstyledSafeLink,
+  {
+    base: {
+      color: "text.link",
+      textDecoration: "underline",
+      textDecorationThickness: "max(0.0625em, 1px)",
+      textUnderlineOffset: "0.27em",
+      _hover: {
+        textDecoration: "none",
+      },
+      _visited: {
+        color: "text.linkVisited",
+      },
+    },
+  },
+  { baseComponent: true },
 );

--- a/packages/safelink/src/SafeLinkButton.tsx
+++ b/packages/safelink/src/SafeLinkButton.tsx
@@ -19,6 +19,7 @@ export const SafeLinkButton = forwardRef<HTMLAnchorElement, SafeLinkButtonProps>
   ({ variant, size, css: cssProp, ...props }, ref) => (
     <SafeLink
       {...props}
+      unstyled
       css={css.raw(
         buttonBaseRecipe.raw({ variant }),
         variant !== "link" ? buttonRecipe.raw({ size }) : undefined,

--- a/packages/safelink/src/SafeLinkIconButton.tsx
+++ b/packages/safelink/src/SafeLinkIconButton.tsx
@@ -20,6 +20,7 @@ export const SafeLinkIconButton = forwardRef<HTMLAnchorElement, SafeLinkIconButt
     <SafeLink
       {...props}
       css={css.raw(buttonBaseRecipe.raw({ variant }), iconButtonRecipe.raw({ size }), cssProp)}
+      unstyled
       ref={ref}
     />
   ),

--- a/packages/safelink/src/__tests__/SafeLink-test.tsx
+++ b/packages/safelink/src/__tests__/SafeLink-test.tsx
@@ -26,7 +26,7 @@ test("SafeLink renderers Link correctly if router context is present", async () 
   expect(link).toHaveAttribute("href", "/my/path");
   expect(container.firstChild).toMatchInlineSnapshot(`
     <a
-      class=""
+      class="c_text.link text-decoration_underline td-t_max(0.0625em,_1px) tu-o_0.27em hover:text-decoration_none visited:c_text.linkVisited"
       data-discover="true"
       href="/my/path"
       tabindex="0"
@@ -41,13 +41,13 @@ test("SafeLink defaults to normal link if to prop is an external link", async ()
   const link = await findByRole("link");
   expect(link).toHaveAttribute("href", "https://example.com");
   expect(container.firstChild).toMatchInlineSnapshot(`
-<a
-  class=""
-  href="https://example.com"
->
-  External link
-</a>
-`);
+    <a
+      class="c_text.link text-decoration_underline td-t_max(0.0625em,_1px) tu-o_0.27em hover:text-decoration_none visited:c_text.linkVisited"
+      href="https://example.com"
+    >
+      External link
+    </a>
+  `);
 });
 
 test("SafeLink defaults to normal link if to prop is an old ndla link", async () => {
@@ -57,13 +57,13 @@ test("SafeLink defaults to normal link if to prop is an old ndla link", async ()
   const link = await findByRole("link");
   expect(link).toHaveAttribute("href", "/nb/node/54");
   expect(container.firstChild).toMatchInlineSnapshot(`
-<a
-  class=""
-  href="/nb/node/54"
->
-  Normal link
-</a>
-`);
+    <a
+      class="c_text.link text-decoration_underline td-t_max(0.0625em,_1px) tu-o_0.27em hover:text-decoration_none visited:c_text.linkVisited"
+      href="/nb/node/54"
+    >
+      Normal link
+    </a>
+  `);
 });
 
 test("SafeLink renderers normal link correctly when router context is not present", async () => {
@@ -75,13 +75,13 @@ test("SafeLink renderers normal link correctly when router context is not presen
   const link = await findByRole("link");
   expect(link).toHaveAttribute("href", "/my/path");
   expect(container.firstChild).toMatchInlineSnapshot(`
-<a
-  class=""
-  href="/my/path"
->
-  No router context
-</a>
-`);
+    <a
+      class="c_text.link text-decoration_underline td-t_max(0.0625em,_1px) tu-o_0.27em hover:text-decoration_none visited:c_text.linkVisited"
+      href="/my/path"
+    >
+      No router context
+    </a>
+  `);
 });
 
 test("SafeLink renderers normal mailto-link correctly", async () => {
@@ -91,13 +91,13 @@ test("SafeLink renderers normal mailto-link correctly", async () => {
   const link = await findByRole("link");
   expect(link).toHaveAttribute("href", "mailto:test@ndla.no");
   expect(container.firstChild).toMatchInlineSnapshot(`
-<a
-  class=""
-  href="mailto:test@ndla.no"
->
-  test@ndla.no
-</a>
-`);
+    <a
+      class="c_text.link text-decoration_underline td-t_max(0.0625em,_1px) tu-o_0.27em hover:text-decoration_none visited:c_text.linkVisited"
+      href="mailto:test@ndla.no"
+    >
+      test@ndla.no
+    </a>
+  `);
 });
 
 test("isOldNdlaLink checks", () => {

--- a/packages/safelink/src/index.ts
+++ b/packages/safelink/src/index.ts
@@ -11,5 +11,5 @@ export { SafeLinkButton } from "./SafeLinkButton";
 export type { SafeLinkIconButtonProps } from "./SafeLinkIconButton";
 export { SafeLinkIconButton } from "./SafeLinkIconButton";
 export type { SafeLinkButtonProps } from "./SafeLinkButton";
-export { SafeLink } from "./SafeLink";
-export type { SafeLinkProps } from "./SafeLink";
+export { SafeLink, UnstyledSafeLink } from "./SafeLink";
+export type { SafeLinkProps, UnstyledSafeLinkProps } from "./SafeLink";

--- a/packages/ui/src/AnchorHeading/AnchorHeading.tsx
+++ b/packages/ui/src/AnchorHeading/AnchorHeading.tsx
@@ -12,6 +12,10 @@ import { type ReactNode, useMemo } from "react";
 
 const StyledAnchor = styled(SafeLink, {
   base: {
+    color: "inherit",
+    _visited: {
+      color: "inherit",
+    },
     _before: {
       position: "absolute",
       marginInlineStart: "-0.75em",
@@ -19,11 +23,8 @@ const StyledAnchor = styled(SafeLink, {
       visibility: "hidden",
     },
     _hover: {
-      textDecoration: "underline",
-      tablet: {
-        _before: {
-          visibility: "visible",
-        },
+      _before: {
+        visibility: "visible",
       },
     },
   },

--- a/packages/ui/src/Breadcrumb/HomeBreadcrumb.tsx
+++ b/packages/ui/src/Breadcrumb/HomeBreadcrumb.tsx
@@ -15,12 +15,8 @@ import type { IndexedBreadcrumbItem, SimpleBreadcrumbItem } from "./BreadcrumbIt
 const StyledSafeLink = styled(SafeLink, {
   base: {
     color: "inherit",
-    textDecoration: "underline",
-    _hover: {
-      textDecoration: "none",
-    },
-    _focusVisible: {
-      textDecoration: "none",
+    _visited: {
+      color: "inherit",
     },
   },
 });
@@ -36,6 +32,9 @@ const StyledArrowRight = styled(ArrowRightShortLine, {
 const IconSafeLink = styled(SafeLink, {
   base: {
     color: "inherit",
+    _visited: {
+      color: "inherit",
+    },
   },
 });
 

--- a/packages/ui/src/FileList/File.tsx
+++ b/packages/ui/src/FileList/File.tsx
@@ -37,10 +37,9 @@ export interface FileFormat {
 
 const StyledSafeLink = styled(SafeLink, {
   base: {
-    textUnderlineOffset: "2px",
-    textDecoration: "underline",
-    _hover: {
-      textDecoration: "none",
+    color: "inherit",
+    _visited: {
+      color: "inherit",
     },
   },
 });

--- a/packages/ui/src/LicenseByline/LicenseLink.tsx
+++ b/packages/ui/src/LicenseByline/LicenseLink.tsx
@@ -18,15 +18,7 @@ interface Props extends Omit<SafeLinkProps, "to"> {
 
 const StyledSafeLink = styled(SafeLink, {
   base: {
-    color: "text.link",
-    textDecoration: "underline",
     whiteSpace: "nowrap",
-    _hover: {
-      textDecoration: "none",
-    },
-    _focusWithin: {
-      textDecoration: "none",
-    },
     mobileWideDown: {
       _disabled: {
         display: "none",

--- a/packages/ui/src/LinkBlock/LinkBlock.tsx
+++ b/packages/ui/src/LinkBlock/LinkBlock.tsx
@@ -8,7 +8,7 @@
 
 import { ArrowRightLine, CalendarLine } from "@ndla/icons";
 import { Heading } from "@ndla/primitives";
-import { SafeLink } from "@ndla/safelink";
+import { UnstyledSafeLink } from "@ndla/safelink";
 import { styled } from "@ndla/styled-system/jsx";
 import type { LinkBlockEmbedData } from "@ndla/types-embed";
 import { toIntlLanguage } from "@ndla/util";
@@ -25,35 +25,39 @@ const InfoWrapper = styled("div", {
   },
 });
 
-const StyledSafeLink = styled(SafeLink, {
-  base: {
-    display: "flex",
-    justifyContent: "space-between",
-    alignItems: "center",
-    background: "surface.default",
-    padding: "medium",
-    border: "1px solid",
-    borderColor: "stroke.subtle",
-    borderRadius: "xsmall",
-    "& h3": {
-      textDecoration: "underline",
-    },
-    "& [data-forward]": {
-      transitionProperty: "width, height",
-      transitionTimingFunction: "ease-in-out",
-      transitionDuration: "fast",
-    },
-    _hover: {
+const StyledSafeLink = styled(
+  UnstyledSafeLink,
+  {
+    base: {
+      display: "flex",
+      justifyContent: "space-between",
+      alignItems: "center",
+      background: "surface.default",
+      padding: "medium",
+      border: "1px solid",
+      borderColor: "stroke.subtle",
+      borderRadius: "xsmall",
       "& h3": {
-        textDecoration: "none",
+        textDecoration: "underline",
       },
       "& [data-forward]": {
-        width: "large",
-        height: "large",
+        transitionProperty: "width, height",
+        transitionTimingFunction: "ease-in-out",
+        transitionDuration: "fast",
+      },
+      _hover: {
+        "& h3": {
+          textDecoration: "none",
+        },
+        "& [data-forward]": {
+          width: "large",
+          height: "large",
+        },
       },
     },
   },
-});
+  { baseComponent: true },
+);
 
 const StyledDateContainer = styled("div", {
   base: {


### PR DESCRIPTION
Kjenner litt på at det ofte er en plage at link-stylingen forsvinner når man styler en lenke videre. Lurer på om dette er en greiere default. Eksporterer en `UnstyledSafeLink` som fungerer helt likt, bare at den ikke har noe styling i det hele tatt. 

Denne er veldig breaking et par steder, med en viss fare for følgefeil. Tror dog det er riktig vei å gå.

Dersom en skal velge hvilken komponent en skal bruke bør man tenke sånn her:
1. Er det en lenke som bare trenger en annen tekstfarge? Bruk SafeLink
2. Skal du lage noe som ikke ligner på en lenke i det hele tatt og vil bruke `styled`? Bruk UnstyledSafeLink
3. Hvis du skal lage noe som ligner fryktelig mye på måten vi setter opp `SafeLinkButton` på? Bruk `<SafeLink unstyled css={...} />`